### PR TITLE
feat(): add legacy edge button

### DIFF
--- a/components/Download.vue
+++ b/components/Download.vue
@@ -191,7 +191,7 @@ export default class extends Vue {
     if (platform === "androidTWA") {
       await this.generateAndroidPackage();
     } 
-    else if (platform === "windows10") {
+    else if (platform === "windows10New") {
       await this.generateWindowsEdgePackage();
     }
     else {

--- a/pages/_lang/publish.vue
+++ b/pages/_lang/publish.vue
@@ -814,12 +814,21 @@
           </p>
         </div>
 
-        <div id="androidModalButtonSection">
+        <div id="androidModalButtonSection" class="edgeBlock">
           <Download
             class="androidDownloadButton"
-            platform="windows10"
+            platform="windows10New"
             :message="$t('publish.download')"
             :showMessage="true"
+            v-on:downloadPackageError="showPackageDownloadError($event)"
+          />
+
+          <Download
+            :showMessage="true"
+            id="legacyDownloadButton"
+            class="webviewButton"
+            platform="windows10"
+            message="Use a legacy webview instead (not recommended)"
             v-on:downloadPackageError="showPackageDownloadError($event)"
           />
         </div>
@@ -1125,7 +1134,10 @@
 
               <p>
                 You'll get a package with your side-loadable PWA to test right away. Your PWA will
-                be running on the new <a href="https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/">Chromium based Edge</a>, giving you access to all of the latest APIs
+                be running on the new
+                <a
+                  href="https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/"
+                >Chromium based Edge</a>, giving you access to all of the latest APIs
                 available in Edge!
               </p>
 
@@ -2591,12 +2603,20 @@ footer a {
   font-size: 10px;
 }
 
-#androidModalBody #extraSection #legacyDownloadButton {
+#androidModalBody #extraSection #legacyDownloadButton, #androidModalBody #androidModalButtonSection #legacyDownloadButton {
   color: grey;
   font-size: 10px;
   background: transparent;
   padding-left: 0;
   border: none;
+  margin-top: 1em;
+}
+
+.edgeBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
 }
 
 #androidModalBody {


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the new behavior?
Adds a new button to allow the user to still download a legacy edge package if they want. This works the exact same way as the legacy android webview button works.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
