### PR TITLE
Fix typo in web app manifest screenshot file

### DIFF
--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -48,37 +48,37 @@
   "screenshots": [
     {
       "src": "/Images/assets/screenShots/s1.png",
-      "size": "1600x1020",
+      "sizes": "1600x1020",
       "type": "image/png",
       "description": "PWA Builder Home Screen"
     },
     {
       "src": "/Images/assets/screenShots/s2.png",
-      "size": "1600x1020",
+      "sizes": "1600x1020",
       "type": "image/png",
       "description": "PWA Builder is also a PWA and can be used in app mode"
     },
     {
       "src": "/Images/assets/screenShots/s3.png",
-      "size": "1600x1020",
+      "sizes": "1600x1020",
       "type": "image/png",
       "description": "Enter your URL to get a PWA score"
     },
     {
       "src": "/Images/assets/screenShots/s4.png",
-      "size": "1600x1020",
+      "sizes": "1600x1020",
       "type": "image/png",
       "description": "See the manifest on the site, or a generated manifest from PWA Builder"
     },
     {
       "src": "/Images/assets/screenShots/s5.png",
-      "size": "1600x1020",
+      "sizes": "1600x1020",
       "type": "image/png",
       "description": "Find easy to use service workers that fit almost any site."
     },
     {
       "src": "/Images/assets/screenShots/s6.png",
-      "size": "1600x1020",
+      "sizes": "1600x1020",
       "type": "image/png",
       "description": "Find easy to use snippits that make your web site more app-like"
     }


### PR DESCRIPTION
Application pane in Chrome Canary DevTools raises a warning with pwabuilder.com web manifest as you can see below. This PR fixes it by renaming `size` to `sizes` [screenshots property](https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots).

![image](https://user-images.githubusercontent.com/634478/107974149-7570f480-6fb6-11eb-8528-3f153437f722.png)
