### PR TITLE
lower text color contrast text

### DIFF
--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -943,7 +943,7 @@ h2 {
     position: absolute;
     bottom: 10px;
     margin-right: 32px;
-    color: rgba(60, 60, 60, 0.6);
+    color: #000000;
     background: transparent;
 
     p {
@@ -1348,10 +1348,6 @@ h2 {
       left: unset;
       padding-bottom: 16px;
     }
-  }
-
-  #inputSection > footer {
-    position: relative;
   }
 }
 


### PR DESCRIPTION
Fixes
https://github.com/pwa-builder/PWABuilder/issues/821

## PR Type

- Accessibility text change, removed left over relative positioning code from an earlier revision that I've changed to flex at breaks points since.

## Describe the current behavior?

- Color contrast wasn't high enough on mentioned lower text.

## Describe the new behavior?

- brought it up

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
