### PR TITLE
Sending manifest contents to API

### DIFF
--- a/components/ScoreCard.vue
+++ b/components/ScoreCard.vue
@@ -917,9 +917,14 @@ export default class extends Vue {
     if (cachedData) {
       manifestScoreData = cachedData;
     } else {
-      const response = await fetch(
-        `${process.env.testAPIUrl}/WebManifest?site=${this.url}`
-      );
+      // We'll need to analyze the manifest.
+      // Send along the manifest contents if we've got 'em.
+      const manifestContents = this.getManifestContentsFromSessionStorage();
+      const manifestAnalysisUrl = `${process.env.testAPIUrl}/WebManifest?site=${this.url}`;
+      const response = await fetch(manifestAnalysisUrl, {
+        method: "POST",
+        body: manifestContents ? JSON.stringify({ manifest: manifestContents }) : ""
+      });
       manifestScoreData = await response.json();
 
       await setCache("manifestScoreData", this.url, manifestScoreData);
@@ -952,6 +957,14 @@ export default class extends Vue {
     this.manifestData = this.manifest;
 
     this.$emit("manifestTestDone", { score: this.manifestScore });
+  }
+
+  private getManifestContentsFromSessionStorage(): string | null {
+    if (sessionStorage && this.url) {
+      return sessionStorage.getItem("manifest/" + this.url);
+    }
+
+    return null;
   }
 
   private async lookAtSW() {

--- a/components/ScoreCard.vue
+++ b/components/ScoreCard.vue
@@ -913,7 +913,6 @@ export default class extends Vue {
     let manifestScoreData: any | null = null;
 
     const cachedData = await getCache("manifestScoreData", this.url);
-
     if (cachedData) {
       manifestScoreData = cachedData;
     } else {

--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -538,7 +538,7 @@ export default class extends Vue {
   }
 
   public manifestTestBroke() {
-    console.log("here");
+    
   }
 
   public swTestDone(ev) {
@@ -546,7 +546,6 @@ export default class extends Vue {
 
     // service worker test normally ends last
     // so turn testing to false here
-    console.log('doing stuff');
     this.testing = false;
   }
 

--- a/store/modules/generator/generator.actions.ts
+++ b/store/modules/generator/generator.actions.ts
@@ -61,7 +61,7 @@ export const actions: Actions<State, RootState> = {
       }
 
       // Create
-      await this.$axios.$post(apiUrl, { siteUrl: state.url });
+      await new ManifestFetcher(state.url!, this.$axios).fetch();
     }
 
     // Update
@@ -78,7 +78,6 @@ export const actions: Actions<State, RootState> = {
 
     customManifest['screenshots'] = [];
 
-    console.log('state', state.screenshots.length);
     if (state.screenshots !== undefined) {
       state.screenshots.forEach((screenshot) => {
         customManifest['screenshots'].push(Object.assign({}, screenshot));

--- a/store/modules/generator/generator.state.ts
+++ b/store/modules/generator/generator.state.ts
@@ -12,7 +12,7 @@ export interface Manifest {
   short_name: string | null;
   start_url: string | null;
   theme_color: string | null;
-  generated: boolean | null;
+  generated?: boolean | null;
   url: string | null;
   shortcuts?: ShortcutItem[];
   categories?: string[];

--- a/utils/manifest-fetcher.ts
+++ b/utils/manifest-fetcher.ts
@@ -21,9 +21,10 @@ export class ManifestFetcher {
         // Fallback: try our fallbacks simulatenously and see any of them can fetch the manifest.
         try {
             // Promise.any(...) may not exist. Use our polyfill if needed.
+            const fallbacks = [this.getManifestViaFilePost(), this.getManifestViaHtmlParse()];
             const promiseAnyOrPolyfill: (promises: Promise<ManifestDetectionResult>[]) => Promise<ManifestDetectionResult> = 
                 (promises) => Promise["any"] ? Promise["any"](promises) : this.promiseAny(promises);
-            return await promiseAnyOrPolyfill([this.getManifestViaFilePost(), this.getManifestViaHtmlParse()])
+            return await promiseAnyOrPolyfill(fallbacks);
         } catch (fallbackError) {
             console.error("Manifest detection fallbacks also failed. Manifest not detected.", fallbackError);
 

--- a/utils/manifest-fetcher.ts
+++ b/utils/manifest-fetcher.ts
@@ -20,8 +20,9 @@ export class ManifestFetcher {
 
         // Fallback: try our fallbacks simulatenously and see any of them can fetch the manifest.
         try {
-            // Promise.any(...) may not exist. Use our polyfill if needed.
             const fallbacks = [this.getManifestViaFilePost(), this.getManifestViaHtmlParse()];
+
+            // Promise.any(...) may not exist. Use our polyfill if needed.
             const promiseAnyOrPolyfill: (promises: Promise<ManifestDetectionResult>[]) => Promise<ManifestDetectionResult> = 
                 (promises) => Promise["any"] ? Promise["any"](promises) : this.promiseAny(promises);
             return await promiseAnyOrPolyfill(fallbacks);


### PR DESCRIPTION
Fixes #976 

In this PR, we:

- Run the manifest detectors simultaneously and use whatever result completes successfully
- Send the manifest contents to API v2, so as to avoid repeat errors when analyzing the manifest, and to speed up analysis by skipping having to fetch it again.

The last point above will fully work once the API v2 has been updated to accept the POST'd manifest.