### PR TITLE
Accessibility Issue Fix: Added keyboard focus for Start and Get Started buttons

### DIFF
--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -534,6 +534,11 @@ declare var awa: any;
   border: none;
 }
 
+#starterActions #mainStartButton:focus {
+  outline: auto;  
+  outline-color: black;
+}
+
 #gitCopyToast {
   position: absolute;
   bottom: 16px;
@@ -825,6 +830,10 @@ h2 {
       display: flex;
       align-items: center;
       text-align: center;
+    }
+
+    #getStartedButton:focus {
+      outline: auto;
     }
   }
 


### PR DESCRIPTION
Fixes 
https://github.com/pwa-builder/PWABuilder/issues/847

## PR Type
Accessibility Issue Fix


## Describe the current behavior?
Focus is not visible for the "Start" and "Get Started" buttons


## Describe the new behavior?
Focus is now visible for the "Start" and "Get Started" buttons

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.
