### PR TITLE
fix(): use color picker and add theme_color picker

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -64,7 +64,7 @@ import {
   updateStateField,
 } from '../utils/codemirror';
 
-type BackgroundColorRadioValues = 'none' | 'transparent' | 'custom';
+type ColorRadioValues = 'none' | 'transparent' | 'custom';
 
 @customElement('manifest-options')
 export class AppManifest extends LitElement {
@@ -86,7 +86,10 @@ export class AppManifest extends LitElement {
   @state() screenshotListValid: Array<boolean> = [];
 
   @state()
-  protected backgroundColorRadioValue: BackgroundColorRadioValues = 'none';
+  protected backgroundColorRadioValue: ColorRadioValues = 'none';
+
+  @state()
+  protected themeColorRadioValue: ColorRadioValues = 'none';
 
   @state()
   protected awaitRequest = false;
@@ -144,6 +147,7 @@ export class AppManifest extends LitElement {
 
         #bg-custom-color {
           margin-left: 32px;
+          width: 8em;
         }
 
         .panel {
@@ -237,6 +241,12 @@ export class AppManifest extends LitElement {
 
         .item-top .tooltip {
           margin-left: 4px;
+        }
+
+        .color {
+          max-width: 618px;
+          margin-bottom: 1em;
+          margin-top: 1.5em;
         }
 
         .image-item {
@@ -662,32 +672,56 @@ export class AppManifest extends LitElement {
   }
 
   renderBackgroundColorSettings() {
-    const value = this.manifest ? this.manifest?.theme_color : undefined;
+    const value = this.manifest ? this.manifest?.background_color : undefined;
 
     return html`
-      <div class="setting-item inputs color">
-        <div class="item-top">
-          <h3>Background Color</h3>
-          ${this.renderToolTip('bg-color-tooltip', 'TODO')}
-        </div>
-        <fast-radio-group
-          value=${this.setBackgroundColorRadio()}
-          orientation="vertical"
-          @change=${this.handleBackgroundRadioChange}
-        >
-          <fast-radio value="none">None</fast-radio>
-          <fast-radio value="transparent">Transparent</fast-radio>
-          <fast-radio value="custom">Custom Color</fast-radio>
-        </fast-radio-group>
+      <div class="setting-items inputs color">
+        <div id="background-color-block">
+          <div class="item-top">
+            <h3>Background Color</h3>
+            ${this.renderToolTip('bg-color-tooltip', 'TODO')}
+          </div>
+          <fast-radio-group
+            value=${this.setBackgroundColorRadio()}
+            orientation="vertical"
+            @change=${this.handleBackgroundRadioChange}
+          >
+            <fast-radio value="none">None</fast-radio>
+            <fast-radio value="transparent">Transparent</fast-radio>
+            <fast-radio value="custom">Custom Color</fast-radio>
+          </fast-radio-group>
 
-        ${this.backgroundColorRadioValue === 'custom'
-          ? html`<fast-text-field
-              id="bg-custom-color"
-              placeholder="#XXXXXX"
-              .value=${value}
-              @change=${this.handleBackgroundColorInputChange}
-            ></fast-text-field>`
-          : undefined}
+          ${this.backgroundColorRadioValue === 'custom'
+            ? html`
+              <input type="color" id="bg-custom-color" .value=${value}
+                @change=${this.handleBackgroundColorInputChange} />
+              `
+            : undefined}
+        </div>
+
+        <div id="theme-color-block">
+          <div class="item-top">
+            <h3>Theme Color</h3>
+            ${this.renderToolTip('bg-color-tooltip', 'TODO')}
+          </div>
+          <fast-radio-group
+            value=${this.setThemeColorRadio()}
+            orientation="vertical"
+            @change=${this.handleThemeRadioChange}
+          >
+            <fast-radio value="none">None</fast-radio>
+            <fast-radio value="transparent">Transparent</fast-radio>
+            <fast-radio value="custom">Custom Color</fast-radio>
+          </fast-radio-group>
+
+          ${this.themeColorRadioValue === 'custom'
+            ? html`
+              <input type="color" id="bg-custom-color" .value=${value}
+                @change=${this.handleThemeColorInputChange} />
+              `
+            : undefined}
+        </div>
+        
       </div>
     `;
   }
@@ -827,13 +861,25 @@ export class AppManifest extends LitElement {
   }
 
   handleBackgroundRadioChange(event: CustomEvent) {
-    const value: BackgroundColorRadioValues = (<HTMLInputElement>event.target)
-      .value as BackgroundColorRadioValues;
+    const value: ColorRadioValues = (<HTMLInputElement>event.target)
+      .value as ColorRadioValues;
     this.backgroundColorRadioValue = value;
 
     if (value !== 'custom' && this.manifest) {
       this.updateManifest({
-        themeColor: value,
+        background_color: value,
+      });
+    }
+  }
+
+  handleThemeRadioChange(event: CustomEvent) {
+    const value: ColorRadioValues = (<HTMLInputElement>event.target)
+      .value as ColorRadioValues;
+    this.themeColorRadioValue = value;
+
+    if (value !== 'custom' && this.manifest) {
+      this.updateManifest({
+        theme_color: value,
       });
     }
   }
@@ -843,9 +889,39 @@ export class AppManifest extends LitElement {
       const value = (<HTMLInputElement>event.target).value;
 
       this.updateManifest({
-        themeColor: value,
+        background_color: value,
       });
     }
+  }
+
+  handleThemeColorInputChange(event: CustomEvent) {
+    if (this.manifest) {
+      const value = (<HTMLInputElement>event.target).value;
+
+      this.updateManifest({
+        theme_color: value,
+      });
+    }
+  }
+
+  setBackgroundColorRadio() {
+    if (!this.manifest?.background_color || this.manifest?.background_color === 'none') {
+      return 'none';
+    } else if (this.manifest?.background_color === 'transparent') {
+      return 'transparent';
+    }
+
+    return 'custom';
+  }
+
+  setThemeColorRadio() {
+    if (!this.manifest?.theme_color || this.manifest?.theme_color === 'none') {
+      return 'none';
+    } else if (this.manifest?.theme_color === 'transparent') {
+      return 'transparent';
+    }
+
+    return 'custom';
   }
 
   async handleModalInputFileChange(evt: CustomEvent<FileInputDetails>) {
@@ -986,16 +1062,6 @@ export class AppManifest extends LitElement {
       !this.screenshotListValid.includes(false) &&
       !this.screenshotList.includes(undefined)
     );
-  }
-
-  setBackgroundColorRadio() {
-    if (!this.manifest?.theme_color || this.manifest?.theme_color === 'none') {
-      return 'none';
-    } else if (this.manifest?.theme_color === 'transparent') {
-      return 'transparent';
-    }
-
-    return 'custom';
   }
 
   handleImageUrl(icon: Icon) {

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -122,6 +122,12 @@ export class AppManifest extends LitElement {
       fastMenuCss,
       fastRadioCss,
       css`
+        .custom-color-block {
+          display: flex;
+          flex-direction: column;
+          font-weight: bold;
+        }
+
         app-button,
         loading-button::part(underlying-button) {
           margin-top: 8px;
@@ -145,8 +151,7 @@ export class AppManifest extends LitElement {
           box-shadow: none;
         }
 
-        #bg-custom-color {
-          margin-left: 32px;
+        #bg-custom-color, #theme-custom-color {
           width: 8em;
         }
 
@@ -693,8 +698,11 @@ export class AppManifest extends LitElement {
 
           ${this.backgroundColorRadioValue === 'custom'
             ? html`
-              <input type="color" id="bg-custom-color" .value=${value}
-                @change=${this.handleBackgroundColorInputChange} />
+              <div class="custom-color-block">
+                <label for="bg-custom-color">Custom Color</label>
+                <input type="color" id="bg-custom-color" .value=${value}
+                  @change=${this.handleBackgroundColorInputChange} />
+              </div>
               `
             : undefined}
         </div>
@@ -716,8 +724,11 @@ export class AppManifest extends LitElement {
 
           ${this.themeColorRadioValue === 'custom'
             ? html`
-              <input type="color" id="bg-custom-color" .value=${value}
-                @change=${this.handleThemeColorInputChange} />
+              <div class="custom-color-block">
+                <label for="theme-custom-color">Custom Color</label>
+                <input type="color" id="theme-custom-color" .value=${value}
+                  @change=${this.handleThemeColorInputChange} />
+              </div>
               `
             : undefined}
         </div>


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The color picker being used for the background color was just a standard HTML input. Also, I noticed that we had the background color input but not the theme color input.

## Describe the new behavior?
We now use `input type="color"` so that we get the nice Chromium color pickers.  Also added the theme_color input and finally fixed a bug with the actual updating of the colors in the manifest.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
