### PR TITLE
Added manifest URL to POST body for analysis

### DIFF
--- a/components/ScoreCard.vue
+++ b/components/ScoreCard.vue
@@ -893,7 +893,7 @@ export default class extends Vue {
       const response = await fetch(manifestAnalysisUrl, {
         method: "POST",
         body: manifestContents
-          ? JSON.stringify({ manifest: manifestContents })
+          ? JSON.stringify({ manifest: manifestContents, maniurl: this.url })
           : "",
       });
       manifestScoreData = await response.json();


### PR DESCRIPTION
Sends manifest URL along with manifest body in POST call to manifest analysis API. Makes the front-end conform to this PR: https://github.com/pwa-builder/pwabuilder-api-v2/pull/23