### PR TITLE
fix(): remove red background on cards

### DIFF
--- a/src/script/components/resource-hub.ts
+++ b/src/script/components/resource-hub.ts
@@ -273,15 +273,6 @@ export class ResourceHub extends LitElement {
         undefined,
         919
       ),
-      customBreakPoint(
-        css`
-          .resource-hub.home .cards {
-            background-color: red;
-          }
-        `,
-        undefined,
-        1023
-      ),
     ];
   }
 


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
There was a red background being applied to the resource-hub that is not in the design. 

## Describe the new behavior?
Removed the red background so that it matches the design.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
