### PR TITLE
loading-button set variable for button height

### DIFF
--- a/src/script/components/loading-button.ts
+++ b/src/script/components/loading-button.ts
@@ -23,6 +23,10 @@ export class LoadingButton extends LitElement implements AppButtonElement {
         --accent-foreground-rest: white;
       }
 
+      app-button {
+        height: var(--button-height);
+      }
+
       app-button::part(underlying-button) {
         height: 100%;
         font-size: inherit;

--- a/styles/global.css
+++ b/styles/global.css
@@ -49,6 +49,7 @@
   --sidebar-accent: #A2F4CC;
 
   --button-shadow: 0px 1px 4px rgba(0, 0, 0, 0.25);
+  --button-height: 40px;
   --button-radius: 44px;
   --mobile-button-radius: 61px;
   --mobile-button-height: 64px;


### PR DESCRIPTION
## PR Type

- Bugfix

## Describe the new behavior?

Set variable for the standard button height as a variable.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information

