### PR TITLE
fix(): better icon check for finalChecks + android generation fix

### DIFF
--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -88,7 +88,7 @@ export class AndroidForm extends LitElement {
     super();
   }
 
-  firstUpdated() {
+  async firstUpdated() {
     const form = this.shadowRoot?.querySelector(
       '#android-options-form'
     ) as HTMLFormElement;
@@ -97,9 +97,9 @@ export class AndroidForm extends LitElement {
       this.form = form;
     }
 
-    this.currentManifest = getManifest();
+    this.currentManifest = await getManifest();
 
-    this.default_options = createAndroidPackageOptionsFromManifest();
+    this.default_options = await createAndroidPackageOptionsFromManifest();
   }
 
   initGenerate() {

--- a/src/script/services/publish/android-publish.ts
+++ b/src/script/services/publish/android-publish.ts
@@ -70,8 +70,8 @@ export async function generateAndroidPackage(
   return undefined;
 }
 
-export function createAndroidPackageOptionsFromForm(form: HTMLFormElement): AndroidApkOptions {
-  const manifest = getManifest();
+export async function createAndroidPackageOptionsFromForm(form: HTMLFormElement): Promise<AndroidApkOptions> {
+  const manifest = await getManifest();
   if (!manifest) {
     throw new Error('Could not find the web manifest');
   }
@@ -193,14 +193,14 @@ export function createAndroidPackageOptionsFromForm(form: HTMLFormElement): Andr
   };
 }
 
-export function createAndroidPackageOptionsFromManifest(localManifest?: Manifest): AndroidApkOptions {
+export async function createAndroidPackageOptionsFromManifest(localManifest?: Manifest): Promise<AndroidApkOptions> {
   let manifest: Manifest | undefined;
 
   if (localManifest) {
     manifest = localManifest;
   }
   else {
-    manifest = getManifest();
+    manifest = await getManifest();
   }
 
   if (!manifest) {

--- a/src/script/services/publish/index.ts
+++ b/src/script/services/publish/index.ts
@@ -66,7 +66,7 @@ export async function generatePackage(type: platform, form?: HTMLFormElement) {
     case 'android':
       try {
         if (form) {
-          const androidOptions = createAndroidPackageOptionsFromForm(form);
+          const androidOptions = await createAndroidPackageOptionsFromForm(form);
           console.log('no form android options', androidOptions);
 
           if (androidOptions) {
@@ -84,7 +84,7 @@ export async function generatePackage(type: platform, form?: HTMLFormElement) {
           }
         } else {
           try {
-            const androidOptions = createAndroidPackageOptionsFromManifest();
+            const androidOptions = await createAndroidPackageOptionsFromManifest();
             console.log('form android options', androidOptions);
             const testBlob = await generateAndroidPackage(androidOptions);
 
@@ -97,7 +97,7 @@ export async function generatePackage(type: platform, form?: HTMLFormElement) {
             // Lets try to grab it
             const localManifest = await grabBackupManifest();
             if (localManifest) {
-              const androidOptions = createAndroidPackageOptionsFromManifest(
+              const androidOptions = await createAndroidPackageOptionsFromManifest(
                 localManifest
               );
 

--- a/src/script/services/publish/publish-checks.ts
+++ b/src/script/services/publish/publish-checks.ts
@@ -1,4 +1,6 @@
+import { findSuitableIcon } from '../../utils/icons';
 import { getResults, getURL } from '../app-info';
+import { getGeneratedManifest, getManifest } from '../manifest';
 
 export interface checkResults {
     validURL: boolean,
@@ -8,7 +10,7 @@ export interface checkResults {
 }
 
 export async function finalCheckForPublish(): Promise<checkResults> {
-  return new Promise((resolve, reject) => {
+  return new Promise(async (resolve, reject) => {
     // Final check before a user starts trying to publish
     // We check for the following:
     /**
@@ -21,11 +23,27 @@ export async function finalCheckForPublish(): Promise<checkResults> {
     const results = getResults();
     const testURL = getURL();
 
+    const possible_mani = await getManifest();
+    const possible_gen_mani = await getGeneratedManifest();
+
+    const possible_icons = possible_mani ? possible_mani.icons : possible_gen_mani?.icons;
+
+    const icon =
+      findSuitableIcon(possible_icons, 'any', 512, 512, 'image/png') ||
+      findSuitableIcon(possible_icons, 'any', 192, 192, 'image/png') ||
+      findSuitableIcon(possible_icons, 'any', 512, 512, 'image/jpeg') ||
+      findSuitableIcon(possible_icons, 'any', 192, 192, 'image/jpeg') ||
+      findSuitableIcon(possible_icons, 'any', 512, 512, undefined) || // Fallback to a 512x512 with an undefined type.
+      findSuitableIcon(possible_icons, 'any', 192, 192, undefined) || // Fallback to a 192x192 with an undefined type.
+      findSuitableIcon(possible_icons, 'any', 0, 0, 'image/png') || // No large PNG and no large JPG? See if we have *any* PNG
+      findSuitableIcon(possible_icons, 'any', 0, 0, 'image/jpeg') || // No large PNG and no large JPG? See if we have *any* JPG
+      findSuitableIcon(possible_icons, 'any', 0, 0, undefined); // Welp, we sure tried. Grab any image available.
+
     if (results && testURL) {
       const checkResults = {
         validURL: testURL ? true : false,
         manifest: results?.manifest[0].result,
-        baseIcon: results?.manifest[10].result,
+        baseIcon: icon ? true : false,
         offline: results?.service_worker[1].result,
       };
       resolve(checkResults);


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
We were checking strictly for a 512x512 icon for our final checks. This is an inaccurate check as a 512x512 is not "needed" for Windows package generation.

On Android, we had some methods that needed to be awaited, like the issue I fixed with package generation for Windows yesterday.

## Describe the new behavior?
Icon issue: Changed our icon check to use our findSuitableIcons method to standardize our icon checks. 
Android: Awaited some methods that are now async.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
