### PR TITLE
fix(download): shortcuts must be a real array

### DIFF
--- a/components/Download.vue
+++ b/components/Download.vue
@@ -123,7 +123,7 @@ export default class extends Vue {
       useBrowserOnChromeOS: true,
       splashScreenFadeOutDuration: 300,
       enableNotifications: false,
-      shortcuts: "[]",
+      shortcuts: [],
       signingInfo: {
         fullName: "John Doe",
         organization: "Contoso",


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->

llama-pack/bubblewrap throws the following error: `twaManifest.shortcuts.map is not a function`

This is because the shortcuts property is passed as a string (`"[]"`) and not as an actual array.

## Describe the new behavior?

We’re now passing in an actual array.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
N/A