### PR TITLE
URL resolution for Android platform

### DIFF
--- a/src/script/services/publish/android-publish.ts
+++ b/src/script/services/publish/android-publish.ts
@@ -178,7 +178,7 @@ export function createAndroidPackageOptionsFromManifest(): AndroidApkOptions {
     themeColor: manifest.theme_color || '#FFFFFF',
     shareTarget: manifest.share_target,
     webManifestUrl: maniURL,
-  };    
+  };
 }
 
 /**


### PR DESCRIPTION
Fixes Android platform download by resolving relative URLs.

In the old site, these URLs were absolute-ified inside the state manager after fetching the manifest.