### PR TITLE
feat(): new app-alert component

### DIFF
--- a/src/script/components/app-alert.ts
+++ b/src/script/components/app-alert.ts
@@ -1,0 +1,115 @@
+import { LitElement, html, css, customElement, property } from 'lit-element';
+
+@customElement('app-alert')
+export class AppAlert extends LitElement {
+  @property({ type: Boolean }) open: boolean = false;
+  @property({ type: String }) title: string = 'Title';
+
+  contextAnimation: Animation | null = null;
+  dialog: Element | null | undefined = null;
+
+  static get styles() {
+    return css`
+      #alert {
+        padding-left: 16px;
+        padding-right: 16px;
+        background: var(--primary-background-color);
+        box-shadow: 0px 16px 24px rgba(0, 0, 0, 0.24);
+        border-radius: 4px;
+        max-width: 300px;
+      }
+
+      #alert-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      #alert-header h5 {
+        font-size: 20px;
+        line-height: 24px;
+        font-weight: var(--font-bold);
+        margin-top: 12px;
+        margin-bottom: 12px;
+      }
+
+      #alert-header fast-button ion-icon {
+        height: 2em;
+        width: 2em;
+        color: #c2c9d1;
+      }
+
+      #alert-actions {
+        display: flex;
+        justify-content: flex-end;
+        padding-bottom: 20px;
+      }
+    `;
+  }
+
+  constructor() {
+    super();
+  }
+
+  public async openAlert(xValue: number, yValue: number) {
+    this.open = true;
+    await this.updateComplete;
+
+    this.dialog = this.shadowRoot?.querySelector('#alert');
+    console.log(this.dialog);
+
+    if (this.dialog) {
+      (this.dialog as HTMLElement).style.top = `${yValue}px`;
+      (this.dialog as HTMLElement).style.left = `${xValue}px`;
+
+      this.contextAnimation = this.dialog.animate(
+        [
+          { transform: 'translateY(6px)', opacity: 0 },
+          { transform: 'translateY(0)', opacity: 1 },
+        ],
+        {
+          duration: 100,
+          fill: 'both',
+        }
+      );
+    }
+  }
+
+  public async close() {
+    if (this.contextAnimation) {
+      this.contextAnimation.reverse();
+      await this.contextAnimation.finished;
+    }
+
+    this.open = false;
+  }
+
+  render() {
+    if (this.open) {
+      return html`
+        <div id="alert">
+          <div id="alert-header">
+            <h5>${this.title}</h5>
+
+            <fast-button
+              @click="${() => this.close()}"
+              appearance="lightweight"
+            >
+              <ion-icon name="close"></ion-icon>
+            </fast-button>
+          </div>
+
+          <div id="alert-content">
+            <slot></slot>
+          </div>
+
+          <div id="alert-actions">
+            <slot name="actions"></slot>
+          </div>
+        </div>
+      `;
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/script/pages/app-about.ts
+++ b/src/script/pages/app-about.ts
@@ -2,6 +2,11 @@ import { LitElement, css, html, customElement } from 'lit-element';
 import { testManifest } from '../services/tests/manifest';
 import { testServiceWorker } from '../services/tests/service-worker';
 
+// double import needed to get full impl
+// and type
+import '../components/app-alert';
+import { AppAlert } from '../components/app-alert';
+
 @customElement('app-about')
 export class AppAbout extends LitElement {
   static get styles() {
@@ -25,10 +30,27 @@ export class AppAbout extends LitElement {
     }
   }
 
+  testAlert(ev: any) {
+    console.log(ev);
+    const alert: AppAlert | null | undefined = this.shadowRoot?.querySelector("app-alert");
+
+    if (alert) {
+      alert.openAlert(ev.clientX, ev.clientY);
+    }
+  }
+
   render() {
     return html`
       <div>
         <h2>About Page</h2>
+
+        <fast-button @click="${(ev: any) => this.testAlert(ev)}">test alert</fast-button>
+
+        <app-alert title="Test Alert">
+          <p>Info description. Lorem ipsum dolor sit amet, consectetur elit adipiscing, sed do eiusm tem. Ipsum dolor sit.</p>
+
+          <fast-anchor slot="actions">Test</fast-anchor>
+        </app-alert>
       </div>
     `;
   }


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the new behavior?
New alert component, can be tested on the about page. This component works very similarly to app-modal in the fact that its content all comes from slots and therefore is fully customizable. However, this component differs from app-modal in the fact that it is controlled through an exposed JS API from the component, not just props. The reason for this is because the alert is meant to open where the user clicked (like the right click dialogue) so I need to do things in JS for that to happen.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
