### PR TITLE
General fixes and cleanup

### DIFF
--- a/src/script/components/app-header.ts
+++ b/src/script/components/app-header.ts
@@ -144,7 +144,7 @@ export class AppHeader extends LitElement {
 
   render() {
     return html`
-      <header>
+      <header part="header">
         <img id="header-icon" src="/assets/images/header_logo.png" alt="header logo">
 
         <nav id="desktop-nav">

--- a/src/script/components/score-results.ts
+++ b/src/script/components/score-results.ts
@@ -60,7 +60,6 @@ export class ScoreResults extends LitElement {
 
   firstUpdated() {
     this.organizedResults = this.organize();
-    console.log(this.organizedResults);
   }
 
   organize() {

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -20,7 +20,6 @@ import { fetchManifest } from '../services/manifest';
 import '../components/content-header';
 import '../components/resource-hub';
 import '../components/loading-button';
-import '../components/app-modal';
 import '../components/dropdown-menu';
 import '../components/app-sidebar';
 
@@ -375,19 +374,6 @@ export class AppHome extends LitElement {
           >
         </form>
       </content-header>
-
-      <app-modal
-        title="Modal Title"
-        body="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Urna, sit scelerisque vestibulum magnis. Auctor dolor, tincidunt enim."
-        ?open="${true}"
-      >
-
-        <div slot="modal-actions">
-          <app-dropdown .menuItems=${['A', 'B', 'C']}></app-dropdown>
-
-          <app-button>Test Button</app-button>
-        </div>
-      </app-modal>
 
       <resource-hub page="home" all>
         <h2 slot="title">PWABuilder Resource Hub</h2>

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -200,11 +200,6 @@ export class AppPublish extends LitElement {
           const options = createWindowsPackageOptionsFromManifest('anaheim');
 
           this.blob = await generateWindowsPackage('anaheim', options);
-
-          /*await fileSave(this.blob, {
-            fileName: 'your_windows_pwa.zip',
-            extensions: ['.zip'],
-          });*/
         } catch (err) {
           this.showAlertModal(err);
         }
@@ -214,7 +209,7 @@ export class AppPublish extends LitElement {
           // eslint-disable-next-line no-case-declarations
           const androidOptions = createAndroidPackageOptionsFromManifest();
 
-          await generateAndroidPackage(androidOptions);
+          this.blob = await generateAndroidPackage(androidOptions);
         } catch (err) {
           this.showAlertModal(err);
         }

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -10,6 +10,7 @@ import { classMap } from 'lit-html/directives/class-map';
 import '../components/app-header';
 import '../components/app-card';
 import '../components/app-modal';
+import '../components/app-button';
 import {
   createWindowsPackageOptionsFromManifest,
   generateWindowsPackage,

--- a/src/script/pages/app-testing.ts
+++ b/src/script/pages/app-testing.ts
@@ -149,8 +149,8 @@ export class AppTesting extends LitElement {
   async runTests(site: string) {
     try {
       const TestResult = await runAllTests(site);
-      // const search = new URLSearchParams(location.search);
-      // const siteUrl = search.get('site');
+      const search = new URLSearchParams(location.search);
+      const siteUrl = search.get('site');
 
       if (TestResult) {
         console.log('testResult', TestResult);
@@ -161,7 +161,7 @@ export class AppTesting extends LitElement {
 
         this.currentPhrase = 'Results coming to you in 3..2..1..';
         setTimeout(() => {
-          //  Router.go(`/reportcard?site=${siteUrl}&results=${JSON.stringify(TestResult)}`);
+          Router.go(`/reportcard?site=${siteUrl}&results=${JSON.stringify(TestResult)}`);
         }, 300);
       } else {
         this.loading = false;

--- a/src/script/pages/app-testing.ts
+++ b/src/script/pages/app-testing.ts
@@ -17,6 +17,7 @@ import '../components/app-header';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //@ts-ignore
 import style from '../../../styles/animations.css';
+import { loadPaintPolyfillIfNeeded } from '../polyfills/css-paint';
 
 @customElement('app-testing')
 export class AppTesting extends LitElement {
@@ -31,9 +32,15 @@ export class AppTesting extends LitElement {
         :host {
           display: flex;
           flex-direction: column;
-          background: url(/assets/images/background-copy.webp);
+
           height: 100vh;
           overflow: hidden;
+
+          display: block;
+          background: url(/assets/images/glass.jpg);
+          background-size: cover;
+          background-repeat: no-repeat;
+          background-position: right;
         }
 
         #testing-container {
@@ -41,16 +48,37 @@ export class AppTesting extends LitElement {
           display: flex;
           flex-direction: column;
           align-items: center;
-          justify-content: center;
 
           text-align: center;
           font-size: var(--large-font-size);
 
           animation: 160ms fadeIn linear;
+
+          padding-top: 2em;
+          height: 91vh;
+          width: 100%;
+          background: linear-gradient( 
+      106.57deg
+      , rgba(255, 255, 255, 0.616) 0%, rgba(255, 255, 255, 0.098) 100% );
+          backdrop-filter: blur(40px);
+        }
+
+        #glass {
+          --colors: #888094, #5a5ab7, #d9a0f7, #5d2863, #5b5bb9;
+          --min-radius: 30;
+          --max-radius: 100;
+          --num-circles: 15;
+          --min-opacity: 10;
+          --max-opacity: 50;
+          background-image: paint(circles);
+
+          height: 82%;
         }
 
         #testing-container img {
           width: 466px;
+
+          padding-top: 2em;
         }
 
         #testing-container fast-progress {
@@ -69,6 +97,15 @@ export class AppTesting extends LitElement {
           font-weight: var(--font-bold);
           font-size: var(--large-font-size);
           margin-top: 12px;
+        }
+
+        app-header::part(header) {
+          background: transparent;
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          z-index: 2;
         }
 
         @keyframes fadeIn {
@@ -104,13 +141,16 @@ export class AppTesting extends LitElement {
 
       await this.runTests(site);
     }
+
+    await loadPaintPolyfillIfNeeded();
+    (CSS as any).paintWorklet.addModule('/workers/header-paint.js');
   }
 
   async runTests(site: string) {
     try {
       const TestResult = await runAllTests(site);
-      const search = new URLSearchParams(location.search);
-      const siteUrl = search.get('site');
+      // const search = new URLSearchParams(location.search);
+      // const siteUrl = search.get('site');
 
       if (TestResult) {
         console.log('testResult', TestResult);
@@ -121,7 +161,7 @@ export class AppTesting extends LitElement {
 
         this.currentPhrase = 'Results coming to you in 3..2..1..';
         setTimeout(() => {
-          Router.go(`/reportcard?site=${siteUrl}&results=${JSON.stringify(TestResult)}`);
+          //  Router.go(`/reportcard?site=${siteUrl}&results=${JSON.stringify(TestResult)}`);
         }, 300);
       } else {
         this.loading = false;
@@ -158,12 +198,17 @@ export class AppTesting extends LitElement {
 
   render() {
     return html` <app-header></app-header>
-      <div id="testing-container">
-        <img alt="PWABUilder Logo" src="/assets/images/full_header_logo.png" />
+      <div id="glass">
+        <div id="testing-container">
+          <img
+            alt="PWABUilder Logo"
+            src="/assets/images/full_header_logo.png"
+          />
 
-        <span>${this.currentPhrase}</span>
+          <span>${this.currentPhrase}</span>
 
-        ${this.loading ? html`<fast-progress></fast-progress>` : null}
+          ${this.loading ? html`<fast-progress></fast-progress>` : null}
+        </div>
       </div>`;
   }
 }

--- a/src/script/services/manifest.ts
+++ b/src/script/services/manifest.ts
@@ -104,6 +104,7 @@ async function getManifestViaHtmlParse(url: string): Promise<ManifestDetectionRe
       short_name: responseData.manifestContents.short_name || '',
     },
     id: '',
+    generated: responseData.manifestContents ? false : true,
     errors: [],
     suggestions: [],
     warnings: [],

--- a/src/script/services/tests/manifest.ts
+++ b/src/script/services/tests/manifest.ts
@@ -1,14 +1,90 @@
-import { Manifest, TestResult } from '../../utils/interfaces';
+import { ManifestDetectionResult, TestResult } from '../../utils/interfaces';
 import { fetchManifest } from '../manifest';
+
+const default_results = [
+  {
+    infoString: 'Web Manifest Properly Attached',
+    result: false,
+    category: "required"
+  },
+  {
+    infoString: 'Lists icons for add to home screen',
+    result: false,
+    category: "required"
+  },
+  {
+    infoString: 'Contains name property',
+    result: false,
+    category: "required"
+  },
+  {
+    infoString: 'Contains short_name property',
+    result:
+      false,
+      category: "required"
+  },
+  {
+    infoString: 'Designates a start_url',
+    result:
+      false,
+      category: "required"
+  },
+  {
+    infoString: 'Specifies a display mode',
+    result: false,
+    category: "recommended"
+  },
+  {
+    infoString: 'Has a background color',
+    result: false,
+    category: "recommended"
+  },
+  {
+    infoString: 'Has a theme color',
+    result: false,
+    category: "recommended"
+  },
+  {
+    infoString: 'Specifies an orientation mode',
+    result: false,
+    category: "recommended"
+  },
+  {
+    infoString: 'Contains screenshots for app store listings',
+    result: false,
+    category: "recommended"
+  },
+  { infoString: 'Has a square PNG icon 512x512 or larger', result: false, category: "required" },
+  { infoString: 'Has a maskable PNG icon', result: false, category: "recommended" },
+  {
+    infoString: 'Lists shortcuts for quick access',
+    result: false,
+    category: "recommended"
+  },
+  {
+    infoString: 'Contains categories to classify the app',
+    result: false,
+    category: "recommended"
+  },
+  {
+    infoString: 'Contains an IARC ID',
+    result: false,
+    category: "optional"
+  },
+  {
+    infoString: 'Specifies related_application',
+    result: false,
+    category: "optional"
+  },
+]
 
 export async function testManifest(
   url: string
-): Promise<Array<TestResult>> {
-  console.info('Testing Manifest');
+): Promise<Array<TestResult> | boolean> {
   const manifestData = await fetchManifest(url);
 
   if (manifestData) {
-    const manifest = manifestData.content;
+    const manifest = manifestData;
 
     if (manifest) {
       const testResult = doTest(manifest);
@@ -21,104 +97,109 @@ export async function testManifest(
   }
 }
 
-function doTest(manifest: Manifest): Array<TestResult> {
-  return [
-    {
-      infoString: 'Web Manifest Properly Attached',
-      result: true,
-      category: "required"
-    },
-    {
-      infoString: 'Lists icons for add to home screen',
-      result: manifest.icons && manifest.icons.length > 0 ? true : false,
-      category: "required"
-    },
-    {
-      infoString: 'Contains name property',
-      result: manifest.name && manifest.name.length > 1 ? true : false,
-      category: "required"
-    },
-    {
-      infoString: 'Contains short_name property',
-      result:
-        manifest.short_name && manifest.short_name.length > 1 ? true : false,
+function doTest(manifest: ManifestDetectionResult): Array<TestResult> | boolean {
+  if (manifest.generated && manifest.generated === true) {
+    return default_results;
+  }
+  else {
+    return [
+      {
+        infoString: 'Web Manifest Properly Attached',
+        result: true,
         category: "required"
-    },
-    {
-      infoString: 'Designates a start_url',
-      result:
-        manifest.start_url && manifest.start_url.length > 0 ? true : false,
+      },
+      {
+        infoString: 'Lists icons for add to home screen',
+        result: manifest.content.icons && manifest.content.icons.length > 0 ? true : false,
         category: "required"
-    },
-    {
-      infoString: 'Specifies a display mode',
-      result:
-        manifest.display &&
-        ['fullscreen', 'standalone', 'minimal-ui', 'browser'].includes(
-          manifest.display
-        )
-          ? true
-          : false,
-      category: "recommended"
-    },
-    {
-      infoString: 'Has a background color',
-      result: manifest.background_color ? true : false,
-      category: "recommended"
-    },
-    {
-      infoString: 'Has a theme color',
-      result: manifest.theme_color ? true : false,
-      category: "recommended"
-    },
-    {
-      infoString: 'Specifies an orientation mode',
-      result:
-        manifest.orientation && isStandardOrientation(manifest.orientation)
-          ? true
-          : false,
-      category: "recommended"
-    },
-    {
-      infoString: 'Contains screenshots for app store listings',
-      result:
-        manifest.screenshots && manifest.screenshots.length > 0 ? true : false,
-      category: "recommended"
-    },
-    { infoString: 'Has a square PNG icon 512x512 or larger', result: true, category: "required" },
-    { infoString: 'Has a maskable PNG icon', result: true, category: "recommended" },
-    {
-      infoString: 'Lists shortcuts for quick access',
-      result:
-        manifest.shortcuts && manifest.shortcuts.length > 0 ? true : false,
+      },
+      {
+        infoString: 'Contains name property',
+        result: manifest.content.name && manifest.content.name.length > 1 ? true : false,
+        category: "required"
+      },
+      {
+        infoString: 'Contains short_name property',
+        result:
+          manifest.content.short_name && manifest.content.short_name.length > 1 ? true : false,
+          category: "required"
+      },
+      {
+        infoString: 'Designates a start_url',
+        result:
+          manifest.content.start_url && manifest.content.start_url.length > 0 ? true : false,
+          category: "required"
+      },
+      {
+        infoString: 'Specifies a display mode',
+        result:
+          manifest.content.display &&
+          ['fullscreen', 'standalone', 'minimal-ui', 'browser'].includes(
+            manifest.content.display
+          )
+            ? true
+            : false,
         category: "recommended"
-    },
-    {
-      infoString: 'Contains categories to classify the app',
-      result:
-        manifest.categories &&
-        manifest.categories.length > 0 &&
-        containsStandardCategory(manifest.categories)
-          ? true
-          : false,
+      },
+      {
+        infoString: 'Has a background color',
+        result: manifest.content.background_color ? true : false,
+        category: "recommended"
+      },
+      {
+        infoString: 'Has a theme color',
+        result: manifest.content.theme_color ? true : false,
+        category: "recommended"
+      },
+      {
+        infoString: 'Specifies an orientation mode',
+        result:
+          manifest.content.orientation && isStandardOrientation(manifest.content.orientation)
+            ? true
+            : false,
+        category: "recommended"
+      },
+      {
+        infoString: 'Contains screenshots for app store listings',
+        result:
+          manifest.content.screenshots && manifest.content.screenshots.length > 0 ? true : false,
+        category: "recommended"
+      },
+      { infoString: 'Has a square PNG icon 512x512 or larger', result: true, category: "required" },
+      { infoString: 'Has a maskable PNG icon', result: true, category: "recommended" },
+      {
+        infoString: 'Lists shortcuts for quick access',
+        result:
+          manifest.content.shortcuts && manifest.content.shortcuts.length > 0 ? true : false,
           category: "recommended"
-    },
-    {
-      infoString: 'Contains an IARC ID',
-      result: manifest.iarc_rating_id ? true : false,
-      category: "optional"
-    },
-    {
-      infoString: 'Specifies related_application',
-      result:
-        manifest.related_applications &&
-        manifest.related_applications.length > 0 &&
-        manifest.prefer_related_applications !== undefined
-          ? true
-          : false,
-          category: "optional"
-    },
-  ];
+      },
+      {
+        infoString: 'Contains categories to classify the app',
+        result:
+          manifest.content.categories &&
+          manifest.content.categories.length > 0 &&
+          containsStandardCategory(manifest.content.categories)
+            ? true
+            : false,
+            category: "recommended"
+      },
+      {
+        infoString: 'Contains an IARC ID',
+        result: manifest.content.iarc_rating_id ? true : false,
+        category: "optional"
+      },
+      {
+        infoString: 'Specifies related_application',
+        result:
+          manifest.content.related_applications &&
+          manifest.content.related_applications.length > 0 &&
+          manifest.content.prefer_related_applications !== undefined
+            ? true
+            : false,
+            category: "optional"
+      },
+    ];
+  }
 }
 
 function containsStandardCategory(categories: string[]): boolean {

--- a/src/script/utils/interfaces.ts
+++ b/src/script/utils/interfaces.ts
@@ -88,6 +88,7 @@ export interface ManifestDetectionResult {
     short_name: string;
   };
   id: string;
+  generated: boolean;
   errors: [];
   suggestions: [];
   warnings: [];


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the new behavior?
This PR does the following small fixes / tweaks / cleanup chores:
- removes the testing modal that was on the home page. This was there originally as an example of how to use the component, but is not needed now.
- Sites with no manifest are now scored correctly. We were scoring based off the manifest we generated for a site instead of the actual manifest or lack of manifest.
- Correct URL is used for publishing + download is now a separate button (which we had already discussed in design syncs) which fixes an issue where the file access API can only be used from a user gesture. This also required some minor refactoring to the Windows and Android generation logic.
- Added a missing import
- The testing page now has the latest updated background, just like the content-header component. This background can be probably be refactored into a standalone component in the future, but its such a tiny bit of code that is only used in two places that I did not split it out yet.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
