### PR TITLE
fix(): handle spa routing like azure static web apps did automatically

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,10 +1,18 @@
 const express = require("express");
-const cors = require('cors')
+const cors = require('cors');
+const path = require('path');
 const app = express();
 const port = process.env.PORT || 3000;
 
+const static = path.resolve(__dirname, 'dist');
+const index = path.resolve(static, 'index.html');
+
 app.use(cors());
-app.use(express.static("dist"));
+app.use(express.static(static));
+
+app.get('*', (req, res) => {
+  res.sendFile(index);
+});
 
 app.listen(port, () => {
   console.log("App Running");


### PR DESCRIPTION
Fixes #1848 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Our SPA routing was broken (therefore refreshing on a deeper link than / was breaking). This worked fine when we were on azure static web apps because its handled automatically there, but with an app-service we must have specific code to handle it.

## Describe the new behavior?
Update to the node server to re-route all routes to the index page, like is standard for SPAs.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
