### PR TITLE
Added manifest URL to Android options

### DIFF
--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -700,6 +700,20 @@ export class AndroidForm extends LitElement {
               </div>
 
               <div class="form-group">
+                <label for="webManifestUrlInput">
+                  Manifest URL
+                </label>
+                <input
+                  type="url"
+                  class="form-control"
+                  id="webManifestUrlInput"
+                  placeholder="https://myawesomepwa.com/manifest.json"
+                  name="webManifestUrl"
+                  .value="${this.default_options?.webManifestUrl || ''}"
+                />
+              </div>
+
+              <div class="form-group">
                 <label for="splashFadeoutInput"
                   >Splash screen fade out duration (ms)</label
                 >

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -450,7 +450,7 @@ export class AppPublish extends LitElement {
           if (maniCheck === false) {
             err = 'Your PWA does not have a valid Web Manifest';
           } else if (baseIcon === false) {
-            err = 'Your PWA needs atleast a 512x512 PNG icon';
+            err = 'Your PWA needs at least a 512x512 PNG icon';
           } else if (validURL === false) {
             err = 'Your PWA does not have a valid URL';
           }
@@ -478,7 +478,8 @@ export class AppPublish extends LitElement {
           if (maniCheck === false) {
             err = 'Your PWA does not have a valid Web Manifest';
           } else if (baseIcon === false) {
-            err = 'Your PWA needs atleast a 512x512 PNG icon';
+            console.log("zanz ", baseIcon, this.finalChecks);
+            err = 'Your PWA needs at least a 512x512 PNG icon';
           } else if (validURL === false) {
             err = 'Your PWA does not have a valid URL';
           } else if (offlineCheck === false) {

--- a/src/script/services/publish/android-publish.ts
+++ b/src/script/services/publish/android-publish.ts
@@ -142,7 +142,7 @@ export async function createAndroidPackageOptionsFromForm(form: HTMLFormElement,
     startUrl: getStartUrlRelativeToHost(form.startUrl.value || manifest.start_url, new URL(maniURL)),
     themeColor: form.themeColor.value || manifest.theme_color || '#FFFFFF',
     shareTarget: manifest.share_target,
-    webManifestUrl: form.maniURL ? form.maniURL.value : maniURL,
+    webManifestUrl: form.webManifestUrl.value || maniURL,
   };
 }
 


### PR DESCRIPTION
Fixes #1841 by adding manifest URL to Android options. Needed to work around HTTP/2 and HTTP/3 sites.