### PR TITLE
feat(): update url being used for packaging with canonical URL in the background

### DIFF
--- a/src/script/services/app-info.ts
+++ b/src/script/services/app-info.ts
@@ -97,6 +97,16 @@ export function setURL(url: string) {
   }
 }
 
+export function setCanonicalURL(initialURL) {
+  const parts = new URL(initialURL);
+
+  const needed_part = parts.origin;
+
+  if (needed_part) {
+    setURL(needed_part);
+  }
+}
+
 export function getURL() {
   const url = sessionStorage.getItem('current_url');
 

--- a/src/script/services/app-info.ts
+++ b/src/script/services/app-info.ts
@@ -98,12 +98,16 @@ export function setURL(url: string) {
 }
 
 export function setCanonicalURL(initialURL) {
-  const parts = new URL(initialURL);
+  try {
+    const parts = new URL(initialURL);
+    const needed_part = parts.origin;
 
-  const needed_part = parts.origin;
-
-  if (needed_part) {
-    setURL(needed_part);
+    if (needed_part) {
+      setURL(needed_part);
+    }
+  }
+  catch(err) {
+    console.error(err);
   }
 }
 

--- a/src/script/services/manifest.ts
+++ b/src/script/services/manifest.ts
@@ -10,7 +10,7 @@ import {
   ManifestDetectionResult,
 } from '../utils/interfaces';
 import { cleanUrl } from '../utils/url';
-import { setURL } from './app-info';
+import { setCanonicalURL, setURL } from './app-info';
 
 export const emitter = new EventTarget();
 let manifest: Lazy<Manifest>;
@@ -46,6 +46,10 @@ async function getManifestViaFilePost(
     throw new Error(`Unable to get JSON from ${manifestTestUrl}`);
   }
 
+  console.log('responseData', responseData);
+
+  setCanonicalURL(responseData.content.url);
+
   return {
     content: responseData.manifestContents,
     format: 'w3c',
@@ -80,6 +84,8 @@ async function getManifestViaHtmlParse(
     throw new Error(`Error fetching from ${manifestTestUrl}`);
   }
   const responseData: ManifestFinderResult = await response.json();
+
+  setCanonicalURL(responseData.manifestUrl);
 
   if (responseData.error || !responseData.manifestContents) {
     console.warn(

--- a/src/script/services/manifest.ts
+++ b/src/script/services/manifest.ts
@@ -46,8 +46,6 @@ async function getManifestViaFilePost(
     throw new Error(`Unable to get JSON from ${manifestTestUrl}`);
   }
 
-  console.log('responseData', responseData);
-
   setCanonicalURL(responseData.content.url);
 
   return {


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
This fixes a bug where even if the non-canonical URL is being used for testing (such as https://pinterest.com) we will update the URL being used for packaging with the canonical URL (from our backend manifest finder services) in the background. This adds no new latency for the user to init the tests, but also ensures that once it comes to packaging the correct URL is being used (this is especially important for Android).

## Describe the new behavior? 
Once we have the canonical URL from our manifest finder services I call a function to update the URL being worked on with this more correct URL. This all happens without any need for action from the user.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
