### PR TITLE
feat(): simplify URL handling

### DIFF
--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -2,7 +2,8 @@
   "input": {
     "home": {
       "error": {
-        "promises": "There was a problem retrieving the manifest from your site."
+        "promises": "There was a problem retrieving the manifest from your site.",
+        "invalidURL": "The URL you entered is not a properly formatted URL"
       }
     },
     "manifest": {

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -12,7 +12,7 @@ import {
   xxLargeBreakPoint,
   xxxLargeBreakPoint,
 } from '../utils/css/breakpoints';
-import { fetchManifest } from '../services/manifest';
+import { isValidURL } from '../utils/url';
 
 import '../components/content-header';
 import '../components/resource-hub';
@@ -28,6 +28,7 @@ import '@pwabuilder/pwainstall';
 import { Router } from '@vaadin/router';
 import { getProgress, getURL, setProgress } from '../services/app-info';
 import { Lazy, ProgressList, Status } from '../utils/interfaces';
+import { fetchManifest } from '../services/manifest';
 
 @customElement('app-home')
 export class AppHome extends LitElement {
@@ -274,19 +275,21 @@ export class AppHome extends LitElement {
       this.gettingManifest = true;
 
       try {
-        const data = await fetchManifest(this.siteURL);
+        const validation_test = await isValidURL(this.siteURL);
+        
+        if (validation_test === true) {
+          const data = await fetchManifest(this.siteURL);
 
-        if (data.error) {
-          console.log('data.error', data);
+          if (data.error) {
+  
+            this.errorGettingURL = true;
+            this.errorMessage = data.error;
+            console.warn(`Error getting URL: ${data.error}`);
 
-          this.errorGettingURL = true;
-          this.errorMessage = data.error;
-          throw new Error(`Error getting URL: ${data.error}`);
-        } else {
-          console.log('not data.error', data);
+            return;
+          }
 
           this.errorGettingURL = false;
-          this.errorMessage = undefined;
 
           const progress = getProgress();
           this.updateProgress(progress);
@@ -300,19 +303,16 @@ export class AppHome extends LitElement {
             Router.go(`/testing?site=${goodURL}`);
           }
         }
-      } catch (err) {
-        console.log(err, typeof err, err.message);
-        console.error('Error getting site', err.message);
-
-        this.gettingManifest = false;
-
-        this.errorGettingURL = true;
-
-        if (err.message === 'All promises were rejected') {
-          this.errorMessage = localeStrings.input.home.error.promises;
-        } else {
-          this.errorMessage = err;
+        else {
+          this.errorMessage = localeStrings.input.home.error.invalidURL;
+          this.errorGettingURL = true;
         }
+      }
+      catch (err) {
+        console.error('err', err);
+
+        this.errorMessage = err;
+        this.errorGettingURL = true;
       }
 
       this.gettingManifest = false;

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -274,14 +274,13 @@ export class AppHome extends LitElement {
     if (this.siteURL) {
       this.gettingManifest = true;
 
-      try {
-        const validation_test = await isValidURL(this.siteURL);
-        
-        if (validation_test === true) {
+      const validation_test = await isValidURL(this.siteURL);
+
+      if (validation_test === true) {
+        try {
           const data = await fetchManifest(this.siteURL);
 
           if (data.error) {
-  
             this.errorGettingURL = true;
             this.errorMessage = data.error;
             console.warn(`Error getting URL: ${data.error}`);
@@ -297,21 +296,25 @@ export class AppHome extends LitElement {
           const goodURL = getURL();
 
           if (goodURL !== undefined) {
-            // couldnt get manifest, thats ok
-            // lets continue forward with the default
-            // zeroed out results.
+            Router.go(`/testing?site=${goodURL}`);
+          }
+        } catch (err) {
+          // couldnt get manifest
+          // continue forward with zeroed out results
+          // and use generated manifest
+          this.errorGettingURL = false;
+
+          const progress = getProgress();
+          this.updateProgress(progress);
+
+          const goodURL = getURL();
+
+          if (goodURL !== undefined) {
             Router.go(`/testing?site=${goodURL}`);
           }
         }
-        else {
-          this.errorMessage = localeStrings.input.home.error.invalidURL;
-          this.errorGettingURL = true;
-        }
-      }
-      catch (err) {
-        console.error('err', err);
-
-        this.errorMessage = err;
+      } else {
+        this.errorMessage = localeStrings.input.home.error.invalidURL;
         this.errorGettingURL = true;
       }
 

--- a/src/script/utils/url.ts
+++ b/src/script/utils/url.ts
@@ -62,13 +62,13 @@ export async function cleanUrl(url: string) {
   }
 
   if (cleanedUrl) {
-    const test = await isValidUrl(cleanedUrl);
+    const test = await isValidURL(cleanedUrl);
 
     if (
-      test.message !== undefined &&
+      test === false &&
       !url.toLowerCase().startsWith('http://')
     ) {
-      throw `${test.message}: this error means that you may have a bad https cert or the url may not be correct`;
+      throw "This error means that you may have a bad https cert or the url may not be correct";
     } else {
       return cleanedUrl;
     }
@@ -78,13 +78,13 @@ export async function cleanUrl(url: string) {
   }
 }
 
-async function isValidUrl(url: string) {
-  try {
-    return await fetch(url, {
-      mode: 'no-cors',
-      credentials: 'include',
-    });
-  } catch (err) {
-    return err;
-  }
+export function isValidURL(str) {
+  // from https://stackoverflow.com/a/5717133
+  var pattern = new RegExp('^(https?:\\/\\/)?'+
+    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ 
+    '((\\d{1,3}\\.){3}\\d{1,3}))'+
+    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+
+    '(\\?[;&a-z\\d%_.~+=-]*)?'+
+    '(\\#[-a-z\\d_]*)?$','i');
+  return !!pattern.test(str);
 }


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the new behavior?
URLs are handled correctly without making that first test request to tell if its a valid URL or not. This code has also been simplified alot. My next step is to write a backend function that grabs the canonical URL and send that back to the front-end. I will then update the URL that is used for publishing with that canonical URL. This will handle the pinterest + android packging situation.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
