### PR TITLE
Address #755, hide the download card on mobile, fix gdpr notification height for mobile breakpoints

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -31,7 +31,7 @@
       <div class="pure-u-1-2 pure-u-md-1-5">
       </div>
       <div class="pure-u-1-2 pure-u-md-1-5">
-     
+
       </div>
       <div class="l-footer-social pure-u-1 pure-u-md-3-5">
         <a class="l-footer-logo_action" href="https://github.com/pwa-builder" target="_blank">
@@ -173,24 +173,28 @@ header {
       font-style: normal;
     }
   }
+
+  @media (max-width: 640px) {
+    height: auto;
+  }
 }
 
 /*body[data-location='gettingStarted']{
-  
+
   }
 
     body[data-location='generate']{
-   
+
   }
   body[data-location='serviceworker']{
-     
+
   }
 
   body[data-location='publish']{
-    
+
   }
 
   body[data-location='windows']{
-   
+
   }*/
 </style>

--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -911,7 +911,7 @@ h2 {
       }
     }
 
-    @media (max-width: 425px) {
+    @media (max-width: 640px) {
       #starterSection {
         display: none;
       }


### PR DESCRIPTION
Fixes #
issue #755 

## PR Type

- Bugfix

## Describe the current behavior?

Current behavior breaks a mobile breakpoint larger than 425px.

## Describe the new behavior?

Using the fluent design breakpoints to set the max-width of certain properties to behave as expected on mobile (640px), talk about size creep.
This does not include phablets which are considered to be in the same category as small laptops and tablets.

https://docs.microsoft.com/en-us/windows/uwp/design/layout/screen-sizes-and-breakpoints-for-responsive-design

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information

Use of fluent and UWP design to make the decision. Better org alignment?


<img width="519" alt="Screen Shot 2020-05-28 at 10 31 31 AM" src="https://user-images.githubusercontent.com/6520001/83187730-76d65600-a0e3-11ea-8491-15e12b0ff38d.png">
<img width="715" alt="Screen Shot 2020-05-28 at 10 31 41 AM" src="https://user-images.githubusercontent.com/6520001/83187737-79d14680-a0e3-11ea-9621-6f2f1953544a.png">
<img width="698" alt="Screen Shot 2020-05-28 at 10 31 49 AM" src="https://user-images.githubusercontent.com/6520001/83187739-7a69dd00-a0e3-11ea-8c38-0c17e565c6a6.png">
