### PR TITLE
Android options hiding non required options

### DIFF
--- a/components/CodeViewer.vue
+++ b/components/CodeViewer.vue
@@ -33,7 +33,7 @@
       <h2>Errors</h2>
 
       <ul>
-        <li v-for="error in errors">
+        <li v-for="error in errors" v-bind:key="error">
           <span>Line #{{ error.startLineNumber}}:</span>
           {{ error.message }}
         </li>

--- a/pages/_lang/publish.vue
+++ b/pages/_lang/publish.vue
@@ -745,7 +745,7 @@
                   />
                 </div>
 
-                <div class="form-group" v-if="androidForm.signingMode !== 'mine'">
+                <div class="form-group" v-if="androidForm.signingMode === 'new'">
                   <label for="signingKeyFullNameInput">Key full name</label>
                   <input
                     type="text"
@@ -757,7 +757,7 @@
                   />
                 </div>
 
-                <div class="form-group" v-if="androidForm.signingMode !== 'mine'">
+                <div class="form-group" v-if="androidForm.signingMode === 'new'">
                   <label for="signingKeyOrgInput">Key organization</label>
                   <input
                     type="text"
@@ -769,7 +769,7 @@
                   />
                 </div>
 
-                <div class="form-group" v-if="androidForm.signingMode !== 'mine'">
+                <div class="form-group" v-if="androidForm.signingMode === 'new'">
                   <label for="signingKeyOrgUnitInput">Key organizational unit</label>
                   <input
                     type="text"
@@ -781,7 +781,7 @@
                   />
                 </div>
 
-                <div class="form-group" v-if="androidForm.signingMode !== 'mine'">
+                <div class="form-group" v-if="androidForm.signingMode === 'new'">
                   <label for="signingKeyCountryCodeInput">
                     Key country code
                     <i

--- a/pages/_lang/publish.vue
+++ b/pages/_lang/publish.vue
@@ -130,10 +130,13 @@
     >
       <div id="topLabelBox" slot="extraP">
         <label id="topLabel">{{ $t("publish.package_name_detail") }}</label>
-        <p class="l-generator-error" v-if="androidPWAError">
-          <i class="fas fa-exclamation-circle"></i>
-          {{ $t(androidPWAError) }}
-        </p>
+        <ul class="l-generator-error" v-if="androidPWAErrors.length">
+          <li v-for="error in androidPWAErrors" v-bind:key="error">
+            <i class="fas fa-exclamation-circle"></i>
+            &nbsp;
+            <span>{{ $t(error) }}</span>
+          </li>
+        </ul>
       </div>
 
       <section class="androidModalBody androidOptionsModalBody">
@@ -820,10 +823,13 @@
     >
       <div id="topLabelBox" slot="extraP">
         <label id="topLabel">Customize your Windows Package below</label>
-        <p class="l-generator-error" v-if="androidPWAError">
-          <i class="fas fa-exclamation-circle"></i>
-          {{ $t(androidPWAError) }}
-        </p>
+        <ul class="l-generator-error" v-if="windowsOptionsErrors.length">
+          <li v-for="error in windowsOptionsErrors" v-bind:key="error">
+            <i class="fas fa-exclamation-circle"></i>
+            &nbsp;
+            <span>{{ $t(error) }}</span>
+          </li>
+        </ul>
       </div>
 
       <section class="androidModalBody androidOptionsModalBody">
@@ -1627,7 +1633,7 @@ export default class extends Vue {
   @PublishAction enableDownloadButton;
 
   public appxError: string | null = null;
-  public androidPWAError: string | null = null;
+  public androidPWAErrors: string[] = [];
   public apkDownloaded: boolean = false;
   public modalStatus = false;
   public openAndroid: boolean = false;
@@ -1650,6 +1656,7 @@ export default class extends Vue {
 
   public windowsForm: publish.WindowsPackageOptions | null = null;
   public windowsFormCopyForCancellation: publish.WindowsPackageOptions | null = null;
+  public windowsOptionsErrors: string[] = [];
   public windowsOptionsApplied: boolean = false;
 
   private readonly maxKeyFileSizeInBytes = 2097152; // 2MB. Typically, Android keystore files are ~3KB.
@@ -1710,7 +1717,7 @@ export default class extends Vue {
     } catch (err) {
       console.error(err);
 
-      this.androidPWAError = err;
+      this.androidPWAErrors = [err];
     }
   }
 
@@ -1752,7 +1759,7 @@ export default class extends Vue {
 
         this.installing = false;
       } catch (err) {
-        this.androidPWAError = err;
+        this.androidPWAErrors = [err];
         this.installing = false;
       }
     }
@@ -2305,20 +2312,20 @@ export default class extends Vue {
 
     const validationErrors = validateAndroidOptions(this.androidForm);
     if (validationErrors.length > 0) {
-      this.androidPWAError = validationErrors.map((e) => e.error).join(", ");
+      this.androidPWAErrors = validationErrors.map((e) => e.error);
       return;
     }
 
     (this.$refs.androidPWAModal as Modal).hide();
     this.openAndroid = true;
-    this.androidPWAError = null;
+    this.androidPWAErrors = [];
   }
 
   public androidOptionsModalCancelled() {
     this.androidForm =
       this.androidFormCopyForCancellation ||
       this.createAndroidParamsFromManifest();
-    this.androidPWAError = null;
+    this.androidPWAErrors = [];
     (this.$refs.androidPWAModal as Modal).hide();
     this.openAndroid = true;
   }
@@ -2328,7 +2335,7 @@ export default class extends Vue {
       this.windowsFormCopyForCancellation ||
       this.createWindowsParamsFromManifest();
 
-    this.androidPWAError = null;
+    this.windowsOptionsErrors = [];
 
     (this.$refs.windowsPWAModal as Modal).hide();
     this.openWindows = true;
@@ -2341,13 +2348,13 @@ export default class extends Vue {
 
     const validationErrors = validateWindowsOptions(this.windowsForm);
     if (validationErrors.length > 0) {
-      this.androidPWAError = validationErrors.map((e) => e.error).join(", ");
+      this.windowsOptionsErrors = validationErrors.map((e) => e.error);
       return;
     }
 
     (this.$refs.windowsPWAModal as Modal).hide();
     this.openWindows = true;
-    this.androidPWAError = null;
+    this.windowsOptionsErrors = [];
 
     this.windowsOptionsApplied = true;
   }

--- a/pages/_lang/publish.vue
+++ b/pages/_lang/publish.vue
@@ -724,7 +724,7 @@
                   />
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" v-if="androidForm.signingMode !== 'mine'">
                   <label for="signingKeyFullNameInput">Key full name</label>
                   <input
                     type="text"
@@ -736,7 +736,7 @@
                   />
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" v-if="androidForm.signingMode !== 'mine'">
                   <label for="signingKeyOrgInput">Key organization</label>
                   <input
                     type="text"
@@ -748,7 +748,7 @@
                   />
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" v-if="androidForm.signingMode !== 'mine'">
                   <label for="signingKeyOrgUnitInput">Key organizational unit</label>
                   <input
                     type="text"
@@ -760,7 +760,7 @@
                   />
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" v-if="androidForm.signingMode !== 'mine'">
                   <label for="signingKeyCountryCodeInput">
                     Key country code
                     <i

--- a/utils/android-utils.ts
+++ b/utils/android-utils.ts
@@ -122,7 +122,7 @@ export function validateAndroidOptions(options: Partial<AndroidApkOptions | null
 
       requiredSigningFields
         .filter(prop => !options.signing![prop])
-        .forEach(prop => validationErrors.push({ field: prop, error: `Signing key ${prop} must be specified` }));
+        .forEach(prop => validationErrors.push({ field: prop, error: `${prop} must be specified` }));
         
       // If key password and store password are specified, they must be >= 6 chars in length.
       if (options.signing.keyPassword && options.signing.keyPassword.length < 6) {

--- a/utils/android-utils.ts
+++ b/utils/android-utils.ts
@@ -133,7 +133,7 @@ export function validateAndroidOptions(options: Partial<AndroidApkOptions | null
       }
 
       // Ensure country code is 2 chars
-      if (options.signing.countryCode && options.signing.countryCode.length !== 2) {
+      if (options.signingMode === "new" && options.signing.countryCode && options.signing.countryCode.length !== 2) {
         validationErrors.push({ field: "countryCode", error: "Signing key country code must be 2 letters" });
       }
     }

--- a/utils/android-utils.ts
+++ b/utils/android-utils.ts
@@ -127,6 +127,15 @@ export function validateAndroidOptions(options: Partial<AndroidApkOptions | null
         .filter(prop => !options.signing![prop])
         .forEach(prop => validationErrors.push({ field: "signing", error: `Signing key ${prop} must be specified` }));
 
+        
+      // If key password and store password are specified, they must be >= 6 chars in length.
+      if (options.signing.keyPassword && options.signing.keyPassword.length < 6) {
+        validationErrors.push({ field: "signing" , error: "Key password must be at least 6 characters" });
+      }
+      if (options.signing.storePassword && options.signing.storePassword.length < 6) {
+        validationErrors.push({ field: "signing" , error: "Key store password must be at least 6 characters" });
+      }
+
       // Ensure country code is 2 chars
       if (options.signing.countryCode && options.signing.countryCode.length !== 2) {
         validationErrors.push({ field: "signing", error: "Signing key country code must be 2 letters" });

--- a/utils/android-utils.ts
+++ b/utils/android-utils.ts
@@ -126,24 +126,15 @@ export function validateAndroidOptions(options: Partial<AndroidApkOptions | null
         
       // If key password and store password are specified, they must be >= 6 chars in length.
       if (options.signing.keyPassword && options.signing.keyPassword.length < 6) {
-        validationErrors.push({ field: "signing" , error: "Key password must be at least 6 characters" });
+        validationErrors.push({ field: "keyPassword" , error: "Key password must be at least 6 characters" });
       }
       if (options.signing.storePassword && options.signing.storePassword.length < 6) {
-        validationErrors.push({ field: "signing" , error: "Key store password must be at least 6 characters" });
-      }
-
-        
-      // If key password and store password are specified, they must be >= 6 chars in length.
-      if (options.signing.keyPassword && options.signing.keyPassword.length < 6) {
-        validationErrors.push({ field: "signing" , error: "Key password must be at least 6 characters" });
-      }
-      if (options.signing.storePassword && options.signing.storePassword.length < 6) {
-        validationErrors.push({ field: "signing" , error: "Key store password must be at least 6 characters" });
+        validationErrors.push({ field: "storePassword" , error: "Key store password must be at least 6 characters" });
       }
 
       // Ensure country code is 2 chars
       if (options.signing.countryCode && options.signing.countryCode.length !== 2) {
-        validationErrors.push({ field: "signing", error: "Signing key country code must be 2 letters" });
+        validationErrors.push({ field: "countryCode", error: "Signing key country code must be 2 letters" });
       }
     }
   }


### PR DESCRIPTION
Implements #1159, hiding non-required signing options when signing mode = "new"