### PR TITLE
Accessibility Issue Fix: Add alert for “Git clone command copied to your clipboard”

### DIFF
--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -12,7 +12,7 @@
     </div>
 
     <div v-if="showShareToast" id="gitCopyToast">
-      <span>URL copied for sharing</span>
+      <span role="alert">URL copied for sharing</span>
     </div>
 
     <div v-if="gotURL" id="reportShareButtonContainer">


### PR DESCRIPTION
Fixes 
https://github.com/pwa-builder/PWABuilder/issues/817

## PR Type
Accessibility Issue Fix


## Describe the current behavior?
Currently, after pressing the "Clone from Github" button, a visual message appears: “Git clone command copied to your clipboard”. However, a screen reader does not voice this alert. 


## Describe the new behavior?
The “Git clone command copied to your clipboard” message is read aloud by a screen reader. 

