### PR TITLE
fix(): manifests are now updated correctly for multiple tests run in …

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -68,7 +68,6 @@ type BackgroundColorRadioValues = 'none' | 'transparent' | 'custom';
 @customElement('manifest-options')
 export class AppManifest extends LitElement {
   @property({ type: Object, hasChanged: objectHasChanged })
-  manifest = getManifest();
   @property({ type: Number }) score = 0;
   @property({ type: Array, hasChanged: arrayHasChanged })
   screenshotList: Array<string | undefined> = [undefined];
@@ -96,6 +95,9 @@ export class AppManifest extends LitElement {
 
   @state()
   protected editorOpened = false;
+
+  @state() 
+  protected manifest: Lazy<Manifest | undefined>;
 
   protected get siteUrl(): string {
     if (!this.searchParams) {
@@ -410,9 +412,14 @@ export class AppManifest extends LitElement {
   constructor() {
     super();
 
-    manifestEmitter.addEventListener(AppEvents.manifestUpdate, () => {
-      this.manifest = getManifest();
+    manifestEmitter.addEventListener(AppEvents.manifestUpdate, async () => {
+
+      this.manifest = await getManifest();
     });
+  }
+
+  async firstUpdated() {
+    this.manifest = await getManifest();
   }
 
   render() {


### PR DESCRIPTION
…a session

Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
If you tested, for example, Twitter and then Pinterest in the same session, when you tested Pinterest the manifest being shown in the manifest editor was still the Twitter manifest.

## Describe the new behavior?
Manifests are now updated correctly between tests in the same session.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
