### PR TITLE
reference recreated monaco ref, editor holding stale ref

### DIFF
--- a/components/CodeViewer.vue
+++ b/components/CodeViewer.vue
@@ -180,7 +180,7 @@ export default class extends Vue {
   }
 
   public reloadEditor(): void {
-    this.monacoId && (<any>window).monaco.editor.create(document.getElementById(this.monacoId), {
+    this.editor = this.monacoId && (<any>window).monaco.editor.create(document.getElementById(this.monacoId), {
             language: this.codeType,
             value: this.data$,
             lineNumbers: "on",


### PR DESCRIPTION
Fixes #
Found

## PR Type

- Bugfix

## Describe the current behavior?
The reference was stale and referring to an editor that is removed from the dom.

## Describe the new behavior?
On resize captures the new editor.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix) -> dev
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information

Not high pri, just something I noticed while I was trying to replicate the wrapped component