### PR TITLE
fix(): dont show download button until there is actually something to…

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -509,16 +509,18 @@ export class AppManifest extends LitElement {
               class="show-sm"
               .images=${this.iconSrcListParse()}
             ></app-gallery>
-            <loading-button
-              class="hidden-sm"
-              appearance="outline"
-              ?loading=${this.awaitRequest}
-              ?disabled=${this.manifest && this.manifest.icons
-                ? this.manifest.icons.length > 0
-                : false}
-              @click=${this.downloadIcons}
-              >Download</loading-button
-            >
+
+            ${this.manifest &&
+            this.manifest.icons &&
+            this.manifest.icons.length > 0
+              ? html`<loading-button
+                  class="hidden-sm"
+                  appearance="outline"
+                  ?loading=${this.awaitRequest}
+                  @click=${this.downloadIcons}
+                  >Download</loading-button
+                >`
+              : null}
           </div>
           <div class="screenshots">
             <div class="screenshots-header">


### PR DESCRIPTION
… download

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Download button was shown when there were no images to download yet.

## Describe the new behavior?
We now only show the download button once there is something to download.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
