### PR TITLE
fix(): start_url, not startUrl

### DIFF
--- a/src/script/components/windows-form.ts
+++ b/src/script/components/windows-form.ts
@@ -427,7 +427,7 @@ export class WindowsForm extends LitElement {
                     class="form-control"
                     id="windowsStartUrlInput"
                     placeholder="https://mysite.com/startpoint.html"
-                    value="${this.default_options ? this.default_options.manifest.startUrl : "/"}"
+                    .value="${this.default_options ? this.default_options.manifest?.start_url : "/"}"
                     name="startUrl"
                   ></fast-text-field>
                 </div>


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The start_url field in the windows form was showing undefined by default instead of the actual start_url from the users manifest.

## Describe the new behavior?
Correct start_url is now used.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
