### PR TITLE
fix(): badge hover labels are correct

### DIFF
--- a/src/script/components/app-badges.ts
+++ b/src/script/components/app-badges.ts
@@ -45,8 +45,6 @@ export class AppBadges extends LitElement {
   firstUpdated() {
     this.duplicate = sortBadges();
     this.possible_badges = getPossibleBadges();
-
-    console.log('this.duplicate', this.duplicate);
   }
 
   render() {
@@ -68,7 +66,7 @@ export class AppBadges extends LitElement {
                   : true,
               })}"
             >
-              <img .src="${badge.url}" .alt="${badge.name} icon" />
+              <img .title="${badge.name}" .src="${badge.url}" .alt="${badge.name} icon" />
             </div>
           `;
         })}


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
When hovering over the badges the label simply said "badges" instead of the actual name of the badge.

## Describe the new behavior?
The name of the specific badge being hovered over now shows.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
