### PR TITLE
fix(): blog links work on cards

### DIFF
--- a/src/script/components/app-card.ts
+++ b/src/script/components/app-card.ts
@@ -725,6 +725,8 @@ export class AppCard extends LitElement {
   }
 
   route() {
-    this.linkRoute && Router.go(this.linkRoute);
+    if (this.linkRoute) {
+      window.open(this.linkRoute, "_blank")
+    }
   }
 }

--- a/src/script/components/resource-hub.ts
+++ b/src/script/components/resource-hub.ts
@@ -348,6 +348,7 @@ export class ResourceHub extends LitElement {
           cardTitle=${data.title}
           description=${data.description}
           imageUrl=${data.imageUrl}
+          linkRoute=${data.linkUrl}
         >
         </app-card>
       `;


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->
Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The cards in the resource hub on the homepage were not working.

## Describe the new behavior?
These cards now work correctly with the right link.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
