### PR TITLE
Tooltips are aligned correctly

### DIFF
--- a/src/script/components/hover-tooltip.ts
+++ b/src/script/components/hover-tooltip.ts
@@ -1,0 +1,75 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+@customElement('hover-tooltip')
+export class HoverTooltip extends LitElement {
+  @property({ type: String }) text: string = '';
+  @property({ type: String }) link: string = '';
+
+  static get styles() {
+    return css`
+      #hover-tooltip {
+        display: none;
+
+        position: relative;
+
+        flex-direction: column;
+        justify-content: space-around;
+
+        padding: 8px;
+        border-radius: 6px;
+        position: absolute;
+        z-index: 1;
+
+        white-space: break-spaces;
+        width: 14em;
+
+        background: var(--font-color);
+        left: 0em;
+
+        color: #fff;
+        text-decoration: none;
+        font-weight: initial;
+      }
+
+      #tooltip-block {
+        position: relative;
+        cursor: pointer;
+      }
+
+      #tooltip-block img {
+        height: 12px;
+        width: 12px;
+        border-radius: 50%;
+        background: var(--neutral-fill-stealth-rest);
+        padding: 4px;
+        margin-left: 6px;
+      }
+
+      #tooltip-block:hover #hover-tooltip {
+        display: flex;
+      }
+    `;
+  }
+
+  constructor() {
+    super();
+  }
+
+  render() {
+    return html`
+      <div id="tooltip-block">
+        <img
+          src="assets/images/help-outline.svg"
+          alt="help outline"
+          aria-hidden="true"
+          id="tooltip-image"
+        />
+
+        <a id="hover-tooltip" target="_blank" href="${this.link}"
+          >${this.text}</a
+        >
+      </div>
+    `;
+  }
+}

--- a/src/script/components/hover-tooltip.ts
+++ b/src/script/components/hover-tooltip.ts
@@ -60,6 +60,7 @@ export class HoverTooltip extends LitElement {
     return html`
       <div id="tooltip-block">
         <img
+          part="tooltip-image"
           src="assets/images/help-outline.svg"
           alt="help outline"
           aria-hidden="true"

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -46,13 +46,14 @@ import './app-file-input';
 import './app-gallery';
 import './code-editor';
 import './flipper-button';
+import './hover-tooltip';
 import { generateMissingImagesBase64 } from '../services/icon_generator';
 import { generateScreenshots } from '../services/screenshots';
 import { validateScreenshotUrlsList } from '../utils/manifest-validation';
 import {
   mediumBreakPoint,
   smallBreakPoint,
-  xLargeBreakPoint
+  xLargeBreakPoint,
 } from '../utils/css/breakpoints';
 import { hidden_sm } from '../utils/css/hidden';
 import { generateAndDownloadIconZip } from '../services/download_icons';
@@ -249,6 +250,8 @@ export class AppManifest extends LitElement {
           display: flex;
           flex-direction: row;
           align-items: top;
+
+          position: relative;
         }
 
         .item-top h3 {
@@ -467,11 +470,9 @@ export class AppManifest extends LitElement {
             <div class="images-header">
               <div class="item-top">
                 <h3>${localeStrings.text.manifest_options.images.icons.h3}</h3>
-                ${this.renderToolTip(
-                  'upload-icons-tooltip',
-                  localeStrings.tooltip.manifest_options.upload,
-                  'https://developer.mozilla.org/en-US/docs/Web/Manifest/icons'
-                )}
+
+                <hover-tooltip .text="${localeStrings.tooltip.manifest_options.upload}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest/icons"></hover-tooltip>
+
               </div>
               <app-button appearance="outline" @click=${this.openUploadModal}
                 >${localeStrings.button.upload}</app-button
@@ -524,11 +525,9 @@ export class AppManifest extends LitElement {
                 <h3>
                   ${localeStrings.text.manifest_options.images.screenshots.h3}
                 </h3>
-                ${this.renderToolTip(
-                  'generate-screenshot-tooltip',
-                  localeStrings.tooltip.manifest_options.generate,
-                  'https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots'
-                )}
+
+                <hover-tooltip .text="${localeStrings.tooltip.manifest_options.generate}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots"></hover-tooltip>
+
               </div>
               <p>${localeStrings.text.manifest_options.images.screenshots.p}</p>
 
@@ -603,7 +602,9 @@ export class AppManifest extends LitElement {
         <div class="info-item">
           <div class="item-top">
             <h3>${item.title}</h3>
-            ${this.renderToolTip(item.entry + '-tooltip', item.tooltipText)}
+
+            <hover-tooltip .text="${item.tooltipText}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest"></hover-tooltip>
+
           </div>
           <p>${item.description}</p>
           <fast-text-field
@@ -658,7 +659,8 @@ export class AppManifest extends LitElement {
         <div class="setting-item">
           <div class="item-top">
             <h3>${item.title}</h3>
-            ${this.renderToolTip(item.entry + '-tooltip', item.tooltipText)}
+
+            <hover-tooltip .text="${item.tooltipText}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest"></hover-tooltip>
           </div>
           <p>${item.description}</p>
           ${field}
@@ -679,11 +681,9 @@ export class AppManifest extends LitElement {
               ${localeStrings.text.manifest_options.settings.background_color
                 .h3}
             </h3>
-            ${this.renderToolTip(
-              'bg-color-tooltip',
-              localeStrings.tooltip.manifest_options.background_color,
-              'https://developer.mozilla.org/en-US/docs/Web/Manifest/background_color'
-            )}
+
+            <hover-tooltip .text="${localeStrings.tooltip.manifest_options.background_color}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest/background_color"></hover-tooltip>
+
           </div>
           <fast-radio-group
             value=${this.setBackgroundColorRadio()}
@@ -721,11 +721,9 @@ export class AppManifest extends LitElement {
             <h3>
               ${localeStrings.text.manifest_options.settings.theme_color.h3}
             </h3>
-            ${this.renderToolTip(
-              'theme-color-tooltip',
-              localeStrings.tooltip.manifest_options.theme_color,
-              'https://developer.mozilla.org/en-US/docs/Web/Manifest/theme_color'
-            )}
+
+            <hover-tooltip .text="${localeStrings.tooltip.manifest_options.theme_color}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest/theme_color"></hover-tooltip>
+
           </div>
           <fast-radio-group
             value=${this.setThemeColorRadio()}
@@ -997,7 +995,9 @@ export class AppManifest extends LitElement {
 
     this.awaitRequest = false;
 
-    const uploadModal = this.shadowRoot?.getElementById('uploadModal') as ShadowRootQuery<AppModalElement>;
+    const uploadModal = this.shadowRoot?.getElementById(
+      'uploadModal'
+    ) as ShadowRootQuery<AppModalElement>;
     if (uploadModal) {
       uploadModal.close();
     }

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -37,8 +37,6 @@ import {
   fastRadioCss,
 } from '../utils/css/fast-elements';
 
-import { tooltip, styles as ToolTipStyles } from './tooltip';
-
 import './loading-button';
 import './app-modal';
 import './dropdown-menu';
@@ -123,7 +121,6 @@ export class AppManifest extends LitElement {
   static get styles() {
     return [
       ErrorStyles,
-      ToolTipStyles,
       fastButtonCss,
       fastCheckboxCss,
       fastTextFieldCss,
@@ -853,8 +850,6 @@ export class AppManifest extends LitElement {
         .filter(str => str) || []
     );
   }
-
-  renderToolTip = tooltip;
 
   renderModalInput() {
     return html`

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -471,8 +471,10 @@ export class AppManifest extends LitElement {
               <div class="item-top">
                 <h3>${localeStrings.text.manifest_options.images.icons.h3}</h3>
 
-                <hover-tooltip .text="${localeStrings.tooltip.manifest_options.upload}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest/icons"></hover-tooltip>
-
+                <hover-tooltip
+                  .text="${localeStrings.tooltip.manifest_options.upload}"
+                  link="https://developer.mozilla.org/en-US/docs/Web/Manifest/icons"
+                ></hover-tooltip>
               </div>
               <app-button appearance="outline" @click=${this.openUploadModal}
                 >${localeStrings.button.upload}</app-button
@@ -526,8 +528,10 @@ export class AppManifest extends LitElement {
                   ${localeStrings.text.manifest_options.images.screenshots.h3}
                 </h3>
 
-                <hover-tooltip .text="${localeStrings.tooltip.manifest_options.generate}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots"></hover-tooltip>
-
+                <hover-tooltip
+                  .text="${localeStrings.tooltip.manifest_options.generate}"
+                  link="https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots"
+                ></hover-tooltip>
               </div>
               <p>${localeStrings.text.manifest_options.images.screenshots.p}</p>
 
@@ -603,8 +607,10 @@ export class AppManifest extends LitElement {
           <div class="item-top">
             <h3>${item.title}</h3>
 
-            <hover-tooltip .text="${item.tooltipText}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest"></hover-tooltip>
-
+            <hover-tooltip
+              .text="${item.tooltipText}"
+              link="https://developer.mozilla.org/en-US/docs/Web/Manifest"
+            ></hover-tooltip>
           </div>
           <p>${item.description}</p>
           <fast-text-field
@@ -660,7 +666,10 @@ export class AppManifest extends LitElement {
           <div class="item-top">
             <h3>${item.title}</h3>
 
-            <hover-tooltip .text="${item.tooltipText}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest"></hover-tooltip>
+            <hover-tooltip
+              .text="${item.tooltipText}"
+              link="https://developer.mozilla.org/en-US/docs/Web/Manifest"
+            ></hover-tooltip>
           </div>
           <p>${item.description}</p>
           ${field}
@@ -682,8 +691,10 @@ export class AppManifest extends LitElement {
                 .h3}
             </h3>
 
-            <hover-tooltip .text="${localeStrings.tooltip.manifest_options.background_color}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest/background_color"></hover-tooltip>
-
+            <hover-tooltip
+              .text="${localeStrings.tooltip.manifest_options.background_color}"
+              link="https://developer.mozilla.org/en-US/docs/Web/Manifest/background_color"
+            ></hover-tooltip>
           </div>
           <fast-radio-group
             value=${this.setBackgroundColorRadio()}
@@ -722,8 +733,10 @@ export class AppManifest extends LitElement {
               ${localeStrings.text.manifest_options.settings.theme_color.h3}
             </h3>
 
-            <hover-tooltip .text="${localeStrings.tooltip.manifest_options.theme_color}" link="https://developer.mozilla.org/en-US/docs/Web/Manifest/theme_color"></hover-tooltip>
-
+            <hover-tooltip
+              .text="${localeStrings.tooltip.manifest_options.theme_color}"
+              link="https://developer.mozilla.org/en-US/docs/Web/Manifest/theme_color"
+            ></hover-tooltip>
           </div>
           <fast-radio-group
             value=${this.setThemeColorRadio()}

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -240,32 +240,8 @@ export class AppPublish extends LitElement {
           width: 16px;
         }
 
-        #hover-tooltip {
+        hover-tooltip::part(tooltip-image) {
           display: none;
-
-          position: relative;
-
-          flex-direction: column;
-          justify-content: space-around;
-
-          padding: 8px;
-          border-radius: 6px;
-          position: absolute;
-          z-index: 1;
-
-          white-space: break-spaces;
-          width: 14em;
-
-          background: var(--font-color);
-          right: 6em;
-
-          color: #fff;
-          text-decoration: none;
-          font-weight: initial;
-        }
-
-        #test-package-button:hover #hover-tooltip {
-          display: flex;
         }
       `,
       xxxLargeBreakPoint(

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -9,6 +9,7 @@ import '../components/app-button';
 import '../components/loading-button';
 import '../components/windows-form';
 import '../components/android-form';
+import '../components/hover-tooltip';
 import { Router } from '@vaadin/router';
 
 import {
@@ -560,12 +561,8 @@ export class AppPublish extends LitElement {
                       @click="${() => this.generate('windows')}"
                       >Test Package
 
-                      <!-- todo after release: refactor this into a <hover-tooltip /> component -->
-                      <a
-                        id="hover-tooltip"
-                        target="_blank"
-                        href="https://github.com/pwa-builder/pwabuilder-windows-chromium-docs/blob/master/next-steps.md#1-test-your-app-on-your-windows-machine"
-                      >Generate a package you can use to test your app on your Windows Device before going to the Microsoft Store.</a>
+                      <hover-tooltip text="Generate a package you can use to test your app on your Windows Device before going to the Microsoft Store." link="https://github.com/pwa-builder/pwabuilder-windows-chromium-docs/blob/master/next-steps.md#1-test-your-app-on-your-windows-machine"></hover-tooltip>
+
                     </loading-button>
                   </div>
                 `


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Reported in ADO: Current tooltips would show up in the wrong places on the manifest-options page, especially once scrolled. 

## Describe the new behavior?
I have implemented a new component called `hover-tooltip`. This component is a tooltip that will always be positioned correctly, even with scrolling as its positioned just using CSS.

*Note* This new tooltip is now used everywhere but the publish modals as the "old" tooltips are working well there and I didn't want to risk breaking those in some way as part of this PR. I will make this change in a separate PR.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
