### PR TITLE
chore(): remove start_url input from windows form

### DIFF
--- a/src/script/components/windows-form.ts
+++ b/src/script/components/windows-form.ts
@@ -413,33 +413,6 @@ export class WindowsForm extends LitElement {
                 </div>
 
                 <div class="form-group">
-                  <label for="windowsStartUrlInput">
-                    Start URL
-                    <i
-                      class="fas fa-info-circle"
-                      title="Optional. The preferred URL that should be loaded when the user launches the web app. Windows will use this to determine your app's identity, so this value should not change between releases of your app. This can be an absolute or relative path."
-                      aria-label="Optional. The preferred URL that should be loaded when the user launches the web app. Windows will use this to determine your app's identity, so this value should not change between releases of your app. This can be an absolute or relative path."
-                      role="definition"
-                    ></i>
-
-                    ${tooltip(
-                      'windows-start-url',
-                      "Optional. The preferred URL that should be loaded when the user launches the web app. Windows will use this to determine your app's identity, so this value should not change between releases of your app. This can be an absolute or relative path."
-                    )}
-                  </label>
-                  <fast-text-field
-                    type="url"
-                    class="form-control"
-                    id="windowsStartUrlInput"
-                    placeholder="https://mysite.com/startpoint.html"
-                    .value="${this.default_options
-                      ? this.default_options.manifest?.start_url
-                      : '/'}"
-                    name="startUrl"
-                  ></fast-text-field>
-                </div>
-
-                <div class="form-group">
                   <label for="windowsIconUrlInput">
                     <a
                       href="https://github.com/pwa-builder/pwabuilder-windows-chromium-docs/blob/master/image-recommendations.md"


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Removes the start_url input from the Windows form as requested in a bug in ADO.

## Describe the new behavior?
The start_url input is now not in the Windows form.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
