### PR TITLE
fix(): small bug with reports + add fallback

### DIFF
--- a/src/script/components/report-card.ts
+++ b/src/script/components/report-card.ts
@@ -14,7 +14,7 @@ import './score-results';
 
 @customElement('report-card')
 export class ReportCard extends LitElement {
-  @property() results: RawTestResult | undefined;
+  @property() results: RawTestResult;
 
   @internalProperty() maniScore = 0;
   @internalProperty() swScore = 0;
@@ -166,6 +166,23 @@ export class ReportCard extends LitElement {
     super();
   }
 
+  firstUpdated() {
+    if (!this.results) {
+      // Should never really end up here
+      // But just in case this component tries to render without results
+      // lets attempt to grab the last saved results
+      this.handleNoResults();
+    }
+  }
+
+  handleNoResults() {
+    const resultsData = sessionStorage.getItem('results-string');
+
+    if (resultsData) {
+      this.results = JSON.parse(resultsData);
+    }
+  }
+
   opened(targetEl: EventTarget | null) {
     console.log(targetEl);
 
@@ -304,7 +321,7 @@ export class ReportCard extends LitElement {
               >
 
               <score-results
-                .testResults="${this.results?.manifest}"
+                .testResults="${this.results.manifest}"
                 @scored="${(ev: CustomEvent) => this.handleManiScore(ev)}"
               ></score-results>
             </fast-accordion-item>
@@ -330,7 +347,7 @@ export class ReportCard extends LitElement {
                 >Service Worker Options</app-button
               >
               <score-results
-                .testResults="${this.results?.service_worker}"
+                .testResults="${this.results.service_worker}"
                 @scored="${(ev: CustomEvent) => this.handleSWScore(ev)}"
               ></score-results>
             </fast-accordion-item>
@@ -352,7 +369,7 @@ export class ReportCard extends LitElement {
               </div>
 
               <score-results
-                .testResults="${this.results?.security}"
+                .testResults="${this.results.security}"
                 @scored="${(ev: CustomEvent) => this.handleSecurityScore(ev)}"
               ></score-results>
             </fast-accordion-item>

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -21,6 +21,9 @@ import { Router } from '@vaadin/router';
 
 import { BreakpointValues, largeBreakPoint, xxxLargeBreakPoint } from '../utils/css/breakpoints';
 
+//@ts-ignore
+import style from '../../../styles/layout-defaults.css';
+
 @customElement('app-publish')
 export class AppPublish extends LitElement {
   @internalProperty() errored = false;
@@ -41,7 +44,9 @@ export class AppPublish extends LitElement {
   }
 
   static get styles() {
-    return css`
+    return [
+      style,
+      css`
       .header {
         padding: 1rem 3rem;
       }
@@ -170,7 +175,7 @@ export class AppPublish extends LitElement {
           }
         `
       )}
-    `;
+    `];
   }
 
   async generatePackage(type: platform) {


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The report card was rendering without results, which should never happen.

## Describe the new behavior?
This PR makes the report data mandatory for the report-card component + adds a fallback to grab the last saved results if the component attempts to render without results (which should not happen anymore with this fix, but I wanted a fallback anyways).

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
