### PR TITLE
fix(): dont try to cache json

### DIFF
--- a/workbox.mjs
+++ b/workbox.mjs
@@ -3,7 +3,7 @@ import { injectManifest } from 'workbox-build';
 injectManifest({
     globDirectory: 'dist',
     globPatterns: [
-      '**/*.{html,json,js,css,png,webp,jpg}',
+      '**/*.{html,js,css,png,webp,jpg}',
     ],
     swSrc: 'dist/pwabuilder-sw.js',
     swDest: 'dist/pwabuilder-sw.js',


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
We shouldnt try to cache json as it catches `routes.json` which is only used by azure static web apps and causes a 404 when the sw tries to cache it. Because of this, the sw fails to install.

## Describe the new behavior?
Not trying to pre-cache json.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
