### PR TITLE
chore(): remove preview from Windows platform

### DIFF
--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -31,6 +31,11 @@
     }
   },
   "text": {
+    "publish": {
+      "windows_platform": {
+        "p": "Your download will contain instructions for submitting your app to the Microsoft Store. Your app will be powered by the Chromium-based Edge platform."
+      }
+    },
     "manifest_options": {
       "top_section": {
         "h1": "Manifest"

--- a/src/script/components/windows-form.ts
+++ b/src/script/components/windows-form.ts
@@ -17,6 +17,8 @@ import { smallBreakPoint, xxLargeBreakPoint } from '../utils/css/breakpoints';
 import { WindowsPackageOptions } from '../utils/win-validation';
 import { capturePageAction } from '../utils/analytics';
 
+import { localeStrings } from '../../locales';
+
 @customElement('windows-form')
 export class WindowsForm extends LitElement {
   @property({ type: Boolean }) generating: boolean = false;
@@ -491,9 +493,7 @@ export class WindowsForm extends LitElement {
 
         <div id="form-details-block">
           <p>
-            Your download will contain instructions for submitting your app to
-            the Microsoft Store. Your app will be powered by Chromium-based Edge
-            platform (preview).
+            ${localeStrings.text.publish.windows_platform.p}
           </p>
         </div>
 


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
 Other... Please describe:  text update


## Describe the new behavior?
Removes the preview text from the Windows platform.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
