### PR TITLE
fix(): self signing key is passed in correctly

### DIFF
--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -104,10 +104,12 @@ export class AndroidForm extends LitElement {
   }
 
   initGenerate() {
+    console.log('this.file', this.file);
     this.dispatchEvent(
       new CustomEvent('init-android-gen', {
         detail: {
           form: this.form,
+          signingFile: this.file
         },
         composed: true,
         bubbles: true,
@@ -222,7 +224,10 @@ export class AndroidForm extends LitElement {
       }
       // Read it in as a Uint8Array and store it in our signing object.
       const fileReader = new FileReader();
-      fileReader.onload = () => (this.file = fileReader.result as string);
+      fileReader.onload = () => {
+        this.file = fileReader.result as string;
+        return;
+      };
       fileReader.onerror = progressEvent => {
         console.error(
           'Unable to read keystore file',

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -432,7 +432,7 @@ export class AppPublish extends LitElement {
     return localManifest;
   }
 
-  async generate(type: platform, form?: HTMLFormElement) {
+  async generate(type: platform, form?: HTMLFormElement, signingFile?: string) {
     if (type === 'windows') {
       // Final checks for Windows
       if (this.finalChecks) {
@@ -460,6 +460,7 @@ export class AppPublish extends LitElement {
         }
       }
     } else if (type === 'android') {
+      console.log('signingFile', signingFile);
       // Final checks for Android
       if (this.finalChecks) {
         const maniCheck = this.finalChecks.manifest;
@@ -494,8 +495,10 @@ export class AppPublish extends LitElement {
     try {
       this.generating = true;
 
+      console.log('signingFile', signingFile);
+
       
-      const packageData = await generatePackage(type, form);
+      const packageData = await generatePackage(type, form, signingFile);
 
 
       if (packageData) {
@@ -739,7 +742,7 @@ export class AppPublish extends LitElement {
         <android-form
           slot="modal-form"
           .generating=${this.generating}
-          @init-android-gen="${ev => this.generate('android', ev.detail.form)}"
+          @init-android-gen="${ev => this.generate('android', ev.detail.form, ev.detail.signingFile)}"
         ></android-form>
       </app-modal>
 

--- a/src/script/services/publish/android-publish.ts
+++ b/src/script/services/publish/android-publish.ts
@@ -71,7 +71,7 @@ export async function generateAndroidPackage(
   return undefined;
 }
 
-export async function createAndroidPackageOptionsFromForm(form: HTMLFormElement): Promise<AndroidApkOptions> {
+export async function createAndroidPackageOptionsFromForm(form: HTMLFormElement, signingFile?: string): Promise<AndroidApkOptions> {
   const manifest = await getManifest();
   if (!manifest) {
     throw new Error('Could not find the web manifest');
@@ -176,7 +176,7 @@ export async function createAndroidPackageOptionsFromForm(form: HTMLFormElement)
     packageId: form.packageId.value || packageName,
     shortcuts: manifest.shortcuts || [],
     signing: {
-      file: form.file ? form.file.value : null,
+      file: signingFile ? signingFile : null,
       alias: form.alias ? form.alias.value : 'my-key-alias',
       fullName: form.fullName ? form.fullName.value : `${manifest.short_name || manifest.name || 'App'} Admin`,
       organization: form.organization ? form.organization.value : manifest.name || 'PWABuilder',

--- a/src/script/services/publish/index.ts
+++ b/src/script/services/publish/index.ts
@@ -13,7 +13,7 @@ import {
 
 export type platform = 'windows' | 'android' | 'samsung';
 
-export async function generatePackage(type: platform, form?: HTMLFormElement) {
+export async function generatePackage(type: platform, form?: HTMLFormElement, signingFile?: string) {
   switch (type) {
     case 'windows':
       try {
@@ -66,7 +66,7 @@ export async function generatePackage(type: platform, form?: HTMLFormElement) {
     case 'android':
       try {
         if (form) {
-          const androidOptions = await createAndroidPackageOptionsFromForm(form);
+          const androidOptions = await createAndroidPackageOptionsFromForm(form, signingFile);
 
           if (androidOptions) {
             try {


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
If someone was signing a package with their existing signing key the file was not being passed in correctly to the generation process.

## Describe the new behavior?
The signing key file is now passed into the generation process correctly

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
