### PR TITLE
fix(): pass service worker id when generating base package

### DIFF
--- a/src/script/services/publish/web-publish.ts
+++ b/src/script/services/publish/web-publish.ts
@@ -1,6 +1,7 @@
 import { getGeneratedManifest, getManifest } from "../manifest";
 import { env } from '../../utils/environment';
 import { getURL } from "../app-info";
+import { getChosenServiceWorker } from "../service_worker";
 
 export let web_generated = false;
 
@@ -9,6 +10,7 @@ export async function generateWebPackage() {
     const manifest = await getManifest();
     const genManifest = getGeneratedManifest();
     const url = getURL();
+    const chosenSW = getChosenServiceWorker();
 
     // The web package generator dies when screenshots is null. If detected, set screenshots to empty array.
     const manifestWithScreenshots = manifest ? { ...manifest } : { ...genManifest };
@@ -16,10 +18,20 @@ export async function generateWebPackage() {
     if (!manifestWithScreenshots.screenshots) {
       manifestWithScreenshots.screenshots = [];
     }
-    
+
+    let urlToUse;
+
+    if (chosenSW) {
+      urlToUse = `${env.webPackageGeneratorUrl}?siteUrl=${url
+      }&swId=${chosenSW}&hasServiceWorker=${false}`
+    }
+    else {
+      urlToUse = `${env.webPackageGeneratorUrl}?siteUrl=${url
+      }&hasServiceWorker=${true}`
+    }
+
     const response = await fetch(
-      `${env.webPackageGeneratorUrl}?siteUrl=${url
-      }&hasServiceWorker=${false}`,
+      urlToUse,
       {
         method: "POST",
         body: JSON.stringify(manifestWithScreenshots),


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the new behavior?
I updated the API call to match the updated API that Leo did for the web packaging service. I now pass the id of the chosen Service Worker along in the API call and also make use of the hasServiceWorker param correctly.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
