### PR TITLE
Issue #823 in PWABuilder not pwa-features

### DIFF
--- a/components/FeatureCard.vue
+++ b/components/FeatureCard.vue
@@ -9,7 +9,7 @@
     <p v-bind:class="{textWrap: wrapText}">{{ sample.desc }}</p>
 
     <div v-if="showAddButton" class="featureCardActionsBlock">
-      <a class="featureCardAddButton" :href="`https://components.pwabuilder.com/component/${sample.ID}`">
+      <a class="featureCardAddButton" :href="`https://components.pwabuilder.com/component/${sample.ID}`" :aria-label="'View ' + sample.name + ' Component link'">
         View Feature
       </a>
     </div>


### PR DESCRIPTION
aria-label for these cards... no indication of how to get here from poster.

Fixes #823 

## PR Type

- Bugfix

## Describe the current behavior?

- descriptive aria label missing

## Describe the new behavior?

- Adds aria label to element

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
