### PR TITLE
fix(): tooltips do not get cut off

### DIFF
--- a/src/script/components/tooltip.ts
+++ b/src/script/components/tooltip.ts
@@ -8,6 +8,18 @@ function createTooltipId() {
   return 'tooltip-num-' + current;
 }
 
+function openTooltip(ev: MouseEvent, tooltipEl: HTMLElement) {
+  // the style length check looks non-ideal at first
+  // but the DOM api is just not great here in the fact that
+  // if an elemenet does not have the style.top property
+  // initialized yet, its an empty string instead of undefined.
+  // This code is here to throttle style application as multiple hover events
+  // can fire within seconds of each other causing "jumping" in the UI.
+  if (tooltipEl && ev && tooltipEl.style.top.length === 0) {
+    tooltipEl.style.top = `${ev.clientY.toString()}px`;
+  }
+}
+
 export function tooltip(buttonId: string, text: string, url?: string) {
   const tooltipId = createTooltipId();
 
@@ -17,6 +29,7 @@ export function tooltip(buttonId: string, text: string, url?: string) {
       class="tooltip"
       appearance="stealth"
       aria-labelledby="${tooltipId}"
+      @mouseover="${($event) => openTooltip($event, $event.currentTarget.querySelector('.tooltip-text'))}"
     >
       <img
         src="assets/images/help-outline.svg"
@@ -70,7 +83,7 @@ export const styles = css`
     background-color: var(--tooltip-background-color);
     padding: 8px;
     border-radius: 6px;
-    position: relative;
+    position: absolute;
     z-index: 1;
     text-align: center;
 


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Tooltips were getting cut off because they were on a "lower" layer than the surrounding modal.

## Describe the new behavior?
Tooltips are now "position: absolute" to show above the modal layer with a tiny bit of JavaScript to ensure that they tooltips are positioned correctly (with the position being set to absolute we then need to handle positioning the element ourselves).

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
