### PR TITLE
fix(): handle edge case for location.search

### DIFF
--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -492,8 +492,15 @@ export default class extends Vue {
   public async processQueryString() {
     const url = window.location.search.split("=")[1];
     this.cleanedURL = decodeURIComponent(url);
-    this.url = this.cleanedURL;
-    this.checkUrlAndGenerate();
+
+    /*
+      Handle edge case where this.cleanedURL is set to the string undefined (decodeURIComponent returns a string).
+      This edge case is not very likely to pop up, but stops issues such as https://github.com/pwa-builder/PWABuilder/issues/833
+    */
+    if (this.cleanedURL && this.cleanedURL !== "undefined") {
+      this.url = this.cleanedURL;
+      this.checkUrlAndGenerate();
+    }
   }
 
   public async getTopSamples() {


### PR DESCRIPTION
Fixes #833 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
In edge cases where the URL the user lands on is something like this `https://preview.pwabuilder.com/?url` the site used to continue forward like there was a valid URL. This happened because, even though the URL was undefined, decodeURIComponent was returning undefined as a string, this case is now handled. URLs such as these should not be landed on during normal use of the app, but as we have seen with  the linked issue there are edge cases.

## Describe the new behavior?
The case described above is handled.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
