### PR TITLE
fix(): intro grid item paragraphs should have standard width

### DIFF
--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -89,6 +89,8 @@ export class AppHome extends LitElement {
           margin-top: 0;
           color: var(--secondary-font-color);
           font-size: var(--font-size);
+
+          width: 194px;
         }
 
         #input-form {


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
Other... Please describe: CSS Fix


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Paragraphs on the home page were too wide and almost running into each other.

## Describe the new behavior?
These paragraphs now match the design.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
