### PR TITLE
V3 - complete page use resource hub.

### DIFF
--- a/src/script/components/app-card.ts
+++ b/src/script/components/app-card.ts
@@ -37,8 +37,9 @@ export class AppCard extends LitElement {
       // host
       css`
         :host {
+          background: transparent;
           display: flex;
-          color: white;
+          color: var(--primary-color);
           justify-content: center;
           border-radius: 4px;
         }
@@ -393,15 +394,8 @@ export class AppCard extends LitElement {
       `,
       // content card
       css`
-        :host {
-          background: white;
-          display: flex;
-          color: var(--primary-color);
-          justify-content: center;
-        }
-
         fast-card.content-card {
-          background-color: white;
+          background-color: var(--primary-background-color);
           padding: 1rem 0;
           width: 100%;
           max-width: 1024px;

--- a/src/script/components/app-card.ts
+++ b/src/script/components/app-card.ts
@@ -469,7 +469,7 @@ export class AppCard extends LitElement {
 
   renderDefault() {
     return html`
-      <fast-card class="default" part="card">
+      <fast-card class=${this.cardClasses()} part="card">
         <div class="img-overlay ${this.imageClasses()}">
           <slot name="overlay"></slot>
         </div>
@@ -496,7 +496,7 @@ export class AppCard extends LitElement {
     // Featured Card Html
     if (this.featured && window.innerWidth > BreakpointValues.mediumUpper) {
       return html`
-        <fast-card class="blog featured" part="card">
+        <fast-card class=${this.cardClasses()} part="card">
           <div class="img-overlay">
             <div class="overlay-top">
               <span class="date">${this.date}</span>
@@ -517,7 +517,7 @@ export class AppCard extends LitElement {
     }
 
     return html`
-      <fast-card class="blog" part="card">
+      <fast-card class=${this.cardClasses()} part="card">
         <div class="img-overlay">
           <div class="overlay-top">
             <span class="date">${this.date}</span>
@@ -536,7 +536,7 @@ export class AppCard extends LitElement {
 
   renderMicroCard() {
     return html`
-      <fast-card class="micro" part="card" @click=${this.route}>
+      <fast-card class=${this.cardClasses()} part="card" @click=${this.route}>
         <img src="${this.imageUrl}" alt="${this.cardTitle} card header image" />
         <div class="content">
           <h3>${this.cardTitle}</h3>
@@ -547,11 +547,7 @@ export class AppCard extends LitElement {
 
   renderMicroDescriptionCard() {
     return html`
-      <fast-card
-        class="micro micro-description"
-        part="card"
-        @click=${this.route}
-      >
+      <fast-card class=${this.cardClasses()} part="card" @click=${this.route}>
         <img src="${this.imageUrl}" alt="${this.cardTitle} card header image" />
         <div class="content">
           <h3>${this.cardTitle}</h3>
@@ -562,7 +558,7 @@ export class AppCard extends LitElement {
   }
 
   renderContentCard() {
-    return html` <fast-card class="content-card" part="card">
+    return html` <fast-card class=${this.cardClasses()} part="card">
       <div class="header">
         <h3>${this.cardTitle}</h3>
         <p>${this.description}</p>
@@ -590,6 +586,21 @@ export class AppCard extends LitElement {
 
   share() {
     console.log('share');
+  }
+
+  cardClasses() {
+    return classMap({
+      featured: this.featured || this.className.includes('featured'),
+      [AppCardModes.default]: this.className.includes(AppCardModes.default),
+      [AppCardModes.blog]: this.className.includes(AppCardModes.blog),
+      [AppCardModes.micro]: this.className.includes(AppCardModes.micro),
+      [AppCardModes.microDescription]: this.className.includes(
+        AppCardModes.microDescription
+      ),
+      [AppCardModes.contentCard]: this.className.includes(
+        AppCardModes.contentCard
+      ),
+    });
   }
 
   imageClasses() {

--- a/src/script/components/app-card.ts
+++ b/src/script/components/app-card.ts
@@ -18,8 +18,6 @@ export enum AppCardModes {
 
 @customElement('app-card')
 export class AppCard extends LitElement {
-  @property({ type: String }) mode = AppCardModes.default;
-
   @property({ attribute: 'bordered', type: Boolean })
   imageBordered = false;
   @property({ type: String }) imageUrl: string | undefined;
@@ -454,19 +452,19 @@ export class AppCard extends LitElement {
   }
 
   render() {
-    switch (this.mode) {
-      case AppCardModes.blog:
-        return this.renderBlogCard();
-      case AppCardModes.micro:
-        return this.renderMicroCard();
-      case AppCardModes.microDescription:
-        return this.renderMicroDescriptionCard();
-      case AppCardModes.contentCard:
-        return this.renderContentCard();
-      case AppCardModes.default:
-      default:
-        return this.renderDefault();
+    const className = this.className;
+
+    if (className.includes(AppCardModes.blog)) {
+      return this.renderBlogCard();
+    } else if (className.includes(AppCardModes.micro)) {
+      return this.renderMicroCard();
+    } else if (className.includes(AppCardModes.microDescription)) {
+      return this.renderMicroDescriptionCard();
+    } else if (className.includes(AppCardModes.contentCard)) {
+      return this.renderContentCard();
     }
+
+    return this.renderDefault();
   }
 
   renderDefault() {

--- a/src/script/components/blog-showcase.ts
+++ b/src/script/components/blog-showcase.ts
@@ -197,7 +197,7 @@ export class ResourceHub extends LitElement {
             blog: true,
             featured,
           })}
-          title=${post.title}
+          cardTitle=${post.title}
           description=${post.description}
           date=${post.date}
           imageUrl=${post.imageUrl}

--- a/src/script/components/blog-showcase.ts
+++ b/src/script/components/blog-showcase.ts
@@ -202,7 +202,6 @@ export class ResourceHub extends LitElement {
           date=${post.date}
           imageUrl=${post.imageUrl}
           linkRoute=${post.clickUrl}
-          mode="blog"
           shareLink
           .tags=${post.tags}
           .featured=${featured}

--- a/src/script/components/resource-hub.ts
+++ b/src/script/components/resource-hub.ts
@@ -69,6 +69,10 @@ export class ResourceHub extends LitElement {
           padding-right: 4em;
         }
 
+        .complete .resource-header {
+          padding-top: 0;
+        }
+
         .cards {
           display: flex;
           justify-content: center;

--- a/src/script/components/resource-hub.ts
+++ b/src/script/components/resource-hub.ts
@@ -11,7 +11,7 @@ import {
 import { AppCardModes } from '../components/app-card';
 import '../components/app-button';
 
-type ResourceHubPages = 'home' | 'publish';
+type ResourceHubPages = 'home' | 'complete';
 
 @customElement('resource-hub')
 export class ResourceHub extends LitElement {
@@ -20,173 +20,176 @@ export class ResourceHub extends LitElement {
     'home';
 
   static get styles() {
-    return css`
-      :host {
-        background: var(--primary-color);
-        display: flex;
-        color: white;
-        justify-content: center;
-      }
+    return [
+      css`
+        :host {
+          background: var(--primary-color);
+          display: flex;
+          color: white;
+          justify-content: center;
+        }
 
-      ::slotted([slot='title']) {
-        margin: 0;
-        font-weight: var(--font-bold);
-        text-align: center;
+        ::slotted([slot='title']) {
+          margin: 0;
+          font-weight: var(--font-bold);
+          text-align: center;
 
-        font-size: 36px;
-        line-height: 39px;
-        letter-spacing: -0.015em;
-        margin-top: 0;
-      }
+          font-size: 36px;
+          line-height: 39px;
+          letter-spacing: -0.015em;
+          margin-top: 0;
+        }
 
-      ::slotted([slot='description']) {
-        font-weight: var(--font-bold);
-        max-width: 950px;
-        text-align: center;
-      }
+        ::slotted([slot='description']) {
+          font-weight: var(--font-bold);
+          max-width: 950px;
+          text-align: center;
+        }
+      `,
+      css`
+        .resource-header {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          padding-top: 80px;
+          padding-left: 4em;
+          padding-right: 4em;
+        }
 
-      #resource-header {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        padding-top: 80px;
-        padding-left: 4em;
-        padding-right: 4em;
-      }
+        .cards {
+          display: flex;
+          justify-content: center;
+          padding-left: 4em;
+          padding-right: 4em;
+          margin-top: 1em;
+          padding: 0 16px;
+        }
 
-      #cards {
-        display: flex;
-        justify-content: center;
-        padding-left: 4em;
-        padding-right: 4em;
-        margin-top: 1em;
-        padding: 0 16px;
-      }
+        .cards app-card {
+          margin: 8px;
+        }
 
-      #cards app-card {
-        margin: 8px;
-      }
+        .cards app-card::part(card) {
+          margin: 0;
+        }
 
-      #cards app-card::part(card) {
-        margin: 0;
-      }
+        .resource-hub-actions {
+          display: flex;
+          align-items: center;
+          justify-content: center;
 
-      #resource-hub-actions {
-        display: flex;
-        align-items: center;
-        justify-content: center;
+          margin-top: 32px;
+          margin-bottom: 74px;
+        }
 
-        margin-top: 32px;
-        margin-bottom: 74px;
-      }
+        .resource-hub-actions app-button::part(underlying-button) {
+          background-color: white;
+          color: var(--font-color);
+        }
 
-      #resource-hub-actions app-button::part(underlying-button) {
-        background-color: white;
-        color: var(--font-color);
-      }
+        .resource-hub-actions app-button::part(control) {
+          font-size: 16px;
+          font-weight: var(--font-bold);
+        }
 
-      #resource-hub-actions app-button::part(control) {
-        font-size: 16px;
-        font-weight: var(--font-bold);
-      }
+        ${smallBreakPoint(
+          css`
+            :host {
+              background-color: #ededed;
+            }
 
-      ${smallBreakPoint(
-        css`
-          :host {
-            background-color: #ededed;
-          }
+            ::slotted([slot='title']),
+            ::slotted([slot='description']) {
+              color: var(--font-color);
+            }
 
-          ::slotted([slot='title']),
-          ::slotted([slot='description']) {
-            color: var(--font-color);
-          }
+            /* TODO make this gated to only a gallery variant */
+            .cards.horizontal {
+              overflow-y: scroll;
+              overflow-x: none;
+              /* white-space: nowrap; */
 
-          /* TODO make this gated to only a gallery variant */
-          #cards.horizontal {
-            overflow-y: scroll;
-            overflow-x: none;
-            /* white-space: nowrap; */
+              flex-direction: row;
+              align-items: center;
+            }
 
-            flex-direction: row;
-            align-items: center;
-          }
+            #card.horizontal app-card {
+              display: inline-block;
+              min-width: calc(100% - 32px);
+            }
 
-          #card.horizontal app-card {
-            display: inline-block;
-            min-width: calc(100% - 32px);
-          }
+            section {
+              width: 100%;
+            }
 
-          section {
-            width: 100%;
-          }
+            .cards.horizontal {
+              display: flex;
+              flex-direction: column;
+              overflow-x: scroll;
+              scroll-snap-type: x proximity;
+            }
 
-          #cards.horizontal {
-            display: flex;
-            flex-direction: column;
-            overflow-x: scroll;
-            scroll-snap-type: x proximity;
-          }
+            .cards.horizontal app-card {
+              display: inline-block;
+              flex: 0 0 auto;
+              scroll-snap-align: center;
+            }
 
-          #cards.horizontal app-card {
-            display: inline-block;
-            flex: 0 0 auto;
-            scroll-snap-align: center;
-          }
+            .cards.horizontal app-card p,
+            .cards.horizontal app-card h3 {
+              white-space: normal;
+            }
+          `
+        )}
 
-          #cards.horizontal app-card p,
-          #cards.horizontal app-card h3 {
-            white-space: normal;
-          }
-        `
-      )}
+        ${mediumBreakPoint(
+          css`
+            .cards {
+              flex-direction: column;
+              align-items: center;
+            }
+
+            .cards app-card {
+              margin-bottom: 16px;
+            }
+          `,
+          'no-lower'
+        )}
 
       ${mediumBreakPoint(
-        css`
-          #cards {
-            flex-direction: column;
-            align-items: center;
-          }
-
-          #cards app-card {
-            margin-bottom: 16px;
-          }
-        `,
-        'no-lower'
-      )}
-
-      ${mediumBreakPoint(
-        css`
-          #cards {
-            padding: 0 32px;
-          }
-        `
-      )}
+          css`
+            .cards {
+              padding: 0 32px;
+            }
+          `
+        )}
 
       ${largeBreakPoint(
-        css`
-          #cards app-card {
-            max-width: 350px;
-          }
-        `,
-        'no-lower'
-      )}
+          css`
+            .cards app-card {
+              max-width: 350px;
+            }
+          `,
+          'no-lower'
+        )}
 
       ${largeBreakPoint(
-        css`
-          #cards {
-            flex-direction: row;
-            flex-wrap: wrap;
-            align-items: center;
-            padding: 0;
-          }
+          css`
+            .cards {
+              flex-direction: row;
+              flex-wrap: wrap;
+              align-items: center;
+              padding: 0;
+            }
 
-          #cards app-card {
-            margin-bottom: 16px;
-          }
-        `
-      )}
-    `;
+            .cards app-card {
+              margin-bottom: 16px;
+            }
+          `
+        )}
+      `,
+    ];
   }
 
   constructor() {
@@ -195,13 +198,15 @@ export class ResourceHub extends LitElement {
 
   render() {
     return html`
-      <section>
-        <div id="resource-header">
+      <section class=${this.resourceHubClassMap()}>
+        <div class="resource-header">
           <slot name="title"></slot>
           <slot name="description"></slot>
         </div>
 
-        <div id="cards" class=${this.cardsClasses()}>${this.renderCards()}</div>
+        <div class="cards" class=${this.cardsClasses()}>
+          ${this.renderCards()}
+        </div>
 
         ${this.renderViewAllButton()}
       </section>
@@ -213,7 +218,7 @@ export class ResourceHub extends LitElement {
     let cardList: Array<CardData> = [];
     if (this.pageName === 'home') {
       cardList = landingCards();
-    } else if (this.pageName === 'publish') {
+    } else if (this.pageName === 'complete') {
       cardList = publishCards();
     }
 
@@ -233,7 +238,7 @@ export class ResourceHub extends LitElement {
   renderViewAllButton() {
     if (this.showViewAllButton) {
       return html`
-        <div id="resource-hub-actions">
+        <div class="resource-hub-actions">
           <app-button>View all resources</app-button>
         </div>
       `;
@@ -245,19 +250,26 @@ export class ResourceHub extends LitElement {
   cardsClasses() {
     return classMap({
       horizontal:
-        this.pageName === 'publish' &&
+        this.pageName === 'complete' &&
         window.innerWidth <= BreakpointValues.smallUpper,
     });
   }
 
   determineCardMode(): AppCardModes {
     if (
-      this.pageName === 'publish' &&
+      this.pageName === 'complete' &&
       window.innerWidth <= BreakpointValues.smallUpper
     ) {
       return AppCardModes.micro;
     }
 
     return AppCardModes.default;
+  }
+
+  resourceHubClassMap() {
+    return classMap({
+      'resource-hub': true,
+      'complete': this.pageName === 'complete',
+    });
   }
 }

--- a/src/script/components/resource-hub.ts
+++ b/src/script/components/resource-hub.ts
@@ -92,103 +92,98 @@ export class ResourceHub extends LitElement {
           font-size: 16px;
           font-weight: var(--font-bold);
         }
-
-        ${smallBreakPoint(
-          css`
-            :host {
-              background-color: #ededed;
-            }
-
-            ::slotted([slot='title']),
-            ::slotted([slot='description']) {
-              color: var(--font-color);
-            }
-
-            /* TODO make this gated to only a gallery variant */
-            .cards.horizontal {
-              overflow-y: scroll;
-              overflow-x: none;
-              /* white-space: nowrap; */
-
-              flex-direction: row;
-              align-items: center;
-            }
-
-            #card.horizontal app-card {
-              display: inline-block;
-              min-width: calc(100% - 32px);
-            }
-
-            section {
-              width: 100%;
-            }
-
-            .cards.horizontal {
-              display: flex;
-              flex-direction: column;
-              overflow-x: scroll;
-              scroll-snap-type: x proximity;
-            }
-
-            .cards.horizontal app-card {
-              display: inline-block;
-              flex: 0 0 auto;
-              scroll-snap-align: center;
-            }
-
-            .cards.horizontal app-card p,
-            .cards.horizontal app-card h3 {
-              white-space: normal;
-            }
-          `
-        )}
-
-        ${mediumBreakPoint(
-          css`
-            .cards {
-              flex-direction: column;
-              align-items: center;
-            }
-
-            .cards app-card {
-              margin-bottom: 16px;
-            }
-          `,
-          'no-lower'
-        )}
-
-      ${mediumBreakPoint(
-          css`
-            .cards {
-              padding: 0 32px;
-            }
-          `
-        )}
-
-      ${largeBreakPoint(
-          css`
-            .cards app-card {
-              max-width: 350px;
-            }
-          `,
-          'no-lower'
-        )}
-
-      ${largeBreakPoint(
-          css`
-            .cards {
-              flex-direction: row;
-              flex-wrap: wrap;
-              align-items: center;
-              padding: 0;
-            }
-
-            .cards app-card {
-              margin-bottom: 16px;
-            }
-          `
-        )}
       `,
+      smallBreakPoint(
+        css`
+          :host {
+            background-color: #ededed;
+          }
+
+          ::slotted([slot='title']),
+          ::slotted([slot='description']) {
+            color: var(--font-color);
+          }
+
+          /* TODO make this gated to only a gallery variant */
+          .cards.horizontal {
+            overflow-y: scroll;
+            overflow-x: none;
+            /* white-space: nowrap; */
+
+            flex-direction: row;
+            align-items: center;
+          }
+
+          .cards.horizontal app-card {
+            display: inline-block;
+            min-width: calc(100% - 32px);
+          }
+
+          section {
+            width: 100%;
+          }
+
+          .cards.horizontal {
+            display: flex;
+            flex-direction: column;
+            overflow-x: scroll;
+            scroll-snap-type: x proximity;
+          }
+
+          .cards.horizontal app-card {
+            display: inline-block;
+            flex: 0 0 auto;
+            scroll-snap-align: center;
+          }
+
+          .cards.horizontal app-card p,
+          .cards.horizontal app-card h3 {
+            white-space: normal;
+          }
+        `
+      ),
+      mediumBreakPoint(
+        css`
+          .cards {
+            flex-direction: column;
+            align-items: center;
+          }
+
+          .cards app-card {
+            margin-bottom: 16px;
+          }
+        `,
+        'no-lower'
+      ),
+      mediumBreakPoint(
+        css`
+          .cards {
+            padding: 0 32px;
+          }
+        `
+      ),
+      largeBreakPoint(
+        css`
+          .cards app-card {
+            max-width: 350px;
+          }
+        `,
+        'no-lower'
+      ),
+      largeBreakPoint(
+        css`
+          .cards {
+            flex-direction: row;
+            flex-wrap: wrap;
+            align-items: center;
+            padding: 0;
+          }
+
+          .cards app-card {
+            margin-bottom: 16px;
+          }
+        `
+      ),
     ];
   }
 

--- a/src/script/components/resource-hub.ts
+++ b/src/script/components/resource-hub.ts
@@ -23,9 +23,7 @@ export class ResourceHub extends LitElement {
     return [
       css`
         :host {
-          background: var(--primary-color);
           display: flex;
-          color: white;
           justify-content: center;
         }
 
@@ -44,6 +42,16 @@ export class ResourceHub extends LitElement {
           font-weight: var(--font-bold);
           max-width: 950px;
           text-align: center;
+        }
+
+        .home {
+          background: var(--primary-color);
+          color: var(--secondary-color);
+        }
+
+        .complete {
+          background-color: var(--primary-background-color);
+          color: var(--font-color);
         }
       `,
       css`
@@ -220,10 +228,10 @@ export class ResourceHub extends LitElement {
     return cardList.map(data => {
       return html`
         <app-card
-          title=${data.title}
+          class=${mode}
+          cardTitle=${data.title}
           description=${data.description}
           imageUrl=${data.imageUrl}
-          mode=${mode}
         >
         </app-card>
       `;
@@ -264,6 +272,7 @@ export class ResourceHub extends LitElement {
   resourceHubClassMap() {
     return classMap({
       'resource-hub': true,
+      'home': this.pageName === 'home',
       'complete': this.pageName === 'complete',
     });
   }

--- a/src/script/components/resource-hub.ts
+++ b/src/script/components/resource-hub.ts
@@ -53,6 +53,10 @@ export class ResourceHub extends LitElement {
           background-color: var(--primary-background-color);
           color: var(--font-color);
         }
+
+        .resource-hub {
+          width: 100%;
+        }
       `,
       css`
         .resource-header {
@@ -207,9 +211,7 @@ export class ResourceHub extends LitElement {
           <slot name="description"></slot>
         </div>
 
-        <div class="cards" class=${this.cardsClasses()}>
-          ${this.renderCards()}
-        </div>
+        <div class=${this.cardsClasses()}>${this.renderCards()}</div>
 
         ${this.renderViewAllButton()}
       </section>
@@ -252,6 +254,7 @@ export class ResourceHub extends LitElement {
 
   cardsClasses() {
     return classMap({
+      cards: true,
       horizontal:
         this.pageName === 'complete' &&
         window.innerWidth <= BreakpointValues.smallUpper,

--- a/src/script/pages/app-congrats.ts
+++ b/src/script/pages/app-congrats.ts
@@ -531,7 +531,6 @@ export class AppCongrats extends LitElement {
                   linkText="Read Post"
                   linkRoute="${this.featuredPost.clickUrl}"
                   .featured="${true}"
-                  mode="blog"
                   class=${classMap({
                     blog: true,
                     featured: true,
@@ -545,7 +544,7 @@ export class AppCongrats extends LitElement {
                       <app-card
                         cardTitle="${post.title}"
                         description="${post.description}"
-                        mode="blog"
+                        class="blog"
                         imageUrl="${post.imageUrl}"
                       >
                       </app-card>
@@ -566,25 +565,25 @@ export class AppCongrats extends LitElement {
 
               <div id="tools-block">
                 <app-card
+                  class="blog"
                   title="demo"
                   description="demo demo demo"
-                  mode="blog"
                   imageUrl="/assets/icons/icon_192.png"
                 >
                 </app-card>
 
                 <app-card
+                  class="blog"
                   title="demo"
                   description="demo demo demo"
-                  mode="blog"
                   imageUrl="/assets/icons/icon_192.png"
                 >
                 </app-card>
 
                 <app-card
+                  class="blog"
                   title="demo"
                   description="demo demo demo"
-                  mode="blog"
                   imageUrl="/assets/icons/icon_192.png"
                 >
                 </app-card>

--- a/src/script/pages/app-congrats.ts
+++ b/src/script/pages/app-congrats.ts
@@ -22,13 +22,13 @@ import '../components/app-sidebar';
 import '../components/content-header';
 import '../components/app-modal';
 import '../components/app-card';
+import '../components/resource-hub';
 
 import { getPlatformsGenerated } from '../services/congrats';
 import { fileSave } from 'browser-fs-access';
 import { Router } from '@vaadin/router';
 import { generatePackage, platform } from '../services/publish';
-import { BlogPost } from '../services/blog';
-import { allPosts } from '../services/blog';
+import { BlogPost, allPosts } from '../services/blog';
 
 @customElement('app-congrats')
 export class AppCongrats extends LitElement {
@@ -561,7 +561,11 @@ export class AppCongrats extends LitElement {
             </section>
 
             <section id="tools-section">
-              <h3>Helpful tools for you...</h3>
+              <!-- TODO -->
+
+              <resource-hub page="complete">
+                <h3 slot="title">Helpful tools for you...</h3>
+              </resource-hub>
 
               <div id="tools-block">
                 <app-card

--- a/src/script/pages/app-congrats.ts
+++ b/src/script/pages/app-congrats.ts
@@ -561,37 +561,9 @@ export class AppCongrats extends LitElement {
             </section>
 
             <section id="tools-section">
-              <!-- TODO -->
-
               <resource-hub page="complete">
                 <h3 slot="title">Helpful tools for you...</h3>
               </resource-hub>
-
-              <div id="tools-block">
-                <app-card
-                  class="blog"
-                  title="demo"
-                  description="demo demo demo"
-                  imageUrl="/assets/icons/icon_192.png"
-                >
-                </app-card>
-
-                <app-card
-                  class="blog"
-                  title="demo"
-                  description="demo demo demo"
-                  imageUrl="/assets/icons/icon_192.png"
-                >
-                </app-card>
-
-                <app-card
-                  class="blog"
-                  title="demo"
-                  description="demo demo demo"
-                  imageUrl="/assets/icons/icon_192.png"
-                >
-                </app-card>
-              </div>
             </section>
           </div>
         </div>


### PR DESCRIPTION
## PR Type

- Feature

## Describe the new behavior?

- use resource hub for the links to places such as demos and components, and etc.
- going to breakout the blog-showcase component into css as the logic changes make it simpler to just keep the loops within the complete page.

app-card

- use class rather than mode
- technically can mix and match classes...
- ids to classes

resource-hub

- publish -> complete
- some refactor, put in-line with experience learned from manifest page
- simplify and split up css sub functions (makes next step easier).
- ids to classes

## follow up

- modularize the structural CSS from the blog-showcase component which I designed for the complete page. With the change to the implementation being custom, makes more sense to keep the structural logic in the complete page rather than split it off into its own component.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
