### PR TITLE
Issue 915 pt 2

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,8 +1,8 @@
 
 
 <template>
-  <div id="baseContainer">
-    <div id="scrollTarget"></div>
+  <div id="baseContainer" role="presentation">
+    <div id="scrollTarget" role="presentation"></div>
 
     <div class="modal-color"></div>
     <h1 class="logoText" aria-hidden="true">PWA Builder</h1>


### PR DESCRIPTION
Fixes #915 

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
- Accessibility

## Describe the current behavior?

Dev build versions of edge seem to focus on the empty divs with narrator.

## Describe the new behavior?

Marking the divs as role="presentation" to allow their content to be focuseable, but themselves not to be

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
