### PR TITLE
V3 - if screenshots array is undefined, use a new array

### DIFF
--- a/src/script/services/icon_generator.ts
+++ b/src/script/services/icon_generator.ts
@@ -46,8 +46,8 @@ export async function generateMissingImagesBase64(config: MissingImagesConfig) {
     });
 
     if (response.ok) {
-      let icons = (await getManifestGuarded()).icons;
-      icons = icons.concat(((await response.json()) as unknown) as Array<Icon>);
+      let icons = (await getManifestGuarded()).icons ?? [];
+      icons = icons.concat((await response.json()) as unknown as Array<Icon>);
 
       updateManifest({
         icons,

--- a/src/script/services/screenshots.ts
+++ b/src/script/services/screenshots.ts
@@ -31,7 +31,8 @@ export async function generateScreenshots(screenshotsList: Array<string>) {
     if (res.ok) {
       const response = (await res.json()) as ScreenshotServiceResponse;
 
-      let screenshots: Array<Icon> = (await getManifestGuarded())?.screenshots;
+      let screenshots: Array<Icon> =
+        (await getManifestGuarded())?.screenshots ?? [];
       screenshots = screenshots.concat(
         response.images.map(image => {
           image.src = 'data:image/png;base64,' + image.src;


### PR DESCRIPTION
## PR Type

- Bugfix

## Describe the current behavior?

- if the user has a manifest but doesn't have the entries for icons or screenshots, there's an exception thrown.

## Describe the new behavior?

- default to an empty array and add it to the manifest

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
