### PR TITLE
fix(): fixes #1066

### DIFF
--- a/pages/_lang/generate.vue
+++ b/pages/_lang/generate.vue
@@ -7,7 +7,7 @@
       v-if="isInvalidScreenshotUrl"
       id="invalidUrlToast"
     >Invalid url(s): {{ `${invalidScreenshotUrlValues}` }}. Please try again.</div>
-    <main id="main" role="presentation">
+    <main id="generateMain" role="presentation">
       <section id="leftSide" :aria-hidden="ariaHidden">
         <header class="mastHead">
           <h2>{{ $t('generate.subtitle') }}</h2>
@@ -1617,7 +1617,7 @@ footer a {
   letter-spacing: -0.02em;
   color: #db3457;
 }
-#main {
+#generateMain {
   background: white;
   padding-left: 3%;
   padding-right: 3%;
@@ -1788,7 +1788,7 @@ footer a {
   #leftSide {
     width: 100%;
   }
-  #main {
+  #generateMain {
     flex-direction: column;
     padding-left: 31px !important;
     padding-right: 24px !important;


### PR DESCRIPTION
Fixes #1066 

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Layout is broken after navigating to the manifest editor and back.


## Describe the new behavior?
The issue was that we had an id called "main" in both the reportCard and generator pages. Because of that, when you navigated to the generator page the browser loaded that css which meant that when you navigated back that new css on `#main` was overriding. When we move to a web components-based solution in the future (far future haha) we won't have issues like this because of shadow dom.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
