### PR TITLE
fix(): remove next button from base_package page

### DIFF
--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -15,6 +15,9 @@
       "windows": {
         "test_package": "Want to test your app first before going to the Microsoft Store? Tap Download to get a package you can install and test."
       }
+    },
+    "basepack": {
+      "run_new": "After uploading the above files to your Web App tap Run New Test to test your PWA again!"
     }
   }
 }

--- a/src/script/pages/app-basepack.ts
+++ b/src/script/pages/app-basepack.ts
@@ -362,7 +362,7 @@ export class AppBasePack extends LitElement {
                 <h5>Up next</h5>
 
                 <p>
-                  After uploading the above files to your Web App tap Run New Test to test your PWA again, or tap Next to go straight to packaging! 
+                  After uploading the above files to your Web App tap Run New Test to test your PWA again!
                 </p>
               </div>
 
@@ -370,7 +370,6 @@ export class AppBasePack extends LitElement {
                 <app-button @click="${() => this.reTest()}"
                   >Run New Test</app-button
                 >
-                <fast-anchor href="/congrats">Next</fast-anchor>
               </div>
             </section>
           </div>

--- a/src/script/pages/app-basepack.ts
+++ b/src/script/pages/app-basepack.ts
@@ -362,7 +362,7 @@ export class AppBasePack extends LitElement {
                 <h5>Up next</h5>
 
                 <p>
-                  After uploading the above files to your Web App tap Run New Test to test your PWA again!
+                  ${localeStrings.input.basepack.run_new}
                 </p>
               </div>
 


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
As David rightly points out in ADO, the next button on the base package page did not make sense as the user still does not have a manifest uploaded to their app at that point and therefore should not be able to easily go to the congrats page.

## Describe the new behavior?
This PR removes the next button and keeps the Run New Test button, which is the more correct flow for users without a manifest.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
