### PR TITLE
Fix wrong label

### DIFF
--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -853,7 +853,7 @@ export class AndroidForm extends LitElement {
               </div>
 
               <div class="form-group">
-                <label>${localeStrings.text.android.titles.fullscreen}</label>
+                <label>${localeStrings.text.android.titles.notification}</label>
                 <div class="form-check">
                   <input
                     .defaultChecked="${true}"


### PR DESCRIPTION
## PR Type

- Bugfix


## Description

The label name should be "Notification delegation" instead of "Fullscreen".

![screenshot](https://user-images.githubusercontent.com/7892779/124816397-2893b780-df71-11eb-9138-015441c5b21e.png)
