### PR TITLE
fix(): circles-box needs to ignore pointer events so the back button …

### DIFF
--- a/src/script/components/content-header.ts
+++ b/src/script/components/content-header.ts
@@ -62,6 +62,7 @@ export class ContentHeader extends LitElement {
 
       :host(.home) #circles-box {
         width: 100%;
+        pointer-events: none;
       }
 
       #content-side {


### PR DESCRIPTION
…works on mobile

Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The circles-box element, which is used for layout in the content-header, has enough height on it that on mobile it can block the logo / back button.

## Describe the new behavior?
This PR adds pointer-events: none to that element so that the logo / back button are always selectable without breaking the current layout styles.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
