### PR TITLE
fix(): dont re-try in the could not get site error block

### DIFF
--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -322,23 +322,14 @@ export class AppHome extends LitElement {
         }
       } catch (err) {
         console.error('Error getting site', err.message);
-  
-        try {
-          const goodURL = getURL();
-  
-          if (goodURL !== undefined) {
-            // couldnt get manifest, thats ok
-            // lets continue forward with the default
-            // zeroed out results.
-            Router.go(`/testing?site=${goodURL}`);
-          } 
-        } catch (err) {
-          this.errorGettingURL = true;
-          this.errorMessage = err;
-          throw new Error(`Error getting URL: ${err}`);
-        }
+
+        this.gettingManifest = false;
+
+        this.errorGettingURL = true;
+        this.errorMessage = err;
+
       }
-  
+
       this.gettingManifest = false;
     }
   }
@@ -407,7 +398,7 @@ export class AppHome extends LitElement {
               autofocus
             ></fast-text-field>
 
-            ${this.errorGettingURL &&
+            ${
             this.errorMessage &&
             this.errorMessage.length > 0
               ? html`<span class="error-message">${this.errorMessage}</span>`


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
We were re-trying starting the tests in the `catch` block for when we were not able to retrieve a site (404 / 422 type situations) which led to incorrect error handling behavior.

## Describe the new behavior?
We now go straight to the error state in this block instead of re-trying.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
