### PR TITLE
fix(): blog cards are now link tags

### DIFF
--- a/src/script/components/app-card.ts
+++ b/src/script/components/app-card.ts
@@ -27,7 +27,7 @@ export class AppCard extends LitElement {
   @property({ type: String }) description: Lazy<string>;
   @property({ type: String }) date: Lazy<string>;
   @property({ type: String }) linkText: Lazy<string>;
-  @property({ type: String }) linkRoute: Lazy<string>;
+  @property({ type: String }) linkRoute: string;
 
   @property({ type: Boolean }) featured = false;
   @property({ type: Boolean }) shareLink = false;
@@ -353,6 +353,11 @@ export class AppCard extends LitElement {
           color: var(--font-color);
         }
 
+        .blog .card-anchor {
+          text-decoration: none;
+          color: initial;
+        }
+
         fast-badge::part(control) {
           --badge-color-dark: var(--font-color);
           --badge-fill-primary: var(--primary-background-color);
@@ -553,21 +558,23 @@ export class AppCard extends LitElement {
           })}"
           part="card"
         >
-          <div class="img-overlay">
-            <div class="overlay-top">
-              <span class="date">${this.date}</span>
-              ${this.renderShareButton()}
-            </div>
-            <h3>${this.cardTitle}</h3>
-            <p>${this.description}</p>
-            <slot name="overlay"></slot>
+          <a class="card-anchor" .href="${this.linkRoute}" target="_blank" rel="noopener">
+            <div class="img-overlay">
+              <div class="overlay-top">
+                <span class="date">${this.date}</span>
+                ${this.renderShareButton()}
+              </div>
+              <h3>${this.cardTitle}</h3>
+              <p>${this.description}</p>
+              <slot name="overlay"></slot>
 
-            <div class="tag-list">${this.renderTagList()}</div>
-          </div>
-          <img
-            src="${ifDefined(this.imageUrl)}"
-            alt="${this.cardTitle} card header image"
-          />
+              <div class="tag-list">${this.renderTagList()}</div>
+            </div>
+            <img
+              src="${ifDefined(this.imageUrl)}"
+              alt="${this.cardTitle} card header image"
+            />
+          </a>
         </fast-card>
       `;
     }
@@ -588,21 +595,23 @@ export class AppCard extends LitElement {
         })}"
         part="card"
       >
-        <div class="img-overlay">
-          <div class="overlay-top">
-            <span class="date">${this.date}</span>
-            <div class="tag-list">${this.renderTagList()}</div>
-            ${this.renderShareButton()}
+        <a class="card-anchor" .href="${this.linkRoute}" target="_blank" rel="noopener">
+          <div class="img-overlay">
+            <div class="overlay-top">
+              <span class="date">${this.date}</span>
+              <div class="tag-list">${this.renderTagList()}</div>
+              ${this.renderShareButton()}
+            </div>
+            <slot name="overlay"></slot>
           </div>
-          <slot name="overlay"></slot>
-        </div>
-        <img
-          src="${ifDefined(this.imageUrl)}"
-          alt="${this.cardTitle} card header image"
-        />
-        <div class="content">
-          <h3>${this.cardTitle}</h3>
-        </div>
+          <img
+            src="${ifDefined(this.imageUrl)}"
+            alt="${this.cardTitle} card header image"
+          />
+          <div class="content">
+            <h3>${this.cardTitle}</h3>
+          </div>
+        </a>
       </fast-card>
     `;
   }

--- a/src/script/pages/app-congrats.ts
+++ b/src/script/pages/app-congrats.ts
@@ -751,6 +751,7 @@ export class AppCongrats extends LitElement {
                       linkRoute="${this.featuredPost.clickUrl}"
                       .tags=${this.featuredPost.tags}
                       .featured="${this.isFeatured()}"
+                      ?isActionCard="${true}"
                       class="${classMap({
                         blog: true,
                         featured: this.isFeatured(),
@@ -768,6 +769,9 @@ export class AppCongrats extends LitElement {
                             description="${post.description}"
                             class="blog"
                             imageUrl="${post.imageUrl}"
+                            linkText="Read Post"
+                            .linkRoute="${post.clickUrl}"
+                            ?isActionCard="${true}"
                           >
                           </app-card>
                         `;
@@ -777,7 +781,7 @@ export class AppCongrats extends LitElement {
               </div>
 
               <div id="anchor-block">
-                <fast-anchor href="" appearance="hypertext"
+                <fast-anchor href="https://aka.ms/pwabuilderv3" appearance="hypertext"
                   >View more blog posts</fast-anchor
                 >
               </div>


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
Refactoring (no functional changes, no api changes) 
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The blog cards had links passed down in properties but were not using them as a link. Therefore, the idea in the design of the whole card being a clickable link was not working.

## Describe the new behavior?
Each blog card is now a clickable link to the post, with the anchor tag styling reset with a small touch of css.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
