### PR TITLE
Added VSCode F5 debugging

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,5 +6,6 @@
     "rvest.vs-code-prettier-eslint",
     "eg2.vscode-npm-script",
     "christian-kohler.npm-intellisense",
+    "msjsdiag.debugger-for-edge"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // VS Code debugger launch file. When you press F5 in VS Code,
+    // this debugger configuration will launch.
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug in VSCode",
+            "type": "edge",
+            "request": "launch",
+            "version": "stable",
+            "url": "http://localhost:8000",
+            "webRoot": "${workspaceFolder}/build",
+            "sourceMaps": true,
+            "skipFiles": ["node_modules"],
+            "smartStep": true,
+            "pathMapping": {
+                "/": "${workspaceFolder}/build/index.html"
+            },
+            "preLaunchTask": "npm: debug"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "npm: debug",
+        "type": "npm",
+        "script": "debug",
+        "isBackground": true,
+        "problemMatcher": [
+            {
+                "pattern": [
+                  {
+                    "regexp": ".",
+                    "file": 1,
+                    "location": 2,
+                    "message": 3
+                  }
+                ],
+                "background": {
+                  "activeOnStart": true,
+                  "beginsPattern": ".",
+                  "endsPattern": "Web Dev Server started"
+                }
+              }
+        ]
+      }
+    ]
+  }

--- a/README.md
+++ b/README.md
@@ -22,9 +22,17 @@ We recommend the following tools for your dev setup:
 * Editor: [VSCode](https://code.visualstudio.com/)
 * Terminal: [Windows Terminal](https://www.microsoft.com/en-us/p/windows-terminal-preview/9n0dx20hk701?activetab=pivot:overviewtab) or [hyper](https://hyper.is/)
 
+Additionally, when you open the project in VS Code, you'll be prompted to install recommended extensions.
+
 ### Development
 
 Run `npm install` and then run `npm run dev`, the project should open in your default browser. From here you can start developing, your changes will be rebuilt and reloaded in the browser as you develop.
+
+### Debugging in VS Code
+
+In VS Code, install [Debugger for Microsoft Edge extension](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge).
+
+In VSCode, set a breakpoint in a TypeScript file. Then press F5 to launch debugging.
 
 ### Building for Production
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2652,7 +2652,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
       "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
@@ -2739,8 +2738,7 @@
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/express": {
       "version": "4.17.9",
@@ -2815,7 +2813,7 @@
     },
     "@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "resolved": "http://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
@@ -4052,8 +4050,7 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "atob-lite": {
       "version": "2.0.0",
@@ -4072,7 +4069,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -4773,8 +4770,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -5495,8 +5491,7 @@
     "estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
     },
     "esutils": {
       "version": "2.0.3",
@@ -6497,7 +6492,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -6905,7 +6900,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -6926,7 +6921,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -7137,7 +7132,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -7698,8 +7693,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "3.0.0",
@@ -8222,6 +8216,26 @@
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
           "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
           "dev": true
+        }
+      }
+    },
+    "rollup-plugin-sourcemaps": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.3.tgz",
+      "integrity": "sha512-paFu+nT1xvuO1tPFYXGe+XnQvg4Hjqv/eIhG8i5EspfYYPBKL57X7iVbfv55aNVASg3dzWvES9dmWsL2KhfByw==",
+      "requires": {
+        "@rollup/pluginutils": "^3.0.9",
+        "source-map-resolve": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
         }
       }
     },
@@ -9162,7 +9176,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -9255,7 +9269,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rollup --config rollup.config.dev.js && rimraf dist/ && rollup --config rollup.config.js",
-    "start": "concurrently \"rollup --config rollup.config.dev.js --watch\" \"es-dev-server --app-index build/index.html --root-dir build/ --compatibility none --node-resolve --watch --open /\"",
-    "dev": "concurrently \"rollup --config rollup.config.dev.js --watch\" \"web-dev-server --app-index build/index.html --root-dir build/ --compatibility none --node-resolve --watch --open /\""
+    "start": "concurrently \"rollup --config rollup.config.dev.js --watch\" \"web-dev-server\"",
+    "dev": "concurrently \"rollup --config rollup.config.dev.js --watch\" \"web-dev-server\"",
+    "debug": "concurrently \"rollup --config rollup.config.dev.js --watch\" \"web-dev-server --config web-dev-server.debugging.config.mjs\""
   },
   "author": "",
   "license": "ISC",
@@ -42,6 +43,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-workbox": "^5.2.1",
     "rollup-plugin-workbox-inject": "^2.0.0",
+    "rollup-plugin-sourcemaps": "^0.6.3",
     "typescript": "^4.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-workbox": "^5.2.1",
     "rollup-plugin-workbox-inject": "^2.0.0",
-    "rollup-plugin-sourcemaps": "^0.6.3",
     "typescript": "^4.1.3"
   }
 }

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -9,6 +9,7 @@ export default {
   output: {
     dir: "build",
     format: "es",
+    sourcemap: true
   },
   plugins: [
     resolve(),
@@ -25,7 +26,7 @@ export default {
       targets: [
         { src: "assets/**/*", dest: "build/assets/" },
         { src: "styles/global.css", dest: "build/styles/" },
-        { src: "manifest.json", dest: "build/" },
+        { src: "manifest.json", dest: "build/" }
       ],
     }),
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,7 @@ export default {
   input: "build/index.html",
   output: {
     dir: "dist",
-    format: "es",
+    format: "es"
   },
   plugins: [
     resolve(),

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -17,6 +17,7 @@
       "noImplicitAny": true,
       "noImplicitThis": true,
       "outDir": "./build/",
+      "sourceMap": true,
       // Only necessary because @types/uglify-js can't find types for source-map
       "skipLibCheck": true,
       "experimentalDecorators": true,

--- a/web-dev-server.config.mjs
+++ b/web-dev-server.config.mjs
@@ -1,0 +1,9 @@
+// This is the configuration for `npm dev` and `npm start`.
+
+export default {
+    appIndex: "build/index.html",
+    rootDir: "build/",
+    compatibility: "none",
+    watch: true,
+    open: "/"
+  };

--- a/web-dev-server.debugging.config.mjs
+++ b/web-dev-server.debugging.config.mjs
@@ -1,3 +1,4 @@
+// This is the configuration file for `npm debug`
 // This is the same as web-server.config.mjs, except that it doesn't launch a browser, see the `open: false`
 // The browser will instead be launched by VSCode F5 debugging in a separate user profile.
 

--- a/web-dev-server.debugging.config.mjs
+++ b/web-dev-server.debugging.config.mjs
@@ -1,0 +1,10 @@
+// This is the same as web-server.config.mjs, except that it doesn't launch a browser, see the `open: false`
+// The browser will instead be launched by VSCode F5 debugging in a separate user profile.
+
+export default {
+    appIndex: "build/index.html",
+    rootDir: "build/",
+    compatibility: "none",
+    watch: true,
+    open: false
+  };


### PR DESCRIPTION
## PR Type
Build or CI related changes

Specifically, we've added TypeScript debugging to both Dev Tools and VS Code.

## Describe the new behavior?
Our dev build now outputs source maps, enabling you to debug TypeScript in F12 Dev Tools.

Additionally, I've added debugging capabilities for VS Code. To debug in VS Code, install the [Debugger for Microsoft Edge extension](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge), add a breakpoint in a TypeScript file in VS Code, then hit F5 to debug.

I've updated the project's readme with this information. 

I've also updated the VS Code recommended extensions for this project.