### PR TITLE
chore(): change back to .json instead of .webmanifest

### DIFF
--- a/pages/_lang/generate.vue
+++ b/pages/_lang/generate.vue
@@ -293,7 +293,7 @@
           code-type="html"
           v-if="seeEditor"
           title="Add this code to your start page"
-          code="<link rel='manifest' href='/manifest.webmanifest'>"
+          code="<link rel='manifest' href='/manifest.json'>"
           :showHeader="true"
           :showCopyButton="true"
           id="manifestHTML"
@@ -317,7 +317,7 @@
           :showCopyButton="showCopy"
           id="manifestCode"
         >
-          <h3>Add this code to your manifest.webmanifest file</h3>
+          <h3>Add this code to your manifest.json file</h3>
         </CodeViewer>
       </section>
 


### PR DESCRIPTION
Fixes #624 

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix

We currently recommend users use the .webmanifest extension for their web manifest. This PR changes that wording to the more common .json extension. This actually lines us up more with what gets generated by the web platform still anyways https://github.com/pwa-builder/pwabuilder-web/blob/1e6dc4c396561796d1eba22b9baeead5bbd7099d/lib/platform.js#L53
