### PR TITLE
fix(): badge state is now updated correctly for multiple tests run in…

### DIFF
--- a/src/script/services/app-info.ts
+++ b/src/script/services/app-info.ts
@@ -127,6 +127,8 @@ export function getURL() {
 export function setResults(testResults: RawTestResult) {
   console.log('testResults', testResults);
   results = testResults;
+
+  sessionStorage.removeItem('current_results');
   sessionStorage.setItem('current_results', JSON.stringify(testResults));
 }
 

--- a/src/script/services/badges.ts
+++ b/src/script/services/badges.ts
@@ -9,7 +9,7 @@ const possible_badges = [
   { name: 'Store Ready', url: '/assets/badges/store_ready_badge.svg' },
 ];
 
-const current_badges: Array<{ name: string; url: string }> = [];
+let current_badges: Array<{ name: string; url: string }> = [];
 
 export const no_pwa_icon = {
   name: 'Not a PWA',
@@ -18,6 +18,9 @@ export const no_pwa_icon = {
 
 export function giveOutBadges() {
   const results = getResults();
+
+  current_badges = [];
+  sessionStorage.removeItem("current_badges");
 
   if (results) {
     const hasMani = results.manifest[0].result;
@@ -114,9 +117,6 @@ export function sortBadges(): Array<{ name: string; url: string }> {
   const possible_badges = getPossibleBadges();
   const current_badges = getCurrentBadges();
 
-  console.log('current_badges', current_badges);
-  console.log('possible_badges', possible_badges);
-
   const combined: Array<{ name: string; url: string }> = [];
 
   possible_badges.forEach(badge => {
@@ -149,6 +149,7 @@ export function sortBadges(): Array<{ name: string; url: string }> {
 
   console.log('duplicate', duplicates);
 
+  sessionStorage.removeItem("current_badges");
   sessionStorage.setItem('current_badges', JSON.stringify(duplicates));
 
   return duplicates;


### PR DESCRIPTION
… the same session

Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Badge state was not being updated correctly for tests run in the same "session".

## Describe the new behavior?
Badge state is now cleared before each test correctly in a session, which leads to the badge state being updated correctly.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
