### PR TITLE
fix(): bit more margin-top on duo sized devices

### DIFF
--- a/src/script/components/content-header.ts
+++ b/src/script/components/content-header.ts
@@ -162,10 +162,6 @@ export class ContentHeader extends LitElement {
       `)}
 
       ${mediumBreakPoint(css`
-        #main-container {
-          flex-direction: column-reverse;
-          padding-left: 0;
-        }
 
         :host(.home) {
           background-position: top center;
@@ -173,7 +169,11 @@ export class ContentHeader extends LitElement {
           background-image: url(/assets/images/home_mobile.webp);
           background-size: cover;
 
-          height: 30em;
+          height: 40em;
+        }
+
+        :host(.home) #circles-box {
+          height: 40em;
         }
 
         :host(.reportCard) {
@@ -237,7 +237,10 @@ export class ContentHeader extends LitElement {
 
         #main-container {
           padding-top: initial;
-          margin-top: 12em;
+          margin-top: 14em;
+
+          flex-direction: column-reverse;
+          padding-left: 0;
         }
 
         #circles-box {


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Surface duo sized devices had styles that were not quite right, and therefore in a browser with the tab bar up top, the UI was a little "squished".

## Describe the new behavior?
This PR tweaks heights and adds a little more margin top to fix this problem.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
