### PR TITLE
fix(): scroll to top on navigations

### DIFF
--- a/src/script/pages/app-index.ts
+++ b/src/script/pages/app-index.ts
@@ -69,6 +69,10 @@ export class AppIndex extends LitElement {
 
   constructor() {
     super();
+
+    window.addEventListener('vaadin-router-location-changed', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
   }
 
   firstUpdated() {


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
When navigating between pages the scroll position was retained. This is because, like most PWAs, we are a single page app. However, Vaadin router makes it easy to customize the behavior on route changes.

## Describe the new behavior?
We now listen for route changes and smoothly / performantly scroll to the top between navigations.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
