### PR TITLE
Exclude environments directory from TS compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,6 @@
       "~/utils/*": ["./utils/*"],
       "~/test/*": ["./test/*"]
     }
-  }
+  },
+  "exclude": ["./environments/*"]
 }


### PR DESCRIPTION
The directory content is directly imported via require in Nuxt
configuration files. Without this change the content of the directory is
supposed to be compiled via `allowJs` flag, which results in error about
overriding input files.

Thanks!

```text
Cannot write file '/{...}/PWABuilder/environments/development.js' because it would overwrite input file.
```