### PR TITLE
Accessibility Issue Fix: Set tabindex of app manifest link to -1 for screen reader logic

### DIFF
--- a/components/ScoreCard.vue
+++ b/components/ScoreCard.vue
@@ -450,7 +450,7 @@
         <div
           class="brkManifestError"
           v-if="brokenManifest"
-        >Couldn't find an <a href="https://developer.mozilla.org/en-US/docs/Web/Manifest">app manifest</a></div>
+        >Couldn't find an <a href="https://developer.mozilla.org/en-US/docs/Web/Manifest" tabindex="-1">app manifest</a></div>
       </nuxt-link>
 
       <div


### PR DESCRIPTION
Fixes 
https://github.com/pwa-builder/PWABuilder/issues/832

## PR Type
Accessibility Issue Fix

## Describe the current behavior?
Separate 'Tab' focus is moving to the "app manifest" link after pressing 'Tab' from "Couldn't find an app manifest" link.

## Describe the new behavior?
Only "Couldn't find an app manifest" is focused on by a screen reader. "app manifest" is not focused on its own.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.
