### PR TITLE
Issue868 try 2

### DIFF
--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -1329,6 +1329,29 @@ h2 {
   }
 }
 
+@media (max-height: 800px) {
+  main#main {
+    display: block;
+
+    #inputSection {
+      display: block;
+    }
+
+    #topHalfHome,
+    #bottomHalfHome,
+    & > footer {
+      position: relative;
+      bottom: unset;
+      left: unset;
+      padding-bottom: 16px;
+    }
+  }
+
+  #inputSection > footer {
+    position: relative;
+  }
+}
+
 @media (max-height: 600px) {
   .backgroundIndex {
     @include backgroundLeftPoint(30%, 0vh);
@@ -1346,6 +1369,29 @@ h2 {
 @media (max-height: 475px) {
   .backgroundReport {
     @include backgroundRightPoint(80%, 0vh);
+  }
+}
+
+@media (min-resolution: 300dpi) {
+  #hubContainer {
+    overflow: scroll;
+  }
+
+  main#main {
+    display: block;
+
+    #inputSection {
+      display: block;
+    }
+
+    #topHalfHome,
+    #bottomHalfHome,
+    & > footer {
+      position: relative;
+      bottom: unset;
+      left: unset;
+      padding-bottom: 16px;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Fixes #868

## PR Type

- Bugfix
- Accessibility

## Describe the current behavior?

The test spacing throws off the height of lines which causes the collision between the absolutely positioned element and the card block.

## Describe the new behavior?

The issue underlying is the absolute positioning of the terms text, just switching that off for certain view heights, also there's a scroll issue with the grid at the scale so removing it for better flow. Scroll fixed.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
