### PR TITLE
Fix max-empty-lines error during compilation

### DIFF
--- a/components/GeneratorMenu.vue
+++ b/components/GeneratorMenu.vue
@@ -28,7 +28,6 @@ export default class extends Vue {
 </script>
 
 <style lang='scss' scoped>
-
 @import '~assets/scss/base/variables';
 
 .generator_menu {


### PR DESCRIPTION
This removes build error (at least on my fresh install):
```bash
ERROR in 
components/GeneratorMenu.vue
 2:1  ✖  Expected no more than 1 empty line   max-empty-lines
```
Thanks!