### PR TITLE
feat(): add analytics to all page actions + all page navs

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,9 @@
         }
       };
 
-      awa.init(config);
+      if (window.awa) {
+        window.awa.init(config);
+      }
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,11 @@
     <meta name="apple-mobile-web-app-title" content="PWABuilder" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
 
+    <!-- for analytics -->
+    <meta name="ms.appid" content="PWABuilder">
+
+    <link rel="preconnect" href="https://web.vortex.data.microsoft.com">
+
     <!-- Imports an icon to represent the document. -->
     <link rel="icon" href="assets/icons/icon_24.png" type="image/x-icon" />
 
@@ -69,5 +74,17 @@
       nomodule=""
       src="https://unpkg.com/ionicons@5.2.3/dist/ionicons/ionicons.js"
     ></script>
+
+    <!-- for analytics -->
+    <script src="https://az725175.vo.msecnd.net/scripts/jsll-4.js"></script>
+    <script>
+      const config = {
+        coreData: {
+          appId: "PWABuilder"
+        }
+      };
+
+      awa.init(config);
+    </script>
   </body>
 </html>

--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -16,7 +16,7 @@ import { AndroidApkOptions } from '../utils/android-validation';
 
 import { smallBreakPoint, xxLargeBreakPoint } from '../utils/css/breakpoints';
 import { Manifest } from '../utils/interfaces';
-import { ChangeEvent } from 'rollup';
+import { capturePageAction } from '../utils/analytics';
 
 @customElement('android-form')
 export class AndroidForm extends LitElement {
@@ -112,6 +112,12 @@ export class AndroidForm extends LitElement {
         bubbles: true,
       })
     );
+
+    capturePageAction({
+      pageName: 'android-form-used',
+      uri: `${location.pathname}`,
+      pageHeight: window.innerHeight
+    });
   }
 
   toggleSettings(settingsToggleValue: 'basic' | 'advanced') {
@@ -122,6 +128,12 @@ export class AndroidForm extends LitElement {
     } else {
       this.show_adv = false;
     }
+
+    capturePageAction({
+      pageName: 'android-settings-toggled',
+      uri: `${location.pathname}`,
+      pageHeight: window.innerHeight
+    });
   }
 
   opened(targetEl: EventTarget | null) {

--- a/src/script/components/code-editor.ts
+++ b/src/script/components/code-editor.ts
@@ -14,6 +14,7 @@ import {
 import { increment } from '../utils/id';
 
 import "./app-button";
+import { capturePageAction } from '../utils/analytics';
 
 @customElement('code-editor')
 export class CodeEditor extends LitElement {
@@ -84,6 +85,12 @@ export class CodeEditor extends LitElement {
         await navigator.clipboard.writeText(doc.toString());
         this.copyText = "Copied";
         this.copied = true;
+
+        capturePageAction({
+          pageName: "manifest-copied",
+          uri: location.pathname,
+          pageHeight: window.innerHeight
+        });
       }
       catch(err) {
         // We should never really end up here but just in case

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -63,6 +63,7 @@ import {
   dispatchEvent as editorDispatchEvent,
   updateStateField,
 } from '../utils/codemirror';
+import { capturePageAction } from '../utils/analytics';
 
 type ColorRadioValues = 'none' | 'transparent' | 'custom';
 
@@ -1078,6 +1079,12 @@ export class AppManifest extends LitElement {
     try {
       if (this.manifest && this.manifest.icons) {
         await generateAndDownloadIconZip(this.manifest.icons);
+
+        capturePageAction({
+          pageName: "generate-icons",
+          uri: location.pathname,
+          pageHeight: window.innerHeight
+        });
       }
     } catch (e) {
       console.error(e);
@@ -1094,6 +1101,12 @@ export class AppManifest extends LitElement {
         // to-do: take another type look at this
         // @ts-ignore
         await generateScreenshots(this.screenshotList);
+
+        capturePageAction({
+          pageName: "generate-screenshots",
+          uri: location.pathname,
+          pageHeight: window.innerHeight
+        });
       }
     } catch (e) {
       console.error(e);

--- a/src/script/components/sw-picker.ts
+++ b/src/script/components/sw-picker.ts
@@ -11,6 +11,7 @@ import '../components/app-button';
 
 //@ts-ignore
 import style from '../../../styles/list-defaults.css';
+import { capturePageAction } from '../utils/analytics';
 
 interface ServiceWorkerChoice {
   id: number;
@@ -134,6 +135,12 @@ export class SWPicker extends LitElement {
 
     if (this.chosenSW) {
       chooseServiceWorker(this.chosenSW);
+
+      capturePageAction({
+        pageName: "chosen-service-worker",
+        uri: `${location.pathname}/?serviceWorker=${this.chosenSW}`,
+        pageHeight: window.innerHeight
+      });
     }
   }
 

--- a/src/script/components/windows-form.ts
+++ b/src/script/components/windows-form.ts
@@ -15,6 +15,7 @@ import { createWindowsPackageOptionsFromManifest } from '../services/publish/win
 
 import { smallBreakPoint, xxLargeBreakPoint } from '../utils/css/breakpoints';
 import { WindowsPackageOptions } from '../utils/win-validation';
+import { capturePageAction } from '../utils/analytics';
 
 @customElement('windows-form')
 export class WindowsForm extends LitElement {
@@ -88,6 +89,12 @@ export class WindowsForm extends LitElement {
         bubbles: true,
       })
     );
+
+    capturePageAction({
+      pageName: 'windows-form-used',
+      uri: `${location.pathname}`,
+      pageHeight: window.innerHeight
+    });
   }
 
   toggleSettings(settingsToggleValue: 'basic' | 'advanced') {
@@ -98,6 +105,12 @@ export class WindowsForm extends LitElement {
     } else {
       this.show_adv = false;
     }
+
+    capturePageAction({
+      pageName: 'windows-settings-toggled',
+      uri: `${location.pathname}`,
+      pageHeight: window.innerHeight
+    });
   }
 
   opened(targetEl: EventTarget | null) {

--- a/src/script/pages/app-basepack.ts
+++ b/src/script/pages/app-basepack.ts
@@ -29,6 +29,7 @@ import { Router } from '@vaadin/router';
 import { getURL } from '../services/app-info';
 
 import { localeStrings } from '../../locales';
+import { capturePageAction } from '../utils/analytics';
 
 @customElement('app-basepack')
 export class AppBasePack extends LitElement {
@@ -244,6 +245,12 @@ export class AppBasePack extends LitElement {
     }
 
     this.loading = false;
+
+    capturePageAction({
+      pageName: "base-package-generated",
+      uri: `${location.pathname}`,
+      pageHeight: window.innerHeight
+    });
   }
 
   async download() {
@@ -254,6 +261,12 @@ export class AppBasePack extends LitElement {
       });
 
       this.blob = undefined;
+
+      capturePageAction({
+        pageName: "base-package-downloaded",
+        uri: `${location.pathname}`,
+        pageHeight: window.innerHeight
+      });
     }
   }
 
@@ -268,6 +281,12 @@ export class AppBasePack extends LitElement {
 
     if (site) {
       Router.go(`/testing?site=${site}`);
+
+      capturePageAction({
+        pageName: "base-package-retest",
+        uri: `/testing?site=${site}`,
+        pageHeight: window.innerHeight
+      });
     }
   }
 

--- a/src/script/pages/app-congrats.ts
+++ b/src/script/pages/app-congrats.ts
@@ -29,6 +29,7 @@ import { fileSave } from 'browser-fs-access';
 import { Router } from '@vaadin/router';
 import { generatePackage, platform } from '../services/publish';
 import { BlogPost, allPosts } from '../services/blog';
+import { capturePageAction } from '../utils/analytics';
 
 @customElement('app-congrats')
 export class AppCongrats extends LitElement {
@@ -500,6 +501,12 @@ export class AppCongrats extends LitElement {
       this.generating = false;
       this.open_android_options = false;
       this.open_windows_options = false;
+
+      capturePageAction({
+        pageName: `${type}-generated-from-congrats`,
+        uri: location.pathname,
+        pageHeight: window.innerHeight
+      });
     } catch (err) {
       console.error(err);
 
@@ -516,6 +523,12 @@ export class AppCongrats extends LitElement {
 
       this.blob = undefined;
       this.testBlob = undefined;
+
+      capturePageAction({
+        pageName: `${this.blob ? 'store' : 'test'}-package-downloaded-congrats`,
+        uri: `${location.pathname}`,
+        pageHeight: window.innerHeight
+      });
     }
   }
 

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -29,6 +29,7 @@ import { Router } from '@vaadin/router';
 import { getProgress, getURL, setProgress } from '../services/app-info';
 import { Lazy, ProgressList, Status } from '../utils/interfaces';
 import { fetchManifest } from '../services/manifest';
+import { capturePageAction } from '../utils/analytics';
 
 @customElement('app-home')
 export class AppHome extends LitElement {
@@ -267,6 +268,12 @@ export class AppHome extends LitElement {
     inputEvent.preventDefault();
 
     await this.doTest();
+
+    capturePageAction({
+      pageName: `test-started-${this.siteURL}`,
+      uri: `${location.pathname}`,
+      pageHeight: window.innerHeight
+    });
   }
 
   async doTest() {
@@ -297,6 +304,12 @@ export class AppHome extends LitElement {
           if (goodURL !== undefined) {
             Router.go(`/testing?site=${goodURL}`);
           }
+
+          capturePageAction({
+            pageName: `is-pwa-${goodURL}`,
+            uri: `${location.pathname}`,
+            pageHeight: window.innerHeight
+          });
         } catch (err) {
           // couldnt get manifest
           // continue forward with zeroed out results
@@ -311,6 +324,12 @@ export class AppHome extends LitElement {
           if (goodURL !== undefined) {
             Router.go(`/testing?site=${goodURL}`);
           }
+
+          capturePageAction({
+            pageName: `not-pwa-${goodURL}`,
+            uri: `${location.pathname}`,
+            pageHeight: window.innerHeight
+          });
         }
       } else {
         this.errorMessage = localeStrings.input.home.error.invalidURL;

--- a/src/script/pages/app-index.ts
+++ b/src/script/pages/app-index.ts
@@ -6,6 +6,7 @@ import './app-report';
 
 import '../components/app-footer';
 import '../components/app-header';
+import { capturePageView } from '../utils/analytics';
 
 @customElement('app-index')
 export class AppIndex extends LitElement {
@@ -70,8 +71,14 @@ export class AppIndex extends LitElement {
   constructor() {
     super();
 
-    window.addEventListener('vaadin-router-location-changed', () => {
+    window.addEventListener('vaadin-router-location-changed', (ev) => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
+
+      capturePageView({
+        pageName: ev.detail.location.route?.component,
+        uri: ev.detail.location.pathname,
+        pageHeight: window.innerHeight
+      });
     });
   }
 

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -31,6 +31,7 @@ import {
 } from '../services/publish/publish-checks';
 import { generatePackage } from '../services/publish';
 import { getReportErrorUrl } from '../utils/error';
+import { capturePageAction } from '../utils/analytics';
 
 @customElement('app-publish')
 export class AppPublish extends LitElement {
@@ -480,6 +481,12 @@ export class AppPublish extends LitElement {
 
       this.showAlertModal(err, type);
     }
+
+    capturePageAction({
+      pageName: `${type}-package-generated`,
+      uri: `${location.pathname}`,
+      pageHeight: window.innerHeight
+    });
   }
 
   async download() {
@@ -491,6 +498,12 @@ export class AppPublish extends LitElement {
 
       this.blob = undefined;
       this.testBlob = undefined;
+
+      capturePageAction({
+        pageName: `${this.blob ? 'store' : 'test'}-package-downloaded`,
+        uri: `${location.pathname}`,
+        pageHeight: window.innerHeight
+      });
     }
   }
 
@@ -503,14 +516,32 @@ export class AppPublish extends LitElement {
 
   showWindowsOptionsModal() {
     this.open_windows_options = true;
+
+    capturePageAction({
+      pageName: 'windows-settings-opened',
+      uri: `${location.pathname}`,
+      pageHeight: window.innerHeight
+    });
   }
 
   showAndroidOptionsModal() {
     this.open_android_options = true;
+
+    capturePageAction({
+      pageName: 'android-settings-opened',
+      uri: `${location.pathname}`,
+      pageHeight: window.innerHeight
+    });
   }
 
   showSamsungModal() {
     this.open_samsung_modal = true;
+
+    capturePageAction({
+      pageName: 'samsung',
+      uri: `${location.pathname}`,
+      pageHeight: window.innerHeight
+    });
   }
 
   renderContentCards() {

--- a/src/script/pages/app-report.ts
+++ b/src/script/pages/app-report.ts
@@ -20,6 +20,7 @@ import '../components/app-sidebar';
 //@ts-ignore
 import style from '../../../styles/layout-defaults.css';
 import { RawTestResult, ScoreEvent } from '../utils/interfaces';
+import { capturePageAction } from '../utils/analytics';
 
 const possible_messages = {
   overview: {
@@ -238,11 +239,23 @@ export class AppReport extends LitElement {
   openManiOptions() {
     const maniTab = this.shadowRoot?.querySelector('#mani');
     (maniTab as HTMLButtonElement).click();
+
+    capturePageAction({
+      pageName: "manifest-options",
+      uri: location.pathname,
+      pageHeight: window.innerHeight
+    });
   }
 
   openSWOptions() {
     const maniTab = this.shadowRoot?.querySelector('#sw');
     (maniTab as HTMLButtonElement).click();
+
+    capturePageAction({
+      pageName: "service-worker-picker",
+      uri: location.pathname,
+      pageHeight: window.innerHeight
+    });
   }
 
   openOverview() {

--- a/src/script/pages/app-testing.ts
+++ b/src/script/pages/app-testing.ts
@@ -17,6 +17,7 @@ import '../components/app-header';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //@ts-ignore
 import style from '../../../styles/animations.css';
+import { capturePageAction } from '../utils/analytics';
 
 @customElement('app-testing')
 export class AppTesting extends LitElement {
@@ -152,6 +153,12 @@ export class AppTesting extends LitElement {
       this.phrasePager();
 
       await this.runTests(site);
+
+      capturePageAction({
+        pageName: `running-tests-${site}`,
+        uri: `${location.pathname}`,
+        pageHeight: window.innerHeight
+      });
     }
   }
 

--- a/src/script/utils/analytics.ts
+++ b/src/script/utils/analytics.ts
@@ -1,0 +1,25 @@
+/**
+ * const exampleValues = {
+      isAuto: false,
+      behavior: 0,
+      uri: window.location.href,
+      pageName: "featuresPage",
+      pageHeight: window.innerHeight
+    };
+ */
+
+export interface AnalyticsOptions {
+  isAuto?: boolean,
+  behavior?: number,
+  uri?: string,
+  pageName?: string,
+  pageHeight?: number
+}
+
+export function capturePageView(options: AnalyticsOptions) {
+  (window as any).awa.ct.capturePageView(options);
+}
+
+export function capturePageAction(options: AnalyticsOptions) {
+  (window as any).awa.ct.capturePageAction(options);
+}

--- a/src/script/utils/analytics.ts
+++ b/src/script/utils/analytics.ts
@@ -17,9 +17,13 @@ export interface AnalyticsOptions {
 }
 
 export function capturePageView(options: AnalyticsOptions) {
-  (window as any).awa.ct.capturePageView(options);
+  if ((window as any).awa) {
+    (window as any).awa.ct.capturePageView(options);
+  }
 }
 
 export function capturePageAction(options: AnalyticsOptions) {
-  (window as any).awa.ct.capturePageAction(options);
+  if ((window as any).awa) {
+    (window as any).awa.ct.capturePageAction(options);
+  }
 }


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
No analytics were added to v3 yet, we only had our backend analytics.

## Describe the new behavior?
V3 now has analytics for:
- All page navigations
- All page actions, from starting a test through to creating a package. Also tracks if the user is testing a non-pwa or a PWA.

Key details:
- Setup just like it was in v2, so all the data should be the same
- If you look in the code, it looks like im only sending 3 things, thats because the library sends a bunch of other data (it calls it "coreData") by default. I want to stress here that this is exactly how it works in V2 too.
- The Adobe analytics library gets blocked by the strict privacy mode in Edge, most likely gets blocked in Safari and im assuming in Chrome in certain configurations. This has also always happened with PWABuilder V2 and is not due to anything we can control.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
