### PR TITLE
fix(): add missing try catch so that error modal shows up in every ca…

### DIFF
--- a/src/script/services/publish/index.ts
+++ b/src/script/services/publish/index.ts
@@ -13,7 +13,11 @@ import {
 
 export type platform = 'windows' | 'android' | 'samsung';
 
-export async function generatePackage(type: platform, form?: HTMLFormElement, signingFile?: string) {
+export async function generatePackage(
+  type: platform,
+  form?: HTMLFormElement,
+  signingFile?: string
+) {
   switch (type) {
     case 'windows':
       try {
@@ -47,15 +51,21 @@ export async function generatePackage(type: platform, form?: HTMLFormElement, si
             const localManifest = await grabBackupManifest();
 
             if (localManifest) {
-              const options = await createWindowsPackageOptionsFromManifest(
-                localManifest
-              );
-              const testBlob = await generateWindowsPackage(options);
+              try {
+                const options = await createWindowsPackageOptionsFromManifest(
+                  localManifest
+                );
+                const testBlob = await generateWindowsPackage(options);
 
-              return {
-                blob: testBlob || null,
-                type: 'test',
-              };
+                return {
+                  blob: testBlob || null,
+                  type: 'test',
+                };
+              } catch (err) {
+                throw new Error(
+                  `Error generating Windows Package from form: ${err}`
+                );
+              }
             }
           }
         }
@@ -66,21 +76,18 @@ export async function generatePackage(type: platform, form?: HTMLFormElement, si
     case 'android':
       try {
         if (form) {
-          const androidOptions = await createAndroidPackageOptionsFromForm(form, signingFile);
+          const androidOptions = await createAndroidPackageOptionsFromForm(
+            form,
+            signingFile
+          );
 
           if (androidOptions) {
-            try {
-              const blob = await generateAndroidPackage(androidOptions, form);
+            const blob = await generateAndroidPackage(androidOptions, form);
 
-              return {
-                blob: blob || null,
-                type: 'store',
-              };
-            }
-            catch (err) {
-              console.error('err generating android from form', err);
-              return err;
-            }
+            return {
+              blob: blob || null,
+              type: 'store',
+            };
           }
         } else {
           try {
@@ -100,24 +107,28 @@ export async function generatePackage(type: platform, form?: HTMLFormElement, si
                 localManifest
               );
 
-              const testBlob = await generateAndroidPackage(androidOptions);
+              try {
+                const testBlob = await generateAndroidPackage(androidOptions);
 
-              return {
-                blob: testBlob || null,
-                type: 'test',
-              };
+                return {
+                  blob: testBlob || null,
+                  type: 'test',
+                };
+              } catch (err) {
+                throw new Error(`Error generating android from form: ${err}`);
+              }
             }
           }
         }
       } catch (err) {
-        return err;
+        throw new Error(`Error generating android from form: ${err}`);
       }
       break;
     case 'samsung':
       console.log('samsung');
       break;
     default:
-      console.error(
+      throw new Error(
         `A platform type must be passed, ${type} is not a valid platform.`
       );
   }


### PR DESCRIPTION
…se when it should

Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The error modal was not showing in every case when it should have.

## Describe the new behavior?
Turns out, this was due to some missing try/catches, the error modal is now showing in cases it didnt before when it should have, such as with the URL in this issue https://github.com/pwa-builder/PWABuilder/issues/1841

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
