### PR TITLE
Using generatedUrl than manifest.start_url when icons URL is prepared

### DIFF
--- a/store/modules/generator/generator.mutations.ts
+++ b/store/modules/generator/generator.mutations.ts
@@ -32,10 +32,22 @@ export const mutations: MutationTree<State> = {
     state.manifestId = result.id;
     state.siteServiceWorkers = result.siteServiceWorkers;
     if (result && result.content && result.content.icons) {
-      state.icons = <Icon[]>helpers.prepareIconsUrls(result.content.icons, state.manifest && state.manifest.start_url ? state.manifest.start_url : '') || [];
+      if(result.generatedUrl)
+      {
+        state.icons = <Icon[]>helpers.prepareIconsUrls(result.content.icons, result.generatedUrl) || [];
+      }
+      else {
+        state.icons = <Icon[]>helpers.prepareIconsUrls(result.content.icons, state.manifest && state.manifest.start_url ? state.manifest.start_url : '') || [];
+      }
     }
     if (result && result.content && result.content.screenshots) {
-      state.screenshots = <Screenshot[]>helpers.prepareIconsUrls(result.content.screenshots, state.manifest && state.manifest.start_url ? state.manifest.start_url : '') || [];
+      if(result.generatedUrl)
+      {
+        state.screenshots = <Screenshot[]>helpers.prepareIconsUrls(result.content.screenshots, result.generatedUrl) || [];
+      }
+      else {
+        state.screenshots = <Screenshot[]>helpers.prepareIconsUrls(result.content.screenshots, state.manifest && state.manifest.start_url ? state.manifest.start_url : '') || [];
+      }
     }
     state.suggestions = result.suggestions;
     state.warnings = result.warnings;


### PR DESCRIPTION
Fixes #
First check the image URL relative to the manifest.json as browsers will do is. Otherwise, check the image URL relative to the website.

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->


## Describe the new behavior?


## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
