### PR TITLE
fix(): site now has correct amount of padding and margin

### DIFF
--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -1040,7 +1040,6 @@ h2 {
 
     display: flex;
     flex-direction: column;
-    padding: 0px;
   }
 
   #inputSection {
@@ -1071,6 +1070,7 @@ h2 {
 
   main {
     display: initial;
+    padding: 0 25px;
   }
 
   #inputSection #bottomHalfHome {
@@ -1102,32 +1102,6 @@ h2 {
 }
 
 @media (max-width: 542px) {
-  #attachSection {
-    margin-left: 25px;
-    margin-right: 25px;
-  }
-
-  #infoSection {
-    margin-left: 25px;
-    margin-right: 25px;
-  }
-
-  .scoreCard {
-    margin-left: 25px;
-    margin-right: 25px;
-    margin-bottom: 20px;
-  }
-
-  #toolkitSection {
-    margin-left: 25px;
-    margin-right: 25px;
-  }
-
-  .topFeatures {
-    margin-left: 25px;
-    margin-right: 25px;
-  }
-
   #hubFooter {
     padding-left: 25px;
     padding-right: 25px;


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The site had the wrong padding/margin between 542px and 800px:

![image](https://user-images.githubusercontent.com/8823093/96510437-5afa5a80-1212-11eb-8ec5-07f46a1084f2.png)


## Describe the new behavior?
Has the correct amount of padding on all sizes.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
