### PR TITLE
fix(): cannot scroll the page when a modal is open

### DIFF
--- a/src/script/components/app-modal.ts
+++ b/src/script/components/app-modal.ts
@@ -4,6 +4,8 @@ import { customElement, property } from 'lit/decorators.js';
 import { ModalCloseEvent } from '../utils/interfaces';
 import { smallBreakPoint } from '../utils/css/breakpoints';
 
+import { turnOffScroll, turnOnScroll } from '../utils/dom-utils';
+
 //@ts-ignore
 import ModalStyles from '../../../styles/modal-styles.css';
 
@@ -134,10 +136,6 @@ export class AppModal extends LitElement {
 
   constructor() {
     super();
-
-    this.addEventListener('scroll', (e: Event) => {
-      console.log('scroll', e);
-    });
   }
 
   firstUpdated() {
@@ -178,6 +176,20 @@ export class AppModal extends LitElement {
     }
   }
 
+  updated(changedProperties: Map<string, any>) {
+    if (changedProperties.has('open')) {
+      if (changedProperties.get('open') === false) {
+        // modal is open 
+        // (check above can be confusing at first glance so explaning here)
+        turnOffScroll();
+      }
+      else {
+        // modal has been closed
+        turnOnScroll();
+      }
+    }
+  }
+
   async close() {
     if (this.modalAni && this.backgroundAni) {
       this.modalAni.reverse();
@@ -202,6 +214,10 @@ export class AppModal extends LitElement {
         bubbles: true,
       })
     );
+
+    // just to ensure scrolling gets turned back on
+    // when the modal is closed
+    turnOnScroll();
   }
 
   render() {

--- a/src/script/utils/dom-utils.ts
+++ b/src/script/utils/dom-utils.ts
@@ -1,0 +1,7 @@
+export function turnOffScroll() {
+  document.documentElement.style.overflowY = "hidden";
+}
+
+export function turnOnScroll() {
+  document.documentElement.style.overflowY = "initial";
+}


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
When a modal was open, if you scrolled (such as you may need to do with the Windows or Android modals on the publish page, you could scroll the page underneath the modal.

## Describe the new behavior?
This PR does what I've done with modals before, which is to set `overflowY` to hidden on the rootElement of the page (which will always be the html element in a normal browser context) to turn off scrolling and then set it back to initial once the modal is closed to turn on normal scrolling again.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
