### PR TITLE
add methods to handle the different body types and creating of the url

### DIFF
--- a/src/script/services/publish/web-publish.ts
+++ b/src/script/services/publish/web-publish.ts
@@ -1,7 +1,8 @@
-import { getGeneratedManifest, getManifest } from "../manifest";
+import { getGeneratedManifest, getManifest } from '../manifest';
 import { env } from '../../utils/environment';
-import { getURL } from "../app-info";
-import { getChosenServiceWorker } from "../service_worker";
+import { getURL } from '../app-info';
+import { getChosenServiceWorker } from '../service_worker';
+import { Manifest } from '../../utils/interfaces';
 
 export let web_generated = false;
 
@@ -13,33 +14,41 @@ export async function generateWebPackage() {
     const chosenSW = getChosenServiceWorker();
 
     // The web package generator dies when screenshots is null. If detected, set screenshots to empty array.
-    const manifestWithScreenshots = manifest ? { ...manifest } : { ...genManifest };
+    const manifestWithScreenshots = manifest
+      ? { ...manifest }
+      : { ...genManifest };
 
     if (!manifestWithScreenshots.screenshots) {
       manifestWithScreenshots.screenshots = [];
     }
 
-    let urlToUse;
+    let baseUrl: string;
+    let urlToUse: string;
+    let headers: Headers | undefined;
+    let body: FormData | string;
+
+    if (manifest.icons.length > 10) {
+      baseUrl = env.webPackageGeneratorUrlForm;
+      body = createNewFormDataWithManifest(manifest);
+    } else {
+      baseUrl = env.webPackageGeneratorUrl;
+      headers = new Headers({
+        'content-type': 'application/json',
+      });
+      body = JSON.stringify(manifestWithScreenshots);
+    }
 
     if (chosenSW) {
-      urlToUse = `${env.webPackageGeneratorUrl}?siteUrl=${url
-      }&swId=${chosenSW}&hasServiceWorker=${false}`
-    }
-    else {
-      urlToUse = `${env.webPackageGeneratorUrl}?siteUrl=${url
-      }&hasServiceWorker=${true}`
+      urlToUse = `${baseUrl}?siteUrl=${url}&swId=${chosenSW}&hasServiceWorker=${false}`;
+    } else {
+      urlToUse = `${baseUrl}?siteUrl=${url}&hasServiceWorker=${true}`;
     }
 
-    const response = await fetch(
-      urlToUse,
-      {
-        method: "POST",
-        body: JSON.stringify(manifestWithScreenshots),
-        headers: new Headers({
-          "content-type": "application/json",
-        }),
-      }
-    );
+    const response = await fetch(urlToUse, {
+      method: 'POST',
+      body,
+      headers,
+    });
     if (response.status === 200) {
       const data = await response.blob();
 
@@ -54,6 +63,38 @@ export async function generateWebPackage() {
       );
     }
   } catch (error) {
-    throw new Error("Failed. Error: " + error);
+    throw new Error('Failed. Error: ' + error);
   }
+}
+
+function createNewFormDataWithManifest(manifest: Manifest): FormData {
+  const form = new FormData();
+
+  const keys = Object.keys(manifest);
+  const length = keys.length;
+
+  for (let i = 0; i < length; i++) {
+    const key = keys[i];
+    let val = manifest[key];
+
+    if (Array.isArray(val)) {
+      const arrLength = val.length;
+      for (let j = 0; j < arrLength; j++) {
+        let arrVal = val[j];
+
+        // want to stringify both objects and nested arrays, this is to prevent form nesting which is a deprecated but functional use. maps and sets shouldn't be in the manifest object.
+        if (typeof arrVal === 'object') {
+          arrVal = JSON.stringify(arrVal);
+        }
+
+        form.append(key, arrVal);
+      }
+    } else if (typeof val === 'object') {
+      val = JSON.stringify(val);
+    }
+
+    form.append(key, val);
+  }
+
+  return form;
 }

--- a/src/script/services/publish/web-publish.ts
+++ b/src/script/services/publish/web-publish.ts
@@ -24,19 +24,7 @@ export async function generateWebPackage() {
 
     let baseUrl: string;
     let urlToUse: string;
-    let headers: Headers | undefined;
-    let body: FormData | string;
-
-    if (manifest.icons.length > 10) {
-      baseUrl = env.webPackageGeneratorUrlForm;
-      body = createNewFormDataWithManifest(manifest);
-    } else {
-      baseUrl = env.webPackageGeneratorUrl;
-      headers = new Headers({
-        'content-type': 'application/json',
-      });
-      body = JSON.stringify(manifestWithScreenshots);
-    }
+    const body = createNewFormDataWithManifest(manifest);
 
     if (chosenSW) {
       urlToUse = `${baseUrl}?siteUrl=${url}&swId=${chosenSW}&hasServiceWorker=${false}`;
@@ -47,7 +35,6 @@ export async function generateWebPackage() {
     const response = await fetch(urlToUse, {
       method: 'POST',
       body,
-      headers,
     });
     if (response.status === 200) {
       const data = await response.blob();

--- a/src/script/utils/environment.ts
+++ b/src/script/utils/environment.ts
@@ -13,6 +13,8 @@ export const env = {
   safeUrlFetcher:
     'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl',
   webPackageGeneratorUrl: 'https://pwabuilder-web-platform.azurewebsites.net/',
+  webPackageGeneratorUrlForm:
+    'https://pwabuilder-web-platform.azurewebsites.net/form',
   ratingUrl:
     'https://pwabuilder-url-logger-api.azurewebsites.net/api/analyses/getaveragescores',
 };

--- a/src/script/utils/environment.ts
+++ b/src/script/utils/environment.ts
@@ -13,7 +13,7 @@ export const env = {
   safeUrlFetcher:
     'https://pwabuilder-safe-url.azurewebsites.net/api/getsafeurl',
   webPackageGeneratorUrl: 'https://pwabuilder-web-platform.azurewebsites.net/',
-  webPackageGeneratorUrlForm:
+  webPackageGeneratorFormUrl:
     'https://pwabuilder-web-platform.azurewebsites.net/form',
   ratingUrl:
     'https://pwabuilder-url-logger-api.azurewebsites.net/api/analyses/getaveragescores',


### PR DESCRIPTION
#1864 

## PR Type

- Bugfix

## Describe the current behavior?

If the json payload was too large (24mb), the service rejects the call. Rather than just upping the value until we get successful requests, using a form should provide more reliable calls.

## Describe the new behavior?

Adds a form based post request, logic set so that apps with more than 10 declared icons uses this endpoint. The service in question parses the form and converts it into json before handling it, so the end product is the same.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
