### PR TITLE
Fix for Lit crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "deepmerge": "^4.2.2",
     "downloadjs": "^1.4.7",
     "express": "^4.17.1",
-    "lit": "^2.0.0-rc.1",
+    "lit": "^2.0.0-rc.2",
     "lodash-es": "^4.17.21",
     "workbox-build": "^6.1.5",
     "workbox-core": "^6.1.2",

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -317,7 +317,10 @@ export class AppHome extends LitElement {
         this.errorGettingURL = true;
       }
 
-      this.gettingManifest = false;
+      // HACK: Lit 2.0rc1 crashes on Safari 14 (Mac and iOS) on the following line:
+      // this.gettingManifest = false;
+      // To fix this, we've found that putting that call in a 1ms timeout fixes the issue.
+      setTimeout(() => this.gettingManifest = false, 1);
     }
   }
 


### PR DESCRIPTION
Fixes #1838, where Safari crashes during a Lit render cycle. This is a hacky workaround for now.