### PR TITLE
fix(): make sure classic version input is passed when generating

### DIFF
--- a/src/script/services/publish/windows-publish.ts
+++ b/src/script/services/publish/windows-publish.ts
@@ -163,7 +163,7 @@ export async function createWindowsPackageOptionsFromForm(
       generateModernPackage: true,
       classicPackage: {
         generate: true,
-        version: '1.0.0',
+        version: form.classicVersion.value || '1.0.0',
         url: form.url.value || getURL(),
       },
       edgeHtmlPackage: {


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The windows package classic version was only using the default value, not the value the user put in the form.

## Describe the new behavior?
We now use the form value.x

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
