### PR TITLE
form data payload error

### DIFF
--- a/src/script/services/publish/web-publish.ts
+++ b/src/script/services/publish/web-publish.ts
@@ -80,11 +80,13 @@ function createNewFormDataWithManifest(manifest: Manifest): FormData {
 
         form.append(key as string, arrVal);
       }
-    } else if (typeof val === 'object') {
-      val = JSON.stringify(val);
-    }
+    } else {
+      if (typeof val === 'object') {
+        val = JSON.stringify(val);
+      }
 
-    form.append(key as string, val);
+      form.append(key as string, val);
+    }
   }
 
   return form;


### PR DESCRIPTION
was adding malformed json strings of arrays to the payload with logic error

Fixes #
#1892 #1897

## PR Type

- Bugfix

## Describe the current behavior?

Error was caused by form data payload including toString() representations of arrays of objects after parsing the objects and adding them individually. Essentially it was assuming the data was strings. This malformed data doesn't pass the schema requirements on fastifies form data reader and thus throws the error.

formdata payload:
```
screenshots: { "src": "/example1.png", "type": "...", ...}
screenshots: { "src": "/example2.png", "type": "...", ...}
screenshots: [object Object],[object Object],...
```

## Describe the new behavior?

Logic correction to prevent behavior. Omits the third entry in the payload above.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information

<img width="1465" alt="Screen Shot 2021-07-06 at 10 38 06 AM" src="https://user-images.githubusercontent.com/6520001/124643788-59c39900-de46-11eb-8938-51ab297abdff.png">
<img width="1504" alt="Screen Shot 2021-07-06 at 10 38 16 AM" src="https://user-images.githubusercontent.com/6520001/124643794-5c25f300-de46-11eb-87e6-01a3f64a9231.png">
