### PR TITLE
Android form improvements

### DIFF
--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -1239,6 +1239,7 @@ export class AndroidForm extends LitElement {
                           id="signingKeyPasswordInput"
                           name="keyPassword"
                           placeholder="Password to your signing key"
+                          minlength="6"
                           value="${this.keyPassword}"
                         />
                       </div>
@@ -1264,6 +1265,7 @@ export class AndroidForm extends LitElement {
                           id="signingKeyStorePasswordInput"
                           name="storePassword"
                           placeholder="Password to your key store"
+                          minlength="6"
                           value="${this.storePassword}"
                         />
                       </div>

--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -283,7 +283,7 @@ export class AndroidForm extends LitElement {
                   : 'com.contoso.app'}"
                 type="text"
                 required
-                pattern="[a-zA-Z0-9.]*$"
+                pattern="[a-zA-Z0-9._]*$"
                 name="packageId"
               />
             </div>

--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -261,7 +261,7 @@ export class AndroidForm extends LitElement {
           <div class="basic-settings">
             <div class="form-group">
               <label for="packageIdInput">
-                Package Name
+                Package ID
                 <i
                   class="fas fa-info-circle"
                   title="The unique identifier of your app. It should contain only letters, numbers, and periods. Example: com.companyname.appname"


### PR DESCRIPTION
Fixes #1910 and #1911 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
- Underscores were not allowed in the packageID input, which does not match the Android spec.
- A developer could put in a password that is too short

## Describe the new behavior?
- Underscores are now allowed by the "pattern" attribute in the packageID input
- The password fields have a minlength set to 6
I also changed the name of the package ID input to Package ID instead of Package Name

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
