### PR TITLE
fix(): modalId is passed in correctly

### DIFF
--- a/src/script/components/app-modal.ts
+++ b/src/script/components/app-modal.ts
@@ -201,7 +201,7 @@ export class AppModal extends LitElement implements AppModalElement {
     }
 
     this.open = false;
-    this.dispatchEvent(AppModalCloseEvent());
+    this.dispatchEvent(AppModalCloseEvent(this.modalId));
 
     // just to ensure scrolling gets turned back on
     // when the modal is closed

--- a/src/script/utils/events/modal.ts
+++ b/src/script/utils/events/modal.ts
@@ -1,9 +1,9 @@
 import { ModalCloseEvent } from '../interfaces';
 
-export function AppModalCloseEvent() {
+export function AppModalCloseEvent(modalId: string) {
   return new CustomEvent<ModalCloseEvent>('app-modal-close', {
     detail: {
-      modalId: this.modalId,
+      modalId: modalId,
     },
     composed: true,
     bubbles: true,


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
If you opened one of the publish modals, then closed it and then tried to reopen it again the modal would not actually open.

## Describe the new behavior?
The modalId param is now passed into the close event correctly, enabling the modals to now be opened and closed multiple times as expected.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
