### PR TITLE
fix(): do not overwrite user entered URL with the hostname

### DIFF
--- a/src/script/services/app-info.ts
+++ b/src/script/services/app-info.ts
@@ -97,20 +97,6 @@ export function setURL(url: string) {
   }
 }
 
-export function setCanonicalURL(initialURL) {
-  try {
-    const parts = new URL(initialURL);
-    const needed_part = parts.origin;
-
-    if (needed_part) {
-      setURL(needed_part);
-    }
-  }
-  catch(err) {
-    console.error(err);
-  }
-}
-
 export function getURL() {
   const url = sessionStorage.getItem('current_url');
 

--- a/src/script/services/manifest.ts
+++ b/src/script/services/manifest.ts
@@ -10,7 +10,7 @@ import {
   ManifestDetectionResult,
 } from '../utils/interfaces';
 import { cleanUrl } from '../utils/url';
-import { setCanonicalURL, setURL } from './app-info';
+import { setURL } from './app-info';
 
 export const emitter = new EventTarget();
 let manifest: Lazy<Manifest>;
@@ -47,9 +47,6 @@ async function getManifestViaFilePost(
     );
     throw new Error(`Unable to get JSON from ${manifestTestUrl}`);
   }
-
-  setCanonicalURL(responseData.content.url);
-
   return {
     content: responseData.manifestContents,
     format: 'w3c',
@@ -84,8 +81,6 @@ async function getManifestViaHtmlParse(
     throw new Error(`Error fetching from ${manifestTestUrl}`);
   }
   const responseData: ManifestFinderResult = await response.json();
-
-  setCanonicalURL(responseData.manifestUrl);
 
   if (responseData.error || !responseData.manifestContents) {
     console.warn(


### PR DESCRIPTION
Fixes #1859 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
This fixes a regression in V3. With V2, we were using the URL as the user entered it, but in V3 we had code that would set the URL being tested / used to the `new URL(host)` (basically) which is not the URL the user intended to use.

## Describe the new behavior?
We no longer overwrite the URL with `new URL(host)` in our code, instead using the URL as the user entered. I have tested this with multiple apps, including the one in the attached bug.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
