### PR TITLE
Accessibility Issue Fix: Added aria-label for close button

### DIFF
--- a/components/Modal.vue
+++ b/components/Modal.vue
@@ -2,7 +2,7 @@
   <section>
     <div class="modal" v-if="showModal">
       <div class="modal-box">
-        <button class="closeButtonDiv" @click="onClickCancel()">
+        <button aria-label="Close" class="closeButtonDiv" @click="onClickCancel()">
           <i class="fas fa-times"></i>
         </button>
         <div class="modal-body">


### PR DESCRIPTION
Fixes
https://github.com/pwa-builder/PWABuilder/issues/842

## PR Type
Accessibility Issue Fix


## Describe the current behavior?
Currently, a screen reader only reads the close button for the "Upload an Image" modal view as "button".


## Describe the new behavior?
Now, the screen reader reads the close button for the "Upload an Image" modal view as "close button". 

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.
