### PR TITLE
Image rendering fix

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -69,8 +69,6 @@ export class AppManifest extends LitElement {
   @property({ type: Array, hasChanged: arrayHasChanged })
   screenshotList: Array<string | undefined> = [undefined];
 
-  @property({ type: Array })
-  iconsList: Array<Icon> | undefined = [];
 
   @property({ type: Boolean }) uploadModalOpen = false;
   @state() uploadButtonDisabled = true;
@@ -110,6 +108,9 @@ export class AppManifest extends LitElement {
 
   @state({ hasChanged: objectHasChanged })
   protected manifest: Lazy<Manifest>;
+
+  @state()
+  protected iconsList: Array<Icon> | undefined = [];
 
   protected get siteUrl(): string {
     if (!this.searchParams) {
@@ -1030,16 +1031,24 @@ export class AppManifest extends LitElement {
     }
   }
 
-  async handleIconFileUpload() {
+  async handleIconFileUpload(): Promise<void> {
     this.awaitRequest = true;
 
     try {
       if (this.uploadSelectedImageFile) {
+
+        // remove existing icons so we can replace them
+        this.updateManifest({
+          icons: undefined,
+        });
+
+        // clear our local state variable too
+        this.iconsList = undefined;
+
+        // new icons (triggers a render)
         this.iconsList = await generateMissingImagesBase64({
           file: this.uploadSelectedImageFile,
         });
-
-        // this.renderIcons();
       }
     } catch (e) {
       console.error(e);

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -503,8 +503,6 @@ export class AppManifest extends LitElement {
               </app-modal>
             </div>
             <div class="collection image-items hidden-sm">
-              <!--${this.renderIcons()}-->
-
               ${
                 this.iconsList?.map(icon => {
                   const url = this.handleImageUrl(icon);
@@ -786,39 +784,6 @@ export class AppManifest extends LitElement {
         </div>
       </div>
     `;
-  }
-
-  renderIcons() {
-    console.log("this.manifest", this.manifest);
-    if (this.manifest) {
-      return this.manifest?.icons?.map(icon => {
-        const url = this.handleImageUrl(icon);
-  
-        if (url) {
-          return html`<div class="image-item image">
-            <img src="${url}" alt="image text" decoding="async" loading="lazy" />
-            <p>${icon.sizes}</p>
-          </div>`;
-        }
-  
-        return undefined;
-      });
-    }
-    else {
-      this.iconsList?.map(icon => {
-        const url = this.handleImageUrl(icon);
-  
-        if (url) {
-          return html`<div class="image-item image">
-            <img src="${url}" alt="image text" decoding="async" loading="lazy" />
-            <p>${icon.sizes}</p>
-          </div>`;
-        }
-  
-        return undefined;
-      });
-    }
-    return undefined;
   }
 
   renderScreenshotInputUrlList() {

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -480,6 +480,7 @@ export class AppManifest extends LitElement {
                 >${localeStrings.button.upload}</app-button
               >
               <app-modal
+                id="uploadModal"
                 modalId="uploadModal"
                 title="Upload information"
                 body="Choose an Icon to upload. For the best results, we recommend choosing a 512x512 size icon."

--- a/src/script/services/icon_generator.ts
+++ b/src/script/services/icon_generator.ts
@@ -29,7 +29,7 @@ interface IconGeneratorConfig {
 const base64ImageGeneratorUrl =
   'https://appimagegenerator-prod.azurewebsites.net/api/image/base64';
 
-export async function generateMissingImagesBase64(config: MissingImagesConfig) {
+export async function generateMissingImagesBase64(config: MissingImagesConfig): Promise<Array<Icon> | undefined> {
   try {
     const form = new FormData();
     form.append('baseImage', config.file);
@@ -59,9 +59,15 @@ export async function generateMissingImagesBase64(config: MissingImagesConfig) {
       updateManifest({
         icons,
       });
+
+      return icons;
+    }
+    else {
+      return;
     }
   } catch (e) {
     console.error(e);
+    return;
   }
 }
 


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
When uploading an icon we had four issues:
1. For sites that did not already have a manifest and we could not generate one for because of multiple issues (https://partyfavorz.com/) generating icons would fail.
2. Icons were not refreshing after generation succeeded, making it look like the service was not working.
3. Uploading a new icon to a PWA that already has icons would just add on to the existing icons in the manifest, instead of replacing the old icon.
4. The upload modal would not close automatically after generation finished.

## Describe the new behavior?
This PR fixes the above issues:
1. Any site should now be able to generate icons.
2. Icons are now contained in a state variable so that we trigger lit's render pipeline https://lit.dev/docs/components/properties/, this ensures the icons are always rendered when they should be, but without having to change alot of code and rely on events being passed around. Note, reactive properties are the standard way to trigger renders in lit (just like assigning to a state or prop in React) so we should try to always use them instead of relying on events.
3. We now replace the icons correctly.
4. The upload modal now closes after generation is done by making sure it has the expected ID.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
