### PR TITLE
fix(): base package modal text is correct

### DIFF
--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -14,6 +14,9 @@
     "publish": {
       "windows": {
         "test_package": "Want to test your app first before going to the Microsoft Store? Tap Download to get a package you can install and test."
+      },
+      "base_package": {
+        "download": "Download your generated Web Manifest and chosen Service Worker to make your app a PWA!"
       }
     }
   }

--- a/src/script/pages/app-basepack.ts
+++ b/src/script/pages/app-basepack.ts
@@ -269,8 +269,8 @@ export class AppBasePack extends LitElement {
     return html`
       <app-modal
         ?open="${this.blob ? true : false}"
-        title="Test Package Download"
-        .body="${localeStrings.input.publish.windows.test_package}"
+        title="Base Package Download"
+        .body="${localeStrings.input.publish.base_package.download}"
         id="test-download-modal"
       >
         <img


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
Task 33586492

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Text was wrong for the modal on the base_package page.

## Describe the new behavior?
New, correct text for the download modal on the base package page

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
