### PR TITLE
fix(): import report-page directly again

### DIFF
--- a/src/script/pages/app-index.ts
+++ b/src/script/pages/app-index.ts
@@ -2,6 +2,7 @@ import { LitElement, css, html } from 'lit';
 import { customElement } from "lit/decorators.js"
 import { Router } from '@vaadin/router';
 import './app-home';
+import './app-report';
 
 import '../components/app-footer';
 import '../components/app-header';
@@ -92,10 +93,7 @@ export class AppIndex extends LitElement {
           },
           {
             path: '/reportcard',
-            component: 'app-report',
-            action: async () => {
-              await import('./app-report.js');
-            },
+            component: 'app-report'
           },
           {
             path: '/publish',


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
https://github.com/pwa-builder/PWABuilder/projects/3#card-60816382

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
We had moved back to an async import for the report-page so we did not have to import the report-page component in the index. However, because we are (and we need to) programmatically navigating to the report-page we need to import it directly so things are already in memory. At the core, I "think" this might be a vague bug in the vaadin router, but I cant say that for sure.

## Describe the new behavior?
We are now importing it directly again.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
