### PR TITLE
fix(): non-pwa site does not stall on testing page

### DIFF
--- a/src/script/pages/app-testing.ts
+++ b/src/script/pages/app-testing.ts
@@ -113,6 +113,7 @@ export class AppTesting extends LitElement {
       const siteUrl = search.get('site');
 
       if (TestResult) {
+        console.log('testResult', TestResult);
         // Completes the loading phase
         // set last phrase and give 300ms to display to user
         // before moving on

--- a/src/script/services/tests/index.ts
+++ b/src/script/services/tests/index.ts
@@ -26,6 +26,8 @@ export async function runAllTests(url: string): Promise<AllTestResults> {
       security: await securityTestResult,
     }
 
+    console.log('resultsObject', resultsObject);
+
     setResults(resultsObject);
 
     resolve(resultsObject);

--- a/src/script/services/tests/manifest.ts
+++ b/src/script/services/tests/manifest.ts
@@ -8,21 +8,15 @@ export async function testManifest(
   const manifestData = await fetchManifest(url);
 
   if (manifestData) {
-    console.log('in here 0', manifestData);
     const manifest = manifestData.content;
 
     if (manifest) {
       const testResult = doTest(manifest);
-
-      console.log('in here 0.5', testResult);
-
       return testResult;
     } else {
-      console.log('in here 1');
       throw new Error('Could not test manifest');
     }
   } else {
-    console.log('in here 2');
     throw new Error('Could not get manifest data');
   }
 }

--- a/src/script/services/tests/manifest.ts
+++ b/src/script/services/tests/manifest.ts
@@ -8,16 +8,21 @@ export async function testManifest(
   const manifestData = await fetchManifest(url);
 
   if (manifestData) {
+    console.log('in here 0', manifestData);
     const manifest = manifestData.content;
 
     if (manifest) {
       const testResult = doTest(manifest);
 
+      console.log('in here 0.5', testResult);
+
       return testResult;
     } else {
+      console.log('in here 1');
       throw new Error('Could not test manifest');
     }
   } else {
+    console.log('in here 2');
     throw new Error('Could not get manifest data');
   }
 }

--- a/src/script/services/tests/service-worker.ts
+++ b/src/script/services/tests/service-worker.ts
@@ -37,11 +37,7 @@ export async function testServiceWorker(url: string): Promise<Array<TestResult>>
       }
   ];
 
-  if (swTestResult) {
-    return swTestResult;
-  } else {
-    return null;
-  }
+  return swTestResult;
 }
 
 async function detectServiceWorker(
@@ -84,24 +80,23 @@ async function detectOfflineSupport(url: string): Promise<boolean> {
     `${env.testAPIUrl}/offline/?site=${encodeURIComponent(url)}`
   );
 
-  const fetchResultOrTimeout = await Promise.race([
+  const fetchResultOrTimeout: void | Response = await Promise.race([
     tenSecondTimeout,
     offlineFetch,
   ]);
+
   if (!fetchResultOrTimeout) {
     console.warn('Offline check timed out after 10 seconds.');
-    throw new Error('Offline check timed out after 10 seconds.');
   }
-  if (!fetchResultOrTimeout.ok) {
+  if (fetchResultOrTimeout && !fetchResultOrTimeout.ok) {
     console.warn(
       'Unable to detect offline support.',
       fetchResultOrTimeout.status,
       fetchResultOrTimeout.statusText
     );
-    throw new Error(fetchResultOrTimeout.statusText);
   }
 
-  const jsonResult: OfflineCheckResult = await fetchResultOrTimeout.json();
+  const jsonResult: OfflineCheckResult = await (fetchResultOrTimeout as Response).json();
   console.info('Offline support detection succeeded', jsonResult);
   return jsonResult.data.offline;
 }
@@ -118,10 +113,9 @@ async function detectPeriodicSyncSupport(url: string): Promise<boolean> {
       fetchResult.status,
       fetchResult.statusText
     );
-    throw new Error(fetchResult.statusText);
   }
 
   const periodicSyncResultText = await fetchResult.text();
-  console.info('Periodic sync detection succeeded', periodicSyncResultText);
+  console.info('Periodic sync detection succeeded');
   return periodicSyncResultText === 'true';
 }


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Sites that did not have a service worker were stalling out on the testing page. Turns out this was caused by some pre-mature throwing of errors that was breaking promise chains.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
