### PR TITLE
no manifest found causes issue in finally clause

### DIFF
--- a/components/ScoreCard.vue
+++ b/components/ScoreCard.vue
@@ -658,11 +658,12 @@ export default class extends Vue {
       }
 
       this.noManifest = true;
-      return;
     } finally {
       // Regardless notify parent and update manifest call.
       this.$emit("manifestTestDone", { score: this.manifestScore });
-      this.updateManifest(this.manifest);
+      if (this.manifest) {
+        this.updateManifest(this.manifest);
+      }
     }
   }
 


### PR DESCRIPTION
## PR Type

- Bugfix

## Describe the current behavior?

When a manifest is not found, the manifest.generated check in the mutation causes an exception.
Thought the finally clause would be skipped with a return statement in the catch block.

## Describe the new behavior?

Do not trigger the manifest mutation (not needed here anyway) when the manifest is null.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
