### PR TITLE
fix(ux): test package button has tooltip + change generate to store p…

### DIFF
--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -31,7 +31,7 @@ import {
 } from '../services/publish/publish-checks';
 import { generatePackage } from '../services/publish';
 import { getReportErrorUrl } from '../utils/error';
-
+import { tooltip, styles as ToolTipStyles } from '../components/tooltip';
 @customElement('app-publish')
 export class AppPublish extends LitElement {
   @state() errored = false;
@@ -68,6 +68,7 @@ export class AppPublish extends LitElement {
     return [
       style,
       fastAnchorCss,
+      ToolTipStyles,
       css`
         .header {
           padding: 1rem 3rem;
@@ -230,6 +231,39 @@ export class AppPublish extends LitElement {
         #actions app-button {
           margin-right: 0;
           margin-top: 8px;
+        }
+
+        .tooltip {
+          height: 16px;
+          width: 16px;
+        }
+
+        #hover-tooltip {
+          display: none;
+
+          position: relative;
+
+          flex-direction: column;
+          justify-content: space-around;
+
+          padding: 8px;
+          border-radius: 6px;
+          position: absolute;
+          z-index: 1;
+
+          white-space: break-spaces;
+          width: 14em;
+
+          background: var(--font-color);
+          right: 6em;
+
+          color: #fff;
+          text-decoration: none;
+          font-weight: initial;
+        }
+
+        #test-package-button:hover #hover-tooltip {
+          display: flex;
         }
       `,
       xxxLargeBreakPoint(
@@ -530,15 +564,25 @@ export class AppPublish extends LitElement {
                   <app-button
                     class="navigation"
                     @click="${() => this.showWindowsOptionsModal()}"
-                    >Generate</app-button
+                    >Store Package</app-button
                   >
-                  <loading-button
-                    class="navigation secondary"
-                    ?loading=${this.generating}
-                    id="test-package-button"
-                    @click="${() => this.generate('windows')}"
-                    >Test Package</loading-button
-                  >
+
+                  <div>
+                    <loading-button
+                      class="navigation secondary"
+                      ?loading=${this.generating}
+                      id="test-package-button"
+                      @click="${() => this.generate('windows')}"
+                      >Test Package
+
+                      <!-- todo after release: refactor this into a <hover-tooltip /> component -->
+                      <a
+                        id="hover-tooltip"
+                        target="_blank"
+                        href="https://github.com/pwa-builder/pwabuilder-windows-chromium-docs/blob/master/next-steps.md#1-test-your-app-on-your-windows-machine"
+                      >Generate a package you can use to test your app on your Windows Device before going to the Microsoft Store.</a>
+                    </loading-button>
+                  </div>
                 `
               : null}
             ${platform.title.toLowerCase() === 'android'
@@ -546,7 +590,7 @@ export class AppPublish extends LitElement {
                   <app-button
                     class="navigation"
                     @click="${() => this.showAndroidOptionsModal()}"
-                    >Generate</app-button
+                    >Store Package</app-button
                   >
                 `
               : null}


### PR DESCRIPTION
…ackage

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
 Other... Please describe: UX 


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The store package and generate buttons were not clear in their intent.

## Describe the new behavior?
The Test Package button now has a tooltip as requested in ADO (text shown in screenshot below, links to our docs about the test package) and the `generate` button has been changed to Store Package.

![image](https://user-images.githubusercontent.com/8823093/121587984-3abe1c80-c9ea-11eb-9f02-82d469fc6fbe.png)

![image](https://user-images.githubusercontent.com/8823093/121588017-43165780-c9ea-11eb-82d1-2d66e9dfb4f4.png)


## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
