### PR TITLE
feat(): header img goes back + header border to match design

### DIFF
--- a/src/script/components/app-header.ts
+++ b/src/script/components/app-header.ts
@@ -16,6 +16,7 @@ export class AppHeader extends LitElement {
     return css`
       :host {
         --header-background: transparent;
+        --header-border: rgba(0, 0, 0, 0.25) solid 1px;
       }
 
       header {
@@ -28,7 +29,7 @@ export class AppHeader extends LitElement {
         color: white;
         height: 71px;
 
-        border-bottom: rgba(0, 0, 0, 0.25) solid 1px;
+        border-bottom: var(--header-border);
       }
 
       header img {

--- a/src/script/components/app-header.ts
+++ b/src/script/components/app-header.ts
@@ -27,6 +27,12 @@ export class AppHeader extends LitElement {
         background: var(--header-background);
         color: white;
         height: 71px;
+
+        border-bottom: rgba(0, 0, 0, 0.25) solid 1px;
+      }
+
+      header img {
+        cursor: pointer;
       }
 
       header h1 {
@@ -142,10 +148,14 @@ export class AppHeader extends LitElement {
     super();
   }
 
+  goBack() {
+    window.history.back();
+  }
+
   render() {
     return html`
-      <header>
-        <img id="header-icon" src="/assets/images/header_logo.png" alt="header logo">
+      <header part="header">
+        <img @click="${() => this.goBack()}" id="header-icon" src="/assets/images/header_logo.png" alt="header logo">
 
         <nav id="desktop-nav">
           <fast-anchor appearance="hypertext" href="./about">Resources</fast-anchor>

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -52,6 +52,10 @@ export class AppHome extends LitElement {
           padding-top: 0;
         }
 
+        content-header::part(header) {
+          --header-border: none;
+        }
+
         h2 {
           font-size: var(--xlarge-font-size);
           line-height: 46px;

--- a/src/script/pages/app-testing.ts
+++ b/src/script/pages/app-testing.ts
@@ -65,6 +65,16 @@ export class AppTesting extends LitElement {
           border-radius: 0;
         }
 
+        app-header::part(header) {
+          background: transparent;
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          z-index: 2;
+          border: none;
+        }
+
         #testing-container span {
           font-weight: var(--font-bold);
           font-size: var(--large-font-size);


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the new behavior?
This PR adds the following:
- the icon in the header acts as a back button just like on the current production site
- Added a bottom border to the header to match the latest design
- Dont show border on the header on the testing page

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
