### PR TITLE
Added safe URL fetching fallback

### DIFF
--- a/components/Download.vue
+++ b/components/Download.vue
@@ -133,8 +133,8 @@ export default class extends Vue {
         const responseText = await response.text();
         
         // Did it fail because images couldn't be fetched with ECONNREFUSED? E.g. https://github.com/pwa-builder/PWABuilder/issues/1312
-        // If so, retry using our safe image downloader.
-        const hasSafeImages = this.androidOptions.iconUrl && this.androidOptions.iconUrl.includes(process.env.safeImageFetcherUrl || "");
+        // If so, retry using our downloader proxy service.
+        const hasSafeImages = this.androidOptions.iconUrl && this.androidOptions.iconUrl.includes(process.env.safeUrlFetcher || "");
         if (!hasSafeImages && responseText && responseText.includes("ECONNREFUSED")) {
           console.warn("Android package generation failed with ECONNREFUSED. Retrying with safe images.", responseText);
           this.updateAndroidOptionsWithSafeUrls(this.androidOptions);
@@ -337,7 +337,7 @@ export default class extends Vue {
     for (let prop of absoluteUrlProps) {
       const url = options[prop];
       if (url && typeof url === "string") {
-        const safeUrl = `${process.env.safeImageFetcherUrl}?url=${encodeURIComponent(url)}`;
+        const safeUrl = `${process.env.safeUrlFetcher}?url=${encodeURIComponent(url)}`;
         (options as any)[prop] = safeUrl;
       }
     }

--- a/environments/development.js
+++ b/environments/development.js
@@ -11,5 +11,6 @@ module.exports = {
   serviceWorkerDetectorUrl: 'https://pwabuilder-serviceworker-finder.centralus.cloudapp.azure.com',
   macosPackageGeneratorUrl: 'https://pwabuilder-macos.azurewebsites.net/',
   webPackageGeneratorUrl: 'https://pwabuilder-web-platform.azurewebsites.net/',
-  swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net'
+  swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net',
+  safeImageFetcherUrl: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
 };

--- a/environments/development.js
+++ b/environments/development.js
@@ -12,5 +12,5 @@ module.exports = {
   macosPackageGeneratorUrl: 'https://pwabuilder-macos.azurewebsites.net/',
   webPackageGeneratorUrl: 'https://pwabuilder-web-platform.azurewebsites.net/',
   swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net',
-  safeImageFetcherUrl: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
+  safeUrlFetcher: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
 };

--- a/environments/preview.js
+++ b/environments/preview.js
@@ -10,5 +10,6 @@ module.exports = {
   serviceWorkerDetectorUrl: 'https://pwabuilder-serviceworker-finder.centralus.cloudapp.azure.com',
   macosPackageGeneratorUrl: 'https://pwabuilder-macos.azurewebsites.net/',
   webPackageGeneratorUrl: 'https://pwabuilder-web-platform.azurewebsites.net/',
-  swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net'
+  swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net',
+  safeImageFetcherUrl: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
 };

--- a/environments/preview.js
+++ b/environments/preview.js
@@ -11,5 +11,5 @@ module.exports = {
   macosPackageGeneratorUrl: 'https://pwabuilder-macos.azurewebsites.net/',
   webPackageGeneratorUrl: 'https://pwabuilder-web-platform.azurewebsites.net/',
   swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net',
-  safeImageFetcherUrl: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
+  safeUrlFetcher: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
 };

--- a/environments/production.js
+++ b/environments/production.js
@@ -10,5 +10,6 @@ module.exports = {
   serviceWorkerDetectorUrl: 'https://pwabuilder-serviceworker-finder.centralus.cloudapp.azure.com',
   macosPackageGeneratorUrl: 'https://pwabuilder-macos.azurewebsites.net/',
   webPackageGeneratorUrl: 'https://pwabuilder-web-platform.azurewebsites.net/',
-  swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net'
+  swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net',
+  safeImageFetcherUrl: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
 };

--- a/environments/production.js
+++ b/environments/production.js
@@ -11,5 +11,5 @@ module.exports = {
   macosPackageGeneratorUrl: 'https://pwabuilder-macos.azurewebsites.net/',
   webPackageGeneratorUrl: 'https://pwabuilder-web-platform.azurewebsites.net/',
   swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net',
-  safeImageFetcherUrl: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
+  safeUrlFetcher: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
 };

--- a/environments/test.js
+++ b/environments/test.js
@@ -8,5 +8,5 @@ module.exports = {
     macosPackageGeneratorUrl: 'https://pwabuilder-macos.azurewebsites.net/',
     webPackageGeneratorUrl: 'https://pwabuilder-web-platform.azurewebsites.net/',
     swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net',
-    safeImageFetcherUrl: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
+    safeUrlFetcher: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
 }

--- a/environments/test.js
+++ b/environments/test.js
@@ -7,5 +7,6 @@ module.exports = {
     serviceWorkerDetectorUrl: 'https://pwabuilder-serviceworker-finder.centralus.cloudapp.azure.com',
     macosPackageGeneratorUrl: 'https://pwabuilder-macos.azurewebsites.net/',
     webPackageGeneratorUrl: 'https://pwabuilder-web-platform.azurewebsites.net/',
-    swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net'
+    swServerUrl: 'https://pwabuilder-sw-server.azurewebsites.net',
+    safeImageFetcherUrl: 'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl'
 }


### PR DESCRIPTION
Fixes #1314, #1313, #1312, #1299, #1266

In particular, if the Android tools is blocked from accessing an image or manifest, we try again using a URL proxy.