### PR TITLE
Fix `no-unused-variables` and `max-empty-lines` linting errors [EDITED]

### DIFF
--- a/components/GeneratorMenu.vue
+++ b/components/GeneratorMenu.vue
@@ -28,7 +28,6 @@ export default class extends Vue {
 </script>
 
 <style lang='scss' scoped>
-
 @import '~assets/scss/base/variables';
 
 .generator_menu {

--- a/pages/_lang/windows.vue
+++ b/pages/_lang/windows.vue
@@ -193,6 +193,7 @@ export default class extends Vue {
     // (this.$refs.nextStepModal as Modal).show();
   }*/
 
+  // @ts-ignore TS6133 onSelected
   public async onSelected(sample: windowsStore.Sample) {
     console.log(sample);
     try {
@@ -204,6 +205,8 @@ export default class extends Vue {
     }
   }
 
+
+  // @ts-ignore TS6133 onSelected
   public onRemoved(sample: windowsStore.Sample) {
     if (this.selectedSamples.indexOf(sample) != -1) {
       sample.usercode = null;

--- a/store/modules/generator/generator.actions.ts
+++ b/store/modules/generator/generator.actions.ts
@@ -163,6 +163,7 @@ export const actions: Actions<State, RootState> = {
         dispatch('update');
     },
 
+    // @ts-ignore TS6133
     changePreferRelatedApplication({ commit, dispatch }, status: boolean): void {
         commit(types.UPDATE_PREFER_RELATED_APPLICATION, status);
         dispatch('update');


### PR DESCRIPTION
~~when the TypeScript version installs with >2.9, the TSLint starts spilling warning about `no-unused-variables` deprecation. This commit tries to clean the output during build steps:~~

~~- update linter configuration~~
~~- add rules to TS configuration~~
~~- remove variable when not used and not referenced and not required by
  contract~~
~~- prefix unused params with _ when applicable (this removes compiler
  warning)~~
~~- add @ts-ignore pragma where applicable~~

**Edited after rebasing to onto current redesign branch**

Fix linting and compile time errors

- fix max-empty-lines linting error
- add @ts-ignore pragma where applicable to fix TS6133

Thanks!

Thanks!