### PR TITLE
fix(): error modals no long overflow text over the side

### DIFF
--- a/src/script/components/app-modal.ts
+++ b/src/script/components/app-modal.ts
@@ -73,6 +73,7 @@ export class AppModal extends LitElement implements AppModalElement {
 
         #modal-body {
           text-align: center;
+          width: inherit;
         }
 
         #modal-body p {


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Text was overflowing the side of the error modal if it was a longer block of text.

## Describe the new behavior?
Text no longer overflows but instead just scrolls 
![image](https://user-images.githubusercontent.com/8823093/123867878-c9380680-d8e3-11eb-9f77-66f06247532c.png)


## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
