### PR TITLE
fix(): caching workflow redux fix

### DIFF
--- a/components/ScoreCard.vue
+++ b/components/ScoreCard.vue
@@ -931,9 +931,11 @@ export default class extends Vue {
       const cachedData = await getCache("manifest", this.url);
 
       if (cachedData) {
-        // this.manifest = cachedData;
-        this.updateManifest(cachedData);
-        // await this.getManifestInformation();
+        this.manifest = cachedData;
+
+        // Still call this in the background to get manifest
+        // into the redux flow for packaging
+        await this.getManifestInformation();
       } else {
         await this.getManifestInformation();
         await setCache("manifest", this.url, this.manifest);


### PR DESCRIPTION
## PR Type

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
When in the cached flow, we were not getting the manifest into the redux flow. Because of that, when you went to package with the new Windows or Android platforms, they would fail because the manifest (which they get from the redux state) was not in the redux state.

## Describe the new behavior?
This updates the cached flow to still make the call that puts the manifest into the redux flow.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
