### PR TITLE
refactor(): add app-button component

### DIFF
--- a/src/script/components/app-button.ts
+++ b/src/script/components/app-button.ts
@@ -1,0 +1,43 @@
+import { LitElement, css, html, customElement, property } from 'lit-element';
+
+@customElement('app-button')
+export class AppButton extends LitElement {
+  @property({ type: String }) type: string = "";
+  @property({ type: String }) colorMode = "primary";
+
+  static get styles() {
+    return css`
+      :host {
+        border-radius: var(--button-radius);
+        display: block;
+      }
+
+      fast-button {
+        color: white;
+        width: 100%;
+
+        border-radius: var(--button-radius);
+        box-shadow: var(--button-shadow);
+      }
+
+      fast-button::part(control) {
+        font-size: var(--desktop-button-font-size);
+        font-weight: var(--font-bold);
+        padding-left: 34px;
+        padding-right: 34px;
+      }
+    `;
+  }
+
+  constructor() {
+    super();
+  }
+
+  render() {
+    return html`
+      <fast-button part="underlying-button" .type="${this.type}" .color="${this.colorMode}">
+        <slot></slot>
+      </fast-button>
+    `;
+  }
+}

--- a/src/script/components/loading-button.ts
+++ b/src/script/components/loading-button.ts
@@ -1,6 +1,8 @@
 import { LitElement, css, html, customElement, property } from 'lit-element';
 import { smallBreakPoint, mediumBreakPoint } from '../utils/breakpoints';
 
+import "../components/app-button";
+
 @customElement('loading-button')
 export class LoadingButton extends LitElement {
   @property({ type: Boolean }) loading: boolean = false;
@@ -10,11 +12,6 @@ export class LoadingButton extends LitElement {
       fast-progress-ring {
         height: 1.8em;
         width: 1.8em;
-      }
-
-      fast-button::part(control) {
-        font-size: var(--font-size);
-        font-weight: var(--font-bold);
       }
 
       ${smallBreakPoint(css`
@@ -47,11 +44,11 @@ export class LoadingButton extends LitElement {
 
   render() {
     return html`
-      <fast-button part="underlying-button" type="submit" color="primary">
+      <app-button part="underlying-button" type="submit" color="primary">
         ${this.loading
           ? html`<fast-progress-ring></fast-progress-ring>`
           : html`<slot></slot>`}
-      </fast-button>
+      </app-button>
     `;
   }
 }

--- a/src/script/components/resource-hub.ts
+++ b/src/script/components/resource-hub.ts
@@ -6,6 +6,8 @@ import {
   smallBreakPoint,
 } from '../utils/breakpoints';
 
+import '../components/app-button';
+
 type ResourceHubPages = 'home' | 'complete';
 
 @customElement('resource-hub')
@@ -110,11 +112,9 @@ export class ResourceHub extends LitElement {
         margin-bottom: 74px;
       }
 
-      #resource-hub-actions fast-button {
+      #resource-hub-actions app-button::part(underlying-button) {
         background: white;
         color: var(--font-color);
-        border-radius: var(--button-radius);
-        width: 188px;
       }
 
       #resource-hub-actions fast-button::part(control) {
@@ -226,7 +226,7 @@ export class ResourceHub extends LitElement {
     if (this.showViewAllButton) {
       return html`
         <div id="resource-hub-actions">
-          <fast-button>View all resources</fast-button>
+          <app-button>View all resources</app-button>
         </div>
       `;
     }

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -88,10 +88,6 @@ export class AppHome extends LitElement {
       #input-form loading-button::part(underlying-button) {
         display: flex;
 
-        box-shadow: var(--button-shadow);
-        border-radius: var(--button-radius);
-        font-size: var(--desktop-button-font-size);
-        font-weight: var(--font-bold);
       }
 
       #input-form fast-text-field::part(root) {
@@ -144,15 +140,6 @@ export class AppHome extends LitElement {
         #input-form loading-button {
           margin-top: 54px;
         }
-
-        #input-form loading-button::part(underlying-button) {
-          display: flex;
-
-          box-shadow: var(--button-shadow);
-          border-radius: var(--button-radius);
-          font-size: var(--desktop-button-font-size);
-          font-weight: var(--font-bold);
-        }
       `)}
 
       ${mediumBreakPoint(css`
@@ -195,11 +182,9 @@ export class AppHome extends LitElement {
           font-size: 22px;
         }
 
-        #input-form loading-button {
+        #input-form loading-button::part(underlying-button) {
           width: 216px;
           margin-top: 44px;
-          border-radius: var(--mobile-button-radius);
-          height: var(--mobile-button-height);
         }
       `)}
 
@@ -331,7 +316,7 @@ export class AppHome extends LitElement {
         ?open="${true}"
       >
         <div slot="modal-actions">
-          <fast-button>Button</fast-button>
+          <app-button>Test Button</app-button>
         </div>
       </app-modal>
 


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the new behavior?
We have our CSS variables standardized for our buttons, but for the main style of button throughout the site you still needed to make sure you add the right CSS vars. This PR wraps fast-button in an app-component button that has these styles by default so that things are even more standardized across the UI.

This PR also goes ahead and refactors to use this button where the standard button design is used.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
