### PR TITLE
Fix Safari link styles

### DIFF
--- a/src/script/components/app-button.ts
+++ b/src/script/components/app-button.ts
@@ -19,6 +19,7 @@ export class AppButton extends LitElement implements AppButtonElement {
         :host {
           border-radius: var(--button-radius);
           display: block;
+          outline: none;
 
           --font-size: var(--desktop-button-font-size);
           --button-height: 44px;
@@ -46,6 +47,7 @@ export class AppButton extends LitElement implements AppButtonElement {
 
           border-radius: unset;
           box-shadow: none;
+          background-color: transparent;
         }
 
         fast-button.link::part(control) {


### PR DESCRIPTION
# Fixes 
Styles when hovering over the homepage links on Safari

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Code style update (formatting)


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
When hovering over the card links on Safari, the background color is the default dark purple of Fast Elements. 

## Describe the new behavior?
The background color is now set to transparent (same design as in other browsers). 

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [X] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [X] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
This is my first PR so yay :)
