### PR TITLE
fix(): package id can be exactly 50 characters

### DIFF
--- a/src/script/components/windows-form.ts
+++ b/src/script/components/windows-form.ts
@@ -195,7 +195,7 @@ export class WindowsForm extends LitElement {
                 type="text"
                 name="packageId"
                 pattern="[a-zA-Z0-9.]*$"
-                maxlength="49"
+                maxlength="50"
                 required
               />
             </div>


### PR DESCRIPTION
Fixes #1907
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
I was under the impression that the max length of the package id was <50 but its actually <=50 characters long.

## Describe the new behavior?
The input now has a maxlength of 50.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
