### PR TITLE
fix(): service worker caching now works as expected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "PWABuilder",
   "version": "0.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rimraf build/ && rimraf dist/",
-    "build": "rollup --config rollup.config.dev.js && rimraf dist/ && rollup --config rollup.config.js",
+    "build": "rollup --config rollup.config.dev.js && rimraf dist/ && rollup --config rollup.config.js && node workbox.mjs",
     "start": "npm run build && npx nodemon server.js",
     "dev": "concurrently \"rollup --config rollup.config.dev.js --watch\" \"web-dev-server\"",
     "debug": "concurrently \"rollup --config rollup.config.dev.js --watch\" \"web-dev-server --config web-dev-server.debugging.config.mjs\""
@@ -43,8 +43,8 @@
     "workbox-precaching": "^6.1.2"
   },
   "devDependencies": {
-    "@rollup/plugin-json": "^4.1.0",
     "@open-wc/rollup-plugin-html": "^1.2.5",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-replace": "^2.4.2",
     "@rollup/plugin-strip": "^2.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,8 +8,6 @@ import typescript from "@rollup/plugin-typescript";
 import litcss from "rollup-plugin-lit-css";
 import json from '@rollup/plugin-json';
 
-const workbox = require('rollup-plugin-workbox-inject');
-
 export default {
   input: "build/index.html",
   output: {
@@ -41,17 +39,6 @@ export default {
         { src: "workers/**/*", dest: "dist/workers/" },
         { src: "routes.json", dest: "dist/" },
       ],
-    }),
-    workbox({
-      globDirectory: "dist/",
-      globPatterns: [
-        "styles/*.css",
-        "**/*/*.svg",
-        "*.js",
-        "*.html",
-        "assets/**",
-        "*.json",
-      ],
-    }),
+    })
   ],
 };

--- a/workbox.mjs
+++ b/workbox.mjs
@@ -1,0 +1,10 @@
+import { injectManifest } from 'workbox-build';
+
+injectManifest({
+    globDirectory: 'dist',
+    globPatterns: [
+      '**/*.{html,json,js,css,png,webp,jpg}',
+    ],
+    swSrc: 'dist/pwabuilder-sw.js',
+    swDest: 'dist/pwabuilder-sw.js',
+  });


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
https://github.com/pwa-builder/PWABuilder/projects/3#card-60665212

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Our assets were not being cached correctly as Workbox was running before asset generation was done.

## Describe the new behavior?
We are now using the workbox-build module directly instead of relying on a rollup plugin that wraps it. I then have a simple workbox.mjs script (needs the .mjs for node to understand it as a module so we can use standard imports etc) that runs at the end our of production build that inserts the cache manifest into our custom service worker. This enables us to ensure that Workbox is being ran at the correct time.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
