### PR TITLE
refactor(): use css utils instead of raw media queries

### DIFF
--- a/src/script/components/app-header.ts
+++ b/src/script/components/app-header.ts
@@ -1,5 +1,10 @@
 import { LitElement, css, html, customElement, property } from 'lit-element';
 
+import {
+  mediumBreakPoint,
+  smallBreakPoint,
+} from '../utils/breakpoints';
+
 @customElement('app-header')
 export class AppHeader extends LitElement {
   @property({ type: String }) title = 'PWABuilder';
@@ -42,10 +47,18 @@ export class AppHeader extends LitElement {
         }
       }
 
-      @media(max-width: 542px) {
-        header {
-          padding-left: 16px;
-        }
+      ${
+        smallBreakPoint(css`
+          header {
+            padding-left: 16px;
+          }
+        `),
+
+        mediumBreakPoint(css`
+          header {
+            padding-left: 16px;
+          }
+        `)
       }
 
     `;

--- a/src/script/components/content-header.ts
+++ b/src/script/components/content-header.ts
@@ -1,5 +1,7 @@
 import { LitElement, css, html, customElement } from 'lit-element';
 
+import { smallBreakPoint, mediumBreakPoint, xLargeBreakPoint } from '../utils/breakpoints';
+
 import './app-header';
 
 @customElement('content-header')
@@ -15,7 +17,7 @@ export class ContentHeader extends LitElement {
       #main-container {
         display: flex;
         align-items: center;
-        
+
         padding-bottom: 91px;
       }
 
@@ -25,7 +27,15 @@ export class ContentHeader extends LitElement {
         width: 369px;
       }
 
-      @media(max-width: 542px) {
+      ${smallBreakPoint(css`
+        #main-container {
+          flex-direction: column;
+        }
+
+        img {
+          margin-top: 2em;
+        }
+
         #content-side {
           padding: 1em;
         }
@@ -37,9 +47,9 @@ export class ContentHeader extends LitElement {
         ::slotted(ul) {
           grid-gap: 10px;
         }
-      }
+      `)}
 
-      @media(max-width: 800px) {
+      ${mediumBreakPoint(css`
         #main-container {
           flex-direction: column;
         }
@@ -47,14 +57,22 @@ export class ContentHeader extends LitElement {
         img {
           margin-top: 2em;
         }
-      }
 
-      @media(max-width: 1024px) {
+        #content-side {
+          padding: 1em;
+        }
+
+        #main-container {
+          padding-top: initial;
+        }
+      `)}
+
+      ${xLargeBreakPoint(css`
         img {
           height: 18em;
           width: initial;
         }
-      }
+      `)}
     `;
   }
 

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -1,5 +1,7 @@
 import { LitElement, css, html, customElement } from 'lit-element';
 
+import { mediumBreakPoint } from '../utils/breakpoints';
+
 import '../components/content-header';
 import '../components/resource-hub';
 
@@ -78,11 +80,11 @@ export class AppHome extends LitElement {
         border-radius: var(--input-radius);
       }
 
-      @media(max-width: 542px) {
+      ${mediumBreakPoint(css`
         content-header::part(main-container) {
           padding-top: initial;
         }
-      }
+      `)}
     `;
   }
 


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
I was using raw media queries.

## Describe the new behavior?
This PR updates my CSS to use Leo's new utils.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
