### PR TITLE
Edits in manifest reflect in form

### DIFF
--- a/components/CodeViewer.vue
+++ b/components/CodeViewer.vue
@@ -16,7 +16,7 @@
         @editorDidMount="editorMount"
         :theme="`${theme}Theme`"
         :language="codeType"
-        v-model="code"
+        v-model="data$"
         >
       </MonacoEditor>
     </div>
@@ -119,7 +119,7 @@ export default class extends Vue {
   public isReady = true;
   public downloadButtonMessage = "publish.download_manifest";
   public errorNumber = 0;
-
+  public data$  = "";
   public editor : MonacoEditor.editor;
 
   public monacoOptions = {
@@ -141,6 +141,10 @@ export default class extends Vue {
   errors: any[] = [];
   textCopied = false;
 
+  public created(): void {
+    this.data$ = this.code ;
+  }
+
   mounted():void {
     this.defineTheme();
     (<any>window).addEventListener('resize', this.onResize);
@@ -150,8 +154,8 @@ export default class extends Vue {
     (<any>window).removeEventListener("resize", this.onResize);
   }
 
-  onCodeChange(value):void {
-    this.$emit("editorValue", value);
+  onCodeChange():void {
+    this.$emit("editorValue", this.data$);
   }
 
   onDecorationsChange():void {
@@ -178,7 +182,7 @@ export default class extends Vue {
   public reloadEditor(): void {
     this.monacoId && (<any>window).monaco.editor.create(document.getElementById(this.monacoId), {
             language: this.codeType,
-            value: this.code,
+            value: this.data$,
             lineNumbers: "on",
             fixedOverflowWidgets: true,
             wordWrap: "on",
@@ -208,9 +212,7 @@ export default class extends Vue {
 
   @Watch("code")
   public setMonacoValue():void {
-    // this logic will be changed when editing "from manifest to form" is in place.
-    this.removeEditor();
-    this.reloadEditor();
+    this.data$ = this.code ;
   }
 
   editorMount(editor):void {

--- a/pages/_lang/generate.vue
+++ b/pages/_lang/generate.vue
@@ -636,10 +636,11 @@ export default class extends Vue {
     this.basicManifest = false;
   }
 
-  public handleEditorValue() {
+  public handleEditorValue(value) {
     if (this.basicManifest !== false) {
-      // this.manifest = ev;
-      this.updateManifest(this.manifest$);
+      var editedManifest = JSON.parse(value);
+      this.updateManifest(editedManifest);
+      this.manifest$ = { ...this.manifest };
     }
   }
 

--- a/pages/_lang/generate.vue
+++ b/pages/_lang/generate.vue
@@ -637,7 +637,7 @@ export default class extends Vue {
   }
 
   public handleEditorValue(value) {
-    if (this.basicManifest !== false) {
+    if (helper.isValidJson(value)){
       var editedManifest = JSON.parse(value);
       this.updateManifest(editedManifest);
       this.manifest$ = { ...this.manifest };

--- a/pages/_lang/generate.vue
+++ b/pages/_lang/generate.vue
@@ -289,7 +289,7 @@
         <CodeViewer
           code-type="json"
           v-on:invalidManifest="invalidManifest()"
-          v-on:editorValue="handleEditorValue($event)"
+          v-on:editorValue="updateManifestFn($event)"
           v-if="seeEditor"
           :code="getCode()"
           :title="$t('generate.w3c_manifest')"
@@ -395,6 +395,7 @@ export default class extends Vue {
   public  textareaOutlineColor = '';
   public showCopy = true;
   public isImageBroken: boolean = false;
+  public updateManifestFn = helper.debounce(this.handleEditorValue, 3000, false);
 
   @GeneratorState manifest: generator.Manifest;
   @GeneratorState members: generator.CustomMember[];

--- a/utils/helper.ts
+++ b/utils/helper.ts
@@ -12,5 +12,13 @@ export default {
             timeout = setTimeout(later, wait);
             if (callNow) func.apply(context, args);
         };
+    },
+    isValidJson: function (json) {
+        try {
+            JSON.parse(json);
+            return true;
+        } catch (e) {
+            return false;
+        }
     }
 };


### PR DESCRIPTION
Fixes #
1)  edits in manifest should reflect in form and not reset [#560](https://github.com/pwa-builder/PWABuilder/issues/560)

2)  if I edit the manifest, then click back on the form, my work goes away [#564](https://github.com/pwa-builder/PWABuilder/issues/564)

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->


## Describe the new behavior?


## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
