### PR TITLE
fix(): score is always updated correctly

### DIFF
--- a/components/HubHeader.vue
+++ b/components/HubHeader.vue
@@ -184,31 +184,25 @@ export default class extends Vue {
   }
 
   mounted() {
-    const storedScore = sessionStorage.getItem("overallGrade") || null;
+    this.calcedScore = this.score;
 
-    if (storedScore) {
-      this.calcedScore = parseInt(storedScore);
-    } else {
-      this.calcedScore = this.score;
+    if ((window as any).CSS && (window as any).CSS.registerProperty) {
+      try {
+        (CSS as any).registerProperty({
+          name: "--color-stop",
+          syntax: "<color>",
+          inherits: false,
+          initialValue: "transparent",
+        });
 
-      if ((window as any).CSS && (window as any).CSS.registerProperty) {
-        try {
-          (CSS as any).registerProperty({
-            name: "--color-stop",
-            syntax: "<color>",
-            inherits: false,
-            initialValue: "transparent",
-          });
-
-          (CSS as any).registerProperty({
-            name: "--color-start",
-            syntax: "<color>",
-            inherits: false,
-            initialValue: "transparent",
-          });
-        } catch (err) {
-          console.error(err);
-        }
+        (CSS as any).registerProperty({
+          name: "--color-start",
+          syntax: "<color>",
+          inherits: false,
+          initialValue: "transparent",
+        });
+      } catch (err) {
+        console.error(err);
       }
     }
   }
@@ -221,24 +215,6 @@ export default class extends Vue {
   updated() {
     if (this.manifest) {
       this.readyToPublish = true;
-    }
-    if ("requestIdleCallback" in window) {
-      // Use requestIdleCallback to schedule this since its not "necessary" work
-      // and we dont want this running in the middle of animations or user input
-      if (this.score) {
-        (window as any).requestIdleCallback(
-          () => {
-            sessionStorage.setItem("overallGrade", this.score.toString());
-          },
-          {
-            timeout: 2000,
-          }
-        );
-      }
-    } else {
-      if (this.score) {
-        sessionStorage.setItem("overallGrade", this.score.toString());
-      }
     }
   }
 

--- a/components/ScoreCard.vue
+++ b/components/ScoreCard.vue
@@ -557,13 +557,6 @@ export default class extends Vue {
   private async lookAtManifest(): Promise<void> {
     // Gets manifest from api, then scores if not generated.
     try {
-      await this.getManifestInformation();
-
-      if (this.manifest && this.manifest.generated === true) {
-        this.noManifest = true;
-        return;
-      }
-
       await this.testManifest();
     } catch (ex) {
       // If manifest is not retrieved or DNE will fall in here. Mostly effects Security Score
@@ -591,33 +584,44 @@ export default class extends Vue {
   private async testManifest() {
     this.noManifest = false;
 
-    const response = await fetch(
-      `${process.env.testAPIUrl}/WebManifest?site=${this.url}`
-    );
-    const manifestScoreData = await response.json();
+    await this.getManifestInformation();
 
-    this.manifestScore = 15;
+    try {
+      const response = await fetch(
+        `${process.env.testAPIUrl}/WebManifest?site=${this.url}`
+      );
+      const manifestScoreData = await response.json();
 
-    if (manifestScoreData.data !== null) {
-      if (manifestScoreData.data.required.start_url === true) {
-        this.manifestScore = this.manifestScore + 5;
+      this.manifestScore = 15;
+
+      if (manifestScoreData.data !== null) {
+        if (manifestScoreData.data.required.start_url === true) {
+          this.manifestScore = this.manifestScore + 5;
+        }
+
+        if (manifestScoreData.data.required.short_name === true) {
+          this.manifestScore = this.manifestScore + 5;
+        }
+
+        if (manifestScoreData.data.required.name === true) {
+          this.manifestScore = this.manifestScore + 5;
+        }
+
+        if (manifestScoreData.data.required.icons === true) {
+          this.manifestScore = this.manifestScore + 5;
+        }
+
+        if (manifestScoreData.data.required.display === true) {
+          this.manifestScore = this.manifestScore + 5;
+        }
+
+        if (this.manifest && this.manifest.generated === true) {
+          this.noManifest = true;
+          return;
+        }
       }
-
-      if (manifestScoreData.data.required.short_name === true) {
-        this.manifestScore = this.manifestScore + 5;
-      }
-
-      if (manifestScoreData.data.required.name === true) {
-        this.manifestScore = this.manifestScore + 5;
-      }
-
-      if (manifestScoreData.data.required.icons === true) {
-        this.manifestScore = this.manifestScore + 5;
-      }
-
-      if (manifestScoreData.data.required.display === true) {
-        this.manifestScore = this.manifestScore + 5;
-      }
+    } catch (err) {
+      console.error(err);
     }
   }
 

--- a/components/ScoreHeader.vue
+++ b/components/ScoreHeader.vue
@@ -56,7 +56,7 @@ export default class extends Vue {
 
   mounted(): void {
     this.url$ = this.url;
-    this.score = sessionStorage.getItem("overallGrade");
+    // this.score = sessionStorage.getItem("overallGrade");
     this.scrollTarget = document.querySelector("#scrollTarget");
 
     if (this.scrollTarget && "animate" in this.$el) {


### PR DESCRIPTION
Fixes:

- Fixes an intermittent bug David reported where the score was not getting updated correctly and therefore the Congrats card was not always getting displayed when it should have. This PR fixes this by making two changes:

- Dont try to do any "smart" caching of scores. This leads to cases where the score is either 1) not calced correctly or 2) The wrong score may be displayed to the user until the tests are done, which could be confusing.
- Change the "order of operations" in the manifest test so that things get updated in an order that works well with vue's change detection. This also had the side effect of getting rid of some layout thrashing that was happening.
