### PR TITLE
fix(): manifest generation, editing and downloading fixed

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -9,6 +9,7 @@ import ErrorStyles from '../../../styles/error-styles.css';
 
 import {
   emitter as manifestEmitter,
+  getGeneratedManifest,
   getManifest,
   updateManifest,
 } from '../services/manifest';
@@ -412,14 +413,50 @@ export class AppManifest extends LitElement {
   constructor() {
     super();
 
-    manifestEmitter.addEventListener(AppEvents.manifestUpdate, async () => {
+    manifestEmitter.addEventListener(AppEvents.manifestUpdate, async (maniUpdates: any) => {
+      /*const potential_mani = await getManifest();
 
-      this.manifest = await getManifest();
+      if (potential_mani) {
+        this.manifest = await potential_mani;
+        console.log("this.manifest", this.manifest);
+      }
+      else if (potential_mani === undefined) {
+        const gen = await getGeneratedManifest();
+        console.info('Gen manifest', gen);
+
+        this.manifest = gen;
+
+      }*/
+      console.log('maniUpdates', maniUpdates);
+      if (maniUpdates) {
+        this.manifest = maniUpdates.detail;
+      }
     });
   }
 
   async firstUpdated() {
-    this.manifest = await getManifest();
+    try {
+      const potential_mani = await getManifest();
+
+      if (potential_mani) {
+        this.manifest = potential_mani;
+        console.log("this.manifest", this.manifest);
+      }
+      else if (potential_mani === undefined) {
+        const gen = await getGeneratedManifest();
+        console.info('Gen manifest', gen);
+
+        this.manifest = gen;
+
+      }
+    }
+    catch (err) {
+      console.info("in here");
+      const gen = await getGeneratedManifest();
+
+      this.manifest = gen;
+      console.warn(err, gen);
+    }
   }
 
   render() {
@@ -567,6 +604,7 @@ export class AppManifest extends LitElement {
   }
 
   renderInfoItems() {
+    console.log('infoItems', infoItems);
     return infoItems.map(item => {
       const value = this.manifest
         ? (this.manifest[item.entry] as string)
@@ -784,6 +822,8 @@ export class AppManifest extends LitElement {
   handleInputChange(event: InputEvent) {
     const input = <HTMLInputElement | HTMLSelectElement>event.target;
     const fieldName = input.dataset['field'];
+
+    console.log('input.value', input.value, 'fieldName', fieldName);
 
     if (this.manifest && fieldName && this.manifest[fieldName]) {
       this.updateManifest({ [fieldName]: input.value });

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -414,19 +414,6 @@ export class AppManifest extends LitElement {
     super();
 
     manifestEmitter.addEventListener(AppEvents.manifestUpdate, async (maniUpdates: any) => {
-      /*const potential_mani = await getManifest();
-
-      if (potential_mani) {
-        this.manifest = await potential_mani;
-        console.log("this.manifest", this.manifest);
-      }
-      else if (potential_mani === undefined) {
-        const gen = await getGeneratedManifest();
-        console.info('Gen manifest', gen);
-
-        this.manifest = gen;
-
-      }*/
       console.log('maniUpdates', maniUpdates);
       if (maniUpdates) {
         this.manifest = maniUpdates.detail;

--- a/src/script/services/manifest.ts
+++ b/src/script/services/manifest.ts
@@ -237,17 +237,34 @@ export async function updateManifest(manifestUpdates: Partial<Manifest>) {
   // so we should only load it once its actually needed
   await import('https://unpkg.com/deepmerge@4.2.2/dist/umd.js');
 
-  manifest = deepmerge(manifest ? manifest as Manifest : generatedManifest as Manifest, manifestUpdates as Partial<Manifest>, {
-    // customMerge: customManifestMerge, // NOTE: need to manually concat with editor changes.
-  });
+  const manifest_check = manifest ? true : false;
 
-  console.log('deepmerge mani', manifest);
-
-  emitter.dispatchEvent(
-    updateManifestEvent({
-      ...manifest,
-    })
-  );
+  if (manifest_check === true) {
+    manifest = deepmerge(manifest ? manifest as Manifest : generatedManifest as Manifest, manifestUpdates as Partial<Manifest>, {
+      // customMerge: customManifestMerge, // NOTE: need to manually concat with editor changes.
+    });
+  
+    console.log('deepmerge mani', manifest);
+  
+    emitter.dispatchEvent(
+      updateManifestEvent({
+        ...manifest,
+      })
+    );
+  }
+  else {
+    generatedManifest = deepmerge(manifest ? manifest as Manifest : generatedManifest as Manifest, manifestUpdates as Partial<Manifest>, {
+      // customMerge: customManifestMerge, // NOTE: need to manually concat with editor changes.
+    });
+  
+    console.log('deepmerge mani', manifest);
+  
+    emitter.dispatchEvent(
+      updateManifestEvent({
+        ...generatedManifest,
+      })
+    );
+  }
 }
 
 export function updateManifestEvent<T extends Partial<Manifest>>(detail: T) {

--- a/src/script/services/publish/index.ts
+++ b/src/script/services/publish/index.ts
@@ -34,7 +34,7 @@ export async function generatePackage(type: platform, form?: HTMLFormElement) {
         } else {
           // No form, lets generate from the manifest
           try {
-            const options = createWindowsPackageOptionsFromManifest();
+            const options = await createWindowsPackageOptionsFromManifest();
 
             const testBlob = await generateWindowsPackage(options);
             return {
@@ -47,7 +47,7 @@ export async function generatePackage(type: platform, form?: HTMLFormElement) {
             const localManifest = await grabBackupManifest();
 
             if (localManifest) {
-              const options = createWindowsPackageOptionsFromManifest(
+              const options = await createWindowsPackageOptionsFromManifest(
                 localManifest
               );
               const testBlob = await generateWindowsPackage(options);

--- a/src/script/services/publish/web-publish.ts
+++ b/src/script/services/publish/web-publish.ts
@@ -6,12 +6,13 @@ export let web_generated = false;
 
 export async function generateWebPackage() {
   try {
-    const manifest = getManifest();
+    const manifest = await getManifest();
     const genManifest = getGeneratedManifest();
     const url = getURL();
 
     // The web package generator dies when screenshots is null. If detected, set screenshots to empty array.
     const manifestWithScreenshots = manifest ? { ...manifest } : { ...genManifest };
+
     if (!manifestWithScreenshots.screenshots) {
       manifestWithScreenshots.screenshots = [];
     }


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
https://github.com/pwa-builder/PWABuilder/projects/3#card-61981537
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the new behavior?
This PR fixes the following bugs:
- The manifest editor can now see a generated manifest
- The manifest editor can now successfully edit both a generated manifest and one from an app, and update the state correctly too.
- The above fix also fixed a bug with not being able to download on the base_package page
- A manifest is only generated once now if needed, the previous code could potentially generate it multiple times, wasting network time, azure cost etc etc

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
