### PR TITLE
Fix duplication of path on icons

### DIFF
--- a/store/modules/generator/generator.helpers.ts
+++ b/store/modules/generator/generator.helpers.ts
@@ -69,7 +69,11 @@ export const helpers = {
           }
         }
         baseUrl = protocol + '//' + host + additionnalPath;
-        //remove posible trailing/leading slashes 
+
+        //avoid duplication on additionPath if it already exists
+        icon.src = icon.src.replace(additionnalPath, '');
+
+        //remove posible trailing/leading slashes
         icon.src = `${baseUrl.replace(/\/$/, '')}/${icon.src.replace(/^\/+/g, '')}`;
       }
       return icon;

--- a/store/modules/generator/generator.helpers.ts
+++ b/store/modules/generator/generator.helpers.ts
@@ -71,10 +71,10 @@ export const helpers = {
         baseUrl = protocol + '//' + host + additionnalPath;
 
         //avoid duplication on the path if the icon src already has it
-        icon.src = icon.src.replace(additionnalPath, '');
+        icon.src = new URL(icon.src, baseUrl).href;
 
         //remove posible trailing/leading slashes
-        icon.src = `${baseUrl.replace(/\/$/, '')}/${icon.src.replace(/^\/+/g, '')}`;
+        icon.src = `${icon.src.replace(/^\/+/g, '')}`;
       }
       return icon;
     });

--- a/store/modules/generator/generator.helpers.ts
+++ b/store/modules/generator/generator.helpers.ts
@@ -70,7 +70,7 @@ export const helpers = {
         }
         baseUrl = protocol + '//' + host + additionnalPath;
 
-        //avoid duplication on additionPath if it already exists
+        //avoid duplication on the path if the icon src already has it
         icon.src = icon.src.replace(additionnalPath, '');
 
         //remove posible trailing/leading slashes

--- a/uitest/index.spec.js
+++ b/uitest/index.spec.js
@@ -6,9 +6,9 @@ let page;
 
 before(async () => {
   browser = await puppeteer.launch({
-    headless: true
+    headless: true,
+    slowMo: 100
   });
-
   page = await browser.newPage();
   await page.goto('https://pwabuilder-site-prod-staging.azurewebsites.net');
 });
@@ -27,7 +27,7 @@ describe('report card page', () => {
     await page.waitFor('#getStartedInput');
 
     await page.click('#getStartedInput');
-    
+
     await page.type('#getStartedInput', 'https://webboard.app');
 
     await page.click('#getStartedButton');
@@ -41,7 +41,7 @@ describe('report card page', () => {
     await page.waitFor('#getStartedInput');
 
     await page.click('#getStartedInput');
-    
+
     await page.type('#getStartedInput', 'https://self-signed.badssl.com/');
 
     await page.click('#getStartedButton');

--- a/uitest/index.spec.js
+++ b/uitest/index.spec.js
@@ -9,6 +9,7 @@ before(async () => {
     headless: true,
     slowMo: 100
   });
+
   page = await browser.newPage();
   await page.goto('https://pwabuilder-site-prod-staging.azurewebsites.net');
 });


### PR DESCRIPTION
Fixes #
https://github.com/pwa-builder/PWABuilder/issues/731

## PR Type
Bugfix

## Describe the current behavior?
It doesn't check if the additional path on the manifest is also included on the icons url

## Describe the new behavior?
It will remove the additional path if it exist on both icons and manifest to avoid it being duplicated

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional info

Tests were failing on the github action (they pass on local) but it doesn't seem related to my change. I added a possible fix but I can remove it if necessary