### PR TITLE
fix(): hide spans from screen readers

### DIFF
--- a/components/HubHeader.vue
+++ b/components/HubHeader.vue
@@ -62,11 +62,11 @@
           <img src="~/assets/images/score-icon.png" alt="score icon">
 
           <a target="_blank" rel="noopener noreferrer" :href="url">
-            <span>
+            <span aria-hidden="true">
               URL Tested
               <i class="fas fa-external-link-alt"></i>
             </span>
-            <span v-if="url">
+            <span aria-hidden="true" v-if="url">
               {{url.replace('http://','').replace('https://','').split(/[/?#]/)[0]}}
             </span>      
           </a>


### PR DESCRIPTION
Fixes #833 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The span elements inside the anchor tag get focused by the screen-reader, but to a screen reader those elements have no use. 

## Describe the new behavior?
Using aria-hidden to hide these "unactivateable" elements from the screen reader

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
