### PR TITLE
Fixing typo in description of the Display manifest property

### DIFF
--- a/pages/_lang/generate.vue
+++ b/pages/_lang/generate.vue
@@ -196,7 +196,7 @@
                 <h4
                   v-bind:class="{ fieldName: activeFormField === 'displayMode' }"
                 >{{ $t("generate.display") }}</h4>
-                <p>Display indetifies the browser components that should be included in your. "Standalone" appears as a traditional app.</p>
+                <p>Display identifies the browser components that should be included in your. "Standalone" appears as a traditional app.</p>
               </label>
 
               <select


### PR DESCRIPTION
## PR Type
Bugfix

## Describe the current behavior?
There was a typo in the description of the `Display` property for the manifest settings.

## Describe the new behavior?
Fixed the typo

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.