### PR TITLE
refactor(): view more resources button is a link

### DIFF
--- a/src/script/components/resource-hub.ts
+++ b/src/script/components/resource-hub.ts
@@ -104,16 +104,14 @@ export class ResourceHub extends LitElement {
           margin-bottom: 74px;
         }
 
-        .resource-hub-actions app-button {
-          --button-width: 205px;
-        }
-
-        .resource-hub-actions app-button::part(underlying-button) {
+        .resource-hub-actions fast-anchor {
+          width: 205px;
           background-color: white;
           color: var(--font-color);
+          border-radius: var(--button-radius);
         }
 
-        .resource-hub-actions app-button::part(control) {
+        .resource-hub-actions fast-anchor::part(control) {
           font-size: 16px;
           font-weight: var(--font-bold);
         }
@@ -360,7 +358,7 @@ export class ResourceHub extends LitElement {
     if (this.showViewAllButton) {
       return html`
         <div class="resource-hub-actions">
-          <app-button>View all resources</app-button>
+          <fast-anchor appearance="button" href="https://aka.ms/pwabuilderv3" target="_blank" rel="noopener">View all resources</fast-anchor>
         </div>
       `;
     }


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
View More Resources button was a button, not a link.

## Describe the new behavior?
The View More Resources button, still looking like the design specifies, is now a link to the blog aka.ms url David set up.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
