### PR TITLE
Accessibility Issue Fix: Added accessibility labels to the Get Started dropdown

### DIFF
--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -73,16 +73,52 @@
             </p>
 
             <div id="starterActions">
-              <button @click="starterDrop" id="mainStartButton">
+              <nav aria-label="Get Started menu options">
+                <ul id="menubar1"
+                    role="menubar"
+                    aria-label="Get Started menu options">
+                  <li role="none">
+                    <button @click="starterDrop" 
+                            id="mainStartButton" 
+                            type="button" 
+                            role="menuitem" 
+                            aria-haspop="true" 
+                            aria-expanded="false" 
+                            tabindex="0"> 
+                          Get Started!
+                       <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <ul role="menu" aria-label="Get Started">
+                      <li role="none">
+                        <a id="starterDownloadButton"
+                          role="menuitem"
+                          href="#"
+                          tabindex="-1">
+                          Download
+                        </a>
+                      </li>
+                      <li role="none">
+                        <a role="menuitem"
+                          href="#"
+                          tabindex="-1">
+                          Clone from Github
+                        </a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </nav>
+              <button @click="starterDrop" id="mainStartButton" 
+                type="button" role="menuitem" aria-haspop="true" aria-expanded="false" tabindex="0"> 
                 Get Started!
                 <i class="fas fa-chevron-down"></i>
 
                 <div v-if="openDrop" id="starterDropdown">
-                <button id="starterDownloadButton" @click="downloadStarter">
+                <button id="starterDownloadButton" @click="downloadStarter" type="button" tabindex="-1">
                   <i class="fas fa-arrow-down"></i>
                   Download
                 </button>
-                <button @click="cloneStarter">
+                <button @click="cloneStarter" type="button" tabindex="-1">
                   <i class="fab fa-github"></i>
                   Clone from Github
                 </button>

--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -73,52 +73,17 @@
             </p>
 
             <div id="starterActions">
-              <nav aria-label="Get Started menu options">
-                <ul id="menubar1"
-                    role="menubar"
-                    aria-label="Get Started menu options">
-                  <li role="none">
-                    <button @click="starterDrop" 
-                            id="mainStartButton" 
-                            type="button" 
-                            role="menuitem" 
-                            aria-haspop="true" 
-                            aria-expanded="false" 
-                            tabindex="0"> 
-                          Get Started!
-                       <i class="fas fa-chevron-down"></i>
-                    </button>
-                    <ul role="menu" aria-label="Get Started">
-                      <li role="none">
-                        <a id="starterDownloadButton"
-                          role="menuitem"
-                          href="#"
-                          tabindex="-1">
-                          Download
-                        </a>
-                      </li>
-                      <li role="none">
-                        <a role="menuitem"
-                          href="#"
-                          tabindex="-1">
-                          Clone from Github
-                        </a>
-                      </li>
-                    </ul>
-                  </li>
-                </ul>
-              </nav>
               <button @click="starterDrop" id="mainStartButton" 
-                type="button" role="menuitem" aria-haspop="true" aria-expanded="false" tabindex="0"> 
+                type="button" role="menuitem" aria-haspop="true" aria-expanded="false"> 
                 Get Started!
                 <i class="fas fa-chevron-down"></i>
 
-                <div v-if="openDrop" id="starterDropdown">
-                <button id="starterDownloadButton" @click="downloadStarter" type="button" tabindex="-1">
+                <div v-if="openDrop" id="starterDropdown" aria-live="polite">
+                <button id="starterDownloadButton" @click="downloadStarter" type="button">
                   <i class="fas fa-arrow-down"></i>
                   Download
                 </button>
-                <button @click="cloneStarter" type="button" tabindex="-1">
+                <button @click="cloneStarter" type="button">
                   <i class="fab fa-github"></i>
                   Clone from Github
                 </button>


### PR DESCRIPTION
Fixes #
https://github.com/pwa-builder/PWABuilder/issues/810

## PR Type
Refactoring (no functional changes, no api changes)

## Describe the current behavior?
Currently, a screen reader does not indicate that the Get Started button leads to a popup of buttons.

## Describe the new behavior?
When navigating to the Get Started button, the screen reader indicates that the Get Started button has a popup.
