### PR TITLE
fix(): modal does not get stuck closed

### DIFF
--- a/src/script/pages/app-basepack.ts
+++ b/src/script/pages/app-basepack.ts
@@ -226,8 +226,14 @@ export class AppBasePack extends LitElement {
   async doWebGenerate() {
     this.loading = true;
 
+    this.blob = undefined;
+    this.errorMessage = undefined;
+    this.errored = false;
+
     try {
       const generatedPackage = await generateWebPackage();
+
+      console.log('blob', generatedPackage);
 
       if (generatedPackage) {
         this.blob = generatedPackage;
@@ -265,9 +271,16 @@ export class AppBasePack extends LitElement {
     }
   }
 
+  cancel() {
+    this.blob = undefined;
+    this.errored = false;
+    this.errorMessage = undefined;
+  }
+
   render() {
     return html`
       <app-modal
+        @app-modal-close="${() => this.cancel()}"
         ?open="${this.blob ? true : false}"
         title="Test Package Download"
         .body="${localeStrings.input.publish.windows.test_package}"
@@ -353,7 +366,7 @@ export class AppBasePack extends LitElement {
                   <loading-button
                     ?loading="${this.loading}"
                     @click="${() => this.doWebGenerate()}"
-                    >Download</loading-button
+                    >Generate</loading-button
                   >
                 </div>
               </div>


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Base package modal could get stuck closed when you hit the close button.

## Describe the new behavior?
The modal works as expected now. I also changed the download to generate in the main page to match the publish page.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
