### PR TITLE
refactor(): all new windows package form validation using the built in html5 form val…

### DIFF
--- a/src/script/components/windows-form.ts
+++ b/src/script/components/windows-form.ts
@@ -31,14 +31,22 @@ export class WindowsForm extends LitElement {
       ModalStyles,
       ToolTipStyles,
       css`
-        #form-layout fast-text-field::part(root) {
+        #form-layout input {
           border: 1px solid rgba(194, 201, 209, 1);
           border-radius: var(--input-radius);
+          padding: 10px;
+          color: var(--font-color);
         }
 
-        #form-layout fast-text-field::part(control) {
-          color: var(--font-color);
-          border-radius: var(--input-radius);
+        #generate-submit {
+          background: transparent;
+          color: var(--button-font-color);
+          font-weight: bold;
+          border: none;
+          cursor: pointer;
+
+          height: var(--desktop-button-height);
+          width: var(--button-width);
         }
 
         @media (min-height: 760px) and (max-height: 1000px) {
@@ -78,8 +86,10 @@ export class WindowsForm extends LitElement {
     }
   }
 
-  initGenerate() {
+  initGenerate(ev: InputEvent) {
+    ev.preventDefault();
     const form = this.shadowRoot?.querySelector('#windows-options-form');
+    console.log('here', form);
 
     this.dispatchEvent(
       new CustomEvent('init-windows-gen', {
@@ -149,7 +159,12 @@ export class WindowsForm extends LitElement {
 
   render() {
     return html`
-      <form id="windows-options-form" slot="modal-form" style="width: 100%">
+      <form
+        id="windows-options-form"
+        @submit="${ev => this.initGenerate(ev)}"
+        slot="modal-form"
+        style="width: 100%"
+      >
         <div id="form-layout">
           <div class="basic-settings">
             <div class="form-group">
@@ -173,14 +188,15 @@ export class WindowsForm extends LitElement {
                   'https://blog.pwabuilder.com/docs/finding-your-windows-publisher-info/'
                 )}
               </label>
-              <fast-text-field
+              <input
                 id="windowsPackageIdInput"
                 class="form-control"
                 placeholder="app.contoso.edge"
                 type="text"
                 name="packageId"
+                maxlength="49"
                 required
-              ></fast-text-field>
+              />
             </div>
 
             <div class="form-group">
@@ -204,14 +220,14 @@ export class WindowsForm extends LitElement {
                   'https://blog.pwabuilder.com/docs/finding-your-windows-publisher-info/'
                 )}
               </label>
-              <fast-text-field
+              <input
                 type="text"
                 class="form-control"
                 for="windowsDisplayNameInput"
                 required
                 placeholder="Contoso Inc"
                 name="publisherDisplayName"
-              ></fast-text-field>
+              />
             </div>
 
             <div class="form-group">
@@ -235,14 +251,14 @@ export class WindowsForm extends LitElement {
                   'https://blog.pwabuilder.com/docs/finding-your-windows-publisher-info/'
                 )}
               </label>
-              <fast-text-field
+              <input
                 type="text"
                 class="form-control"
                 id="windowsPublisherIdInput"
                 required
                 placeholder="CN=3a54a224-05dd-42aa-85bd-3f3c1478fdca"
                 name="publisherId"
-              ></fast-text-field>
+              />
             </div>
           </div>
 
@@ -267,7 +283,7 @@ export class WindowsForm extends LitElement {
                         App name
                         ${tooltip('windows-app-name', 'The name of your app')}
                       </label>
-                      <fast-text-field
+                      <input
                         type="text"
                         class="form-control"
                         id="windowsAppNameInput"
@@ -277,7 +293,7 @@ export class WindowsForm extends LitElement {
                           ? this.default_options.name
                           : 'My Awesome PWA'}"
                         required
-                      ></fast-text-field>
+                      />
                     </div>
                   </div>
                 </div>
@@ -305,7 +321,7 @@ export class WindowsForm extends LitElement {
                           'https://blog.pwabuilder.com/docs/what-is-a-classic-package/'
                         )}
                       </label>
-                      <fast-text-field
+                      <input
                         type="text"
                         class="form-control"
                         id="windowsAppVersionInput"
@@ -315,7 +331,7 @@ export class WindowsForm extends LitElement {
                           ? this.default_options.version
                           : '1.0.0'}"
                         required
-                      ></fast-text-field>
+                      />
                     </div>
                   </div>
                 </div>
@@ -343,7 +359,7 @@ export class WindowsForm extends LitElement {
                           'https://blog.pwabuilder.com/docs/what-is-a-classic-package/'
                         )}
                       </label>
-                      <fast-text-field
+                      <input
                         type="text"
                         class="form-control"
                         id="windowsClassicAppVersionInput"
@@ -353,7 +369,7 @@ export class WindowsForm extends LitElement {
                           ? this.default_options.classicPackage?.version
                           : '1.0.1'}"
                         required
-                      ></fast-text-field>
+                      />
                     </div>
                   </div>
                 </div>
@@ -373,7 +389,7 @@ export class WindowsForm extends LitElement {
                       'This is the URL for your PWA'
                     )}
                   </label>
-                  <fast-text-field
+                  <input
                     type="url"
                     class="form-control"
                     id="windowsUrlInput"
@@ -383,7 +399,7 @@ export class WindowsForm extends LitElement {
                     value="${this.default_options
                       ? this.default_options.url
                       : getURL()}"
-                  ></fast-text-field>
+                  />
                 </div>
 
                 <div class="form-group">
@@ -401,7 +417,7 @@ export class WindowsForm extends LitElement {
                       'The URL to your app manifest'
                     )}
                   </label>
-                  <fast-text-field
+                  <input
                     type="url"
                     class="form-control"
                     id="windowsManifestUrlInput"
@@ -411,11 +427,11 @@ export class WindowsForm extends LitElement {
                       ? this.default_options.manifestUrl
                       : getManiURL()}"
                     required
-                  ></fast-text-field>
+                  />
                 </div>
 
                 <div class="form-group">
-                  <label for="windowsIconUrlInput">
+                  <label for="iconUrl">
                     <a
                       href="https://blog.pwabuilder.com/docs/image-recommendations-for-windows-pwa-packages/"
                       target="_blank"
@@ -435,20 +451,20 @@ export class WindowsForm extends LitElement {
                       'https://blog.pwabuilder.com/docs/image-recommendations-for-windows-pwa-packages/'
                     )}
                   </label>
-                  <fast-text-field
-                    type="url"
+                  <input
+                    type="text"
                     class="form-control"
-                    id="windowsIconUrlInput"
+                    id="iconUrl"
                     placeholder="https://myawesomepwa.com/512x512.png"
                     .value="${this.default_options
                       ? this.default_options.images?.baseImage
                       : ''}"
                     name="iconUrl"
-                  ></fast-text-field>
+                  />
                 </div>
 
                 <div class="form-group">
-                  <label for="windowsLanguageInput">
+                  <label for="language">
                     Language
                     <i
                       class="fas fa-info-circle"
@@ -462,8 +478,8 @@ export class WindowsForm extends LitElement {
                       'Optional. The primary language for your app package. Additional languages can be specified in Partner Center. If empty, EN-US will be used.'
                     )}
                   </label>
-                  <fast-text-field
-                    type="url"
+                  <input
+                    type="text"
                     class="form-control"
                     id="windowsLanguageInput"
                     placeholder="EN-US"
@@ -471,7 +487,7 @@ export class WindowsForm extends LitElement {
                       ? this.default_options.manifest?.lang
                       : 'US-EN'}"
                     name="language"
-                  ></fast-text-field>
+                  />
                 </div>
               </div>
             </fast-accordion-item>
@@ -479,17 +495,13 @@ export class WindowsForm extends LitElement {
         </div>
 
         <div id="form-details-block">
-          <p>
-            ${localeStrings.text.publish.windows_platform.p}
-          </p>
+          <p>${localeStrings.text.publish.windows_platform.p}</p>
         </div>
 
         <div id="form-options-actions" class="modal-actions">
-          <loading-button
-            @click="${() => this.initGenerate()}"
-            .loading="${this.generating}"
-            >Generate</loading-button
-          >
+          <loading-button .loading="${this.generating}">
+            <input id="generate-submit" type="submit" value="Generate"/>
+          </loading-button>
         </div>
       </form>
     `;

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -433,6 +433,7 @@ export class AppPublish extends LitElement {
   }
 
   async generate(type: platform, form?: HTMLFormElement, signingFile?: string) {
+    console.log('generating');
     if (type === 'windows') {
       // Final checks for Windows
       if (this.finalChecks) {

--- a/styles/form-styles.css
+++ b/styles/form-styles.css
@@ -135,3 +135,8 @@ form {
   font-weight: normal;
   margin-left: 8px;
 }
+
+#form-layout input:invalid {
+  color: var(--error-color);
+  border: 1px solid var(--error-color);
+}


### PR DESCRIPTION
…idation

Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
Refactoring (no functional changes, no api changes) 
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Note: Screenshots below to show the UI. Also, I'm doing this refactor with the Windows form first, and will do the Android form in a separate PR tomorrow after this PR is merged and tested in prod. This lowers the surface area for potential problems.


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The current form behavior was not using the built-in browser form validation, but instead tried to handle it all with JavaScript in the UI. This caused multiple problems that we have ADO tasks open for, including bad validation for the length of the package name for the Windows platform and UX problems when entering invalid values for inputs in the Windows and Android form.

## Describe the new behavior?
We are now using the built-in browser form validation. Because of that, we are able to validate the inputs BEFORE the user hits generate and can give better info when the user hits generate. This greatly improves the current flow we have if someone inputs something invalid, which is:
- User fills out form with some invalid values
- User hits generate
- generate modal closes and error modal pops up with the validation issue
- user re-opens generation modal and fixes the issue
- user re-submits

The new flow is just:
- User immediately has UI feedback on which inputs need to be filled or are invalid
- If the user hits generate and a field is invalid, they will get built-in browser UI showing which input is invalid

![image](https://user-images.githubusercontent.com/8823093/123879131-428c2500-d8f5-11eb-9166-27e9f1b9dd13.png)
![image](https://user-images.githubusercontent.com/8823093/123879185-618ab700-d8f5-11eb-9baa-a08ecb9a1a57.png)
![image](https://user-images.githubusercontent.com/8823093/123879223-6fd8d300-d8f5-11eb-9a04-cf5b7096cce4.png)
![image](https://user-images.githubusercontent.com/8823093/123879300-8ed76500-d8f5-11eb-872e-30bb76ef30bd.png)



## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
