### PR TITLE
fix(): remove check for prefer_related_applications from the related_…

### DIFF
--- a/src/script/services/tests/manifest.ts
+++ b/src/script/services/tests/manifest.ts
@@ -246,11 +246,10 @@ function doTest(manifest: ManifestDetectionResult) {
         category: 'optional',
       },
       {
-        infoString: 'Specifies related_application',
+        infoString: 'Specifies related_applications',
         result:
           manifest.content.related_applications &&
-          manifest.content.related_applications.length > 0 &&
-          manifest.content.prefer_related_applications !== undefined
+          manifest.content.related_applications.length > 0
             ? true
             : false,
         category: 'optional',


### PR DESCRIPTION
…applications check

Fixes #1917 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
We were checking for usage of prefer_related_applications along with related_applications. Technically this was correct as they are supposed to be used together, but we should instead have a separate check for this. 

## Describe the new behavior?
Removed the prefer_related_applications check from the related_applications test. Will ask Melanie for an effective way to make it clear these items are related.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
