### PR TITLE
fix(): remove old route push

### DIFF
--- a/pages/_lang/reportCard.vue
+++ b/pages/_lang/reportCard.vue
@@ -428,8 +428,6 @@ export default class extends Vue {
     };
 
     this.$awa(overrideValues);
-
-    this.$router.push("/features?from=starter");
   }
 
   async cloneStarter() {


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
Fixes an issue I saw when Melanie was demoing Friday where the route that we pushed to after a download of the starter was an old route that did not exist anymore. This section is going to be rebuilt / redesigned with PWABuilder 3.0, but just wanted to do a patch fix for now for this bug.

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the new behavior?
No more re-routing of the user after they have downloaded the starter.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
