### PR TITLE
chore(): use loading button on the home page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7830,7 +7830,6 @@
         "@types/trusted-types": "^1.0.1"
       }
     },
-
     "node_modules/load-json-file": {
       "version": "2.0.0",
       "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",

--- a/src/script/components/loading-button.ts
+++ b/src/script/components/loading-button.ts
@@ -19,7 +19,7 @@ export class LoadingButton extends LitElement implements AppButtonElement {
         height: 1.8em;
         width: 1.8em;
 
-        --accent-foreground-rest: var(--primary-purple);
+        --accent-foreground-rest: white;
       }
 
       ${smallBreakPoint(css`

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -168,12 +168,14 @@ export class AppHome extends LitElement {
             font-size: 22px;
           }
 
-          #input-form app-button {
-            margin-top: 54px;
-            width: 180px;
+          #input-form loading-button {
+            margin-top: 34px;
+            width: 176px;
           }
 
-          #input-form app-button::part(underlying-button) {
+          #input-form loading-button::part(underlying-button) {
+            margin-top: 44px;
+            width: 176px;
             height: 64px;
             font-size: 22px;
           }
@@ -221,19 +223,16 @@ export class AppHome extends LitElement {
           #input-form loading-button::part(underlying-button) {
             margin-top: 44px;
             width: 176px;
+            height: 64px;
+            font-size: 22px;
           }
 
           #input-block {
             margin-bottom: 30px;
           }
 
-          #input-form app-button {
+          #input-form loading-button {
             width: 180px;
-          }
-
-          #input-form app-button::part(underlying-button) {
-            height: 64px;
-            font-size: 22px;
           }
         `)}
 
@@ -405,8 +404,8 @@ export class AppHome extends LitElement {
               : null}
           </div>
 
-          <app-button type="submit" @click="${(e: InputEvent) => this.start(e)}"
-            >Start</app-button
+          <loading-button type="submit" ?loading="${this.gettingManifest}" @click="${(e: InputEvent) => this.start(e)}"
+            >Start</loading-button
           >
         </form>
       </content-header>


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
We had moved to an app-button temporarily because of styling challenges that I had.

## Describe the new behavior?
This PR moves us back to using that component on the home page

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
