### PR TITLE
Migrate no-unused-variable TSLint to TS configuration rules

### DIFF
--- a/components/CodeViewer.vue
+++ b/components/CodeViewer.vue
@@ -133,6 +133,7 @@ export default class extends Vue {
     }
   }
 
+  // @ts-ignore TS6133
   private async copy() {
     const code = this.editor.getValue();
 
@@ -160,10 +161,12 @@ export default class extends Vue {
     }
   }
 
+  // @ts-ignore TS6133
   private showErrorOverlay() {
     this.showOverlay = !this.showOverlay;
   }
 
+  // @ts-ignore TS6133
   private closeOverlay() {
     this.showOverlay = false;
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -24,7 +24,7 @@
     }
 
     private handleUrl() {
-      this.$router.beforeEach((to, from, next) => {
+      this.$router.beforeEach((to, _from, next) => {
         const body = document.querySelector('body');
 
         if (body) {
@@ -35,6 +35,7 @@
       });
     }
 
+    // @ts-ignore TS6133
     private close() {
       this.seen = false;
       localStorage.setItem('PWABuilderGDPR', JSON.stringify(true));

--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -252,7 +252,7 @@ export default class extends Vue {
   }
 
   private lookAtSecurity(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       if (this.url.includes("https")) {
         this.securityScore = this.securityScore + 100;
       }
@@ -264,7 +264,7 @@ export default class extends Vue {
   }
 
   private lookAtManifest(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       console.log("manifestInfo", this.manifest);
       if (this.manifest) {
         this.manifestScore = this.manifestScore + 50;
@@ -357,7 +357,7 @@ export default class extends Vue {
   }
 
   private calcGrade() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       if (
         this.swScore > 90 &&
         this.manifestScore > 90 &&

--- a/store/modules/generator/generator.actions.ts
+++ b/store/modules/generator/generator.actions.ts
@@ -1,5 +1,5 @@
 import { ActionTree, ActionContext } from 'vuex';
-import { Manifest, Icon, RelatedApplication, CustomMember, ColorOptions, types, helpers, state, State } from '~/store/modules/generator';
+import { Manifest, Icon, RelatedApplication, CustomMember, ColorOptions, types, helpers, State } from '~/store/modules/generator';
 import { RootState } from 'store';
 
 const apiUrl = `${process.env.apiUrl}/manifests`;
@@ -130,7 +130,7 @@ export const actions: Actions<State, RootState> = {
         }
     },
 
-    async uploadIcon({ commit, state, dispatch }, iconFile: File): Promise<void> {
+    async uploadIcon({ commit, dispatch }, iconFile: File): Promise<void> {
         const dataUri: string = await helpers.getImageDataURI(iconFile);
         const sizes = await helpers.getImageIconSize(dataUri);
         commit(types.ADD_ICON, { src: dataUri, sizes: `${sizes.width}x${sizes.height}` });
@@ -164,7 +164,7 @@ export const actions: Actions<State, RootState> = {
     },
 
     changePreferRelatedApplication({ commit, dispatch }, status: boolean): void {
-        commit(types.UPDATE_PREFER_RELATED_APPLICATION, state);
+        commit(types.UPDATE_PREFER_RELATED_APPLICATION, status);
         dispatch('update');
     },
 

--- a/store/modules/publish.ts
+++ b/store/modules/publish.ts
@@ -49,7 +49,7 @@ export interface Actions<S, R> extends ActionTree<S, R> {
 
 export const actions: Actions<State, RootState> = {
 
-    resetAppData({ commit, dispatch }): void {
+    resetAppData({ dispatch }): void {
         dispatch('generator/resetStates', undefined, { root: true });
         dispatch('serviceworker/resetStates', undefined, { root: true });
     },

--- a/store/modules/windows/windows.actions.ts
+++ b/store/modules/windows/windows.actions.ts
@@ -79,7 +79,7 @@ export const actions: Actions<State, RootState> = {
   },
 
   async selectSample({ commit }, sample: Sample): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
+    return new Promise<void>(async (resolve) => {
 
       await this.$axios.$get(sample.url).then(res => {
         let source = res.replace(/(\/\*[\s\S]*?\*\/|([^:/]|^)\/\/.*$)/g, '').trim();

--- a/test/store/modules/generator/generator.helpers.test.ts
+++ b/test/store/modules/generator/generator.helpers.test.ts
@@ -51,7 +51,8 @@ describe('store generator helpers', () => {
             const _global = global as any;
             const size = 10;
     
-            _global.document = { 
+            _global.document = {
+                // @ts-ignore TS6133 src
                 createElement: (src: string) => new MockImage(size, size)
             };
 

--- a/test/utils/action-context.mock.ts
+++ b/test/utils/action-context.mock.ts
@@ -10,7 +10,9 @@ const modulesStates = {
 };
 
 export let actionContextMockBuilder = <S>(s: S): ActionContext<S, RootState> => ({
+    // @ts-ignore TS6133 type
     dispatch: (type: string) => Promise.resolve(),
+    // @ts-ignore TS6133 type
     commit: (type: string) => {},
     state: s,
     getters: {},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "experimentalDecorators": true,
     "noImplicitAny": false,
     "noImplicitThis": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "strictNullChecks": true,
     "removeComments": true,
     "suppressImplicitAnyIndexErrors": true,

--- a/tslint.json
+++ b/tslint.json
@@ -49,7 +49,6 @@
         "no-trailing-whitespace": false,
         "no-inferrable-types": true,
         "no-null-keyword": false,
-        "no-unused-variable": true,
         "prefer-const": false
     }
 }


### PR DESCRIPTION
This is a proposal to correct/silence some noise in the `redesign` branch:

- migrate configuration
- work with compilation errors by removing unused variables,
  silencing warnings for unused arguments with `_` notation or
TSIgnore pragma

When run in 'redesign' branch the current setup results in `no-unused-variables` warning and its migration warning or, when moved to TS:

```txt
ERROR in /Users/piotrblazejewicz/git/PWABuilder/components/CodeViewer.vue(136,17):
TS6133: 'copy' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/components/CodeViewer.vue(163,11):
TS6133: 'showErrorOverlay' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/components/CodeViewer.vue(167,11):
TS6133: 'closeOverlay' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/layouts/default.vue(27,34):
TS6133: 'from' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/layouts/default.vue(38,11):
TS6133: 'close' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/pages/_lang/reportCard.vue(255,34):
TS6133: 'reject' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/pages/_lang/reportCard.vue(267,34):
TS6133: 'reject' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/pages/_lang/reportCard.vue(360,34):
TS6133: 'reject' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/store/modules/generator/generator.actions.ts(133,32):
TS6133: 'state' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/store/modules/generator/generator.actions.ts(166,58):
TS6133: 'status' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/store/modules/publish.ts(52,20):
TS6133: 'commit' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/store/modules/windows/windows.actions.ts(82,46):
TS6133: 'reject' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/test/store/modules/generator/generator.helpers.test.ts(55,33):
TS6133: 'src' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/test/utils/action-context.mock.ts(13,16):
TS6133: 'type' is declared but its value is never read.
ERROR in /Users/piotrblazejewicz/git/PWABuilder/test/utils/action-context.mock.ts(14,14):
TS6133: 'type' is declared but its value is never read.
```

I understand that `package.json` declares the TS 2.6.*, but this results in TS 2.9.* installed:
```bash
Version: typescript 2.9.2, tslint 5.12.0
```

Thanks!