### PR TITLE
fix(): dont show upload button until file is ready

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -500,7 +500,7 @@ export class AppManifest extends LitElement {
               <app-modal
                 modalId="uploadModal"
                 title="Upload information"
-                body="This is or uploading icons"
+                body="Choose an Icon to upload. For the best results, we recommend choosing a 512x512 size icon."
                 ?open=${this.uploadModalOpen}
                 @app-modal-close=${this.uploadModalClose}
               >
@@ -508,12 +508,12 @@ export class AppManifest extends LitElement {
                   ${this.renderModalInput()}
                 </form>
                 <div slot="modal-actions">
-                  <loading-button
+                  ${this.uploadImageObjectUrl ? html`<loading-button
                     @click=${this.handleIconFileUpload}
                     ?disabled=${this.generateIconButtonDisabled}
                     ?loading=${this.awaitRequest}
                     >Upload</loading-button
-                  >
+                  >` : null}
                 </div>
               </app-modal>
             </div>


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The upload button was shown even before the file was chosen by the user (it was shown as disabled).

## Describe the new behavior?
We now do not render the upload button until the file is actually chosen.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
