### PR TITLE
fix(): lang input UX updates

### DIFF
--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -6,6 +6,11 @@ export type langType = {
   name: string
 }
 
+export type langCodes = {
+  formatted: string,
+  code: string
+}
+
 function localization() {
   // TODO flesh out if we localize
   return english;
@@ -13,6 +18,6 @@ function localization() {
 
 export const localeStrings = localization();
 
-export const languageCodes = lang.map((it: langType) => {
+export const languageCodes: Array<langCodes> = lang.map((it: langType) => {
   return { formatted: it.name, code: it.code };
 });

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -13,4 +13,6 @@ function localization() {
 
 export const localeStrings = localization();
 
-export const languageCodes = lang.map((it: langType) => it.code);
+export const languageCodes = lang.map((it: langType) => {
+  return { formatted: it.name, code: it.code };
+});

--- a/src/script/components/dropdown-menu.ts
+++ b/src/script/components/dropdown-menu.ts
@@ -10,7 +10,7 @@ const dropdownComponentClass = 'dropdown-component';
 @customElement('app-dropdown')
 export class DropdownMenu extends LitElement {
   @property({ type: Boolean }) openMenu = false;
-  @property({ type: Array }) menuItems: Array<string> = [];
+  @property({ type: Array }) menuItems: Array<string> | Array<{}> = [];
   @property({ type: Number }) selectedIndex = 0;
 
   @property({ attribute: 'static-text', type: String })
@@ -40,6 +40,10 @@ export class DropdownMenu extends LitElement {
 
         .dropdown-component {
           z-index: 20;
+
+          max-height: 15em;
+          overflow-y: scroll;
+          overflow-x: hidden;
         }
 
         fast-button::part(control) {
@@ -114,6 +118,7 @@ export class DropdownMenu extends LitElement {
               : html`<ion-icon name="chevron-up-outline"></ion-icon>`}
           </span>
         </fast-button>
+
         <fast-menu
           class="${classMap({
             'menu': true,
@@ -138,7 +143,7 @@ export class DropdownMenu extends LitElement {
                     <ion-icon name="checkmark-outline"></ion-icon>
                   </span> `
                 : undefined}
-              <span>${item}</span>
+              <span>${item.formatted || item}</span>
             </fast-menu-item>`;
           })}
         </fast-menu>
@@ -151,7 +156,7 @@ export class DropdownMenu extends LitElement {
       return this.staticButtonText;
     }
 
-    return this.menuItems[this.selectedIndex];
+    return (this.menuItems[this.selectedIndex] as any)?.formatted ? (this.menuItems[this.selectedIndex] as any).formatted : this.menuItems[this.selectedIndex];
   }
 
   clickMenuButton() {

--- a/src/script/components/dropdown-menu.ts
+++ b/src/script/components/dropdown-menu.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { langCodes } from '../../locales';
 import { fastMenuCss } from '../utils/css/fast-elements';
 import { Lazy } from '../utils/interfaces';
 import { KeyboardKeys } from '../utils/keyboard';
@@ -10,7 +11,7 @@ const dropdownComponentClass = 'dropdown-component';
 @customElement('app-dropdown')
 export class DropdownMenu extends LitElement {
   @property({ type: Boolean }) openMenu = false;
-  @property({ type: Array }) menuItems: Array<string> | Array<{}> = [];
+  @property({ type: Array }) menuItems: Array<string> | Array<langCodes> = [];
   @property({ type: Number }) selectedIndex = 0;
 
   @property({ attribute: 'static-text', type: String })

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
-import { localeStrings, languageCodes } from '../../locales';
+import { localeStrings, languageCodes, langCodes } from '../../locales';
 
 //@ts-ignore
 import ErrorStyles from '../../../styles/error-styles.css';
@@ -643,15 +643,18 @@ export class AppManifest extends LitElement {
         let index = item.menuItems.indexOf(value);
 
         if (index === -1) {
-          const find = item.menuItems.filter(i => i.code?.startsWith(value))[0];
-          index = item.menuItems.indexOf(find);
+          (item.menuItems as Array<langCodes>).find((value, index) => {
+            value.code?.startsWith(value.code);
+
+            index = index;
+          });
         }
 
         field = html`
           <app-dropdown
             .menuItems=${item.menuItems}
             selectedIndex=${index}
-            data-field="lang"
+            data-field=${item.entry}
             @change=${this.handleInputChange}
           >
           </app-dropdown>
@@ -860,7 +863,7 @@ export class AppManifest extends LitElement {
     if (this.manifest && fieldName && this.manifest[fieldName]) {
       // to-do Justin: Figure out why typescript is casting input.value to a string
       // automatically and how to cast to a better type that will actually compile
-      this.updateManifest({ [fieldName]: (input.value as any).code ? (input.value as any).code : input.value });
+      this.updateManifest({ [fieldName]: (input.value as any).code || input.value });
     }
   }
 
@@ -1099,7 +1102,7 @@ interface InputItem {
   tooltipText: string;
   entry: string;
   type: 'input' | 'select' | 'radios';
-  menuItems?: Array<string> | Array<any>;
+  menuItems?: Array<langCodes> | Array<string>;
 }
 
 const infoItems: Array<InputItem> = [

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -608,7 +608,6 @@ export class AppManifest extends LitElement {
   }
 
   renderInfoItems() {
-    console.log('infoItems', infoItems);
     return infoItems.map(item => {
       const value = this.manifest
         ? (this.manifest[item.entry] as string)
@@ -644,7 +643,7 @@ export class AppManifest extends LitElement {
         let index = item.menuItems.indexOf(value);
 
         if (index === -1) {
-          const find = item.menuItems.filter(i => i.startsWith(value))[0];
+          const find = item.menuItems.filter(i => i.code?.startsWith(value))[0];
           index = item.menuItems.indexOf(find);
         }
 
@@ -652,6 +651,7 @@ export class AppManifest extends LitElement {
           <app-dropdown
             .menuItems=${item.menuItems}
             selectedIndex=${index}
+            data-field="lang"
             @change=${this.handleInputChange}
           >
           </app-dropdown>
@@ -857,10 +857,10 @@ export class AppManifest extends LitElement {
     const input = <HTMLInputElement | HTMLSelectElement>event.target;
     const fieldName = input.dataset['field'];
 
-    console.log('input.value', input.value, 'fieldName', fieldName);
-
     if (this.manifest && fieldName && this.manifest[fieldName]) {
-      this.updateManifest({ [fieldName]: input.value });
+      // to-do Justin: Figure out why typescript is casting input.value to a string
+      // automatically and how to cast to a better type that will actually compile
+      this.updateManifest({ [fieldName]: (input.value as any).code ? (input.value as any).code : input.value });
     }
   }
 
@@ -1099,7 +1099,7 @@ interface InputItem {
   tooltipText: string;
   entry: string;
   type: 'input' | 'select' | 'radios';
-  menuItems?: Array<string>;
+  menuItems?: Array<string> | Array<any>;
 }
 
 const infoItems: Array<InputItem> = [


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
Other... Please describe: UX Update


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Previously, the language input had a few design / ux problems. For one, the dropdown had no max-height, so for the language input it ended up being very large and going off the screen. Secondly, the dropdown only showed the language codes, not something that was easily "human readable".

## Describe the new behavior?
The language dropdown now shows the actual names of the languages but still updates the manifest with the correct value (the language code). The dropdown also now has a max-height + some overflow CSS, preventing it from rendering off screen. I also tested the other dropdowns in this component to be sure I didnt break existing behavior, and I didnt.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
