### PR TITLE
Update link to IARC rating ID

### DIFF
--- a/components/ManifestScoreCard.vue
+++ b/components/ManifestScoreCard.vue
@@ -141,7 +141,7 @@ export default class extends Vue {
       () => this.getStatus((m) => !!m.shortcuts && m.shortcuts.length > 0)
     ),
     new ScoreCardMetric(
-      "Contains an <a href='https://www.w3.org/TR/appmanifest/#iarc_rating_id-member'>IARC rating ID</a> to determine the appropriate ages for the app",
+      "Contains an <a href='https://www.w3.org/TR/manifest-app-info/#iarc_rating_id-member'>IARC rating ID</a> to determine the appropriate ages for the app",
       1,
       "optional",
       () => this.getStatus((m) => !!m.iarc_rating_id)


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
- Documentation content changes


## Describe the current behavior?
Jut a quick PR, The current link is broken since the content has been moved to a new URL.


## Describe the new behavior?
The new URL is https://www.w3.org/TR/manifest-app-info/#iarc_rating_id-member

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
