### PR TITLE
Fix go back when clicking on header logo

### DIFF
--- a/src/script/components/app-header.ts
+++ b/src/script/components/app-header.ts
@@ -156,9 +156,9 @@ export class AppHeader extends LitElement {
   }
 
   goBack() {
-    const currentPlace = location.href;
+    const pathName = location.pathname;
 
-    if (currentPlace.includes('reportcard')) {
+    if (pathName === '/' || pathName === '/reportcard') {
       Router.go('/');
     } else {
       window.history.back();
@@ -169,7 +169,7 @@ export class AppHeader extends LitElement {
     return html`
       <header part="header">
         <img
-          @click="${() => this.goBack()}"
+          @click="${this.goBack}"
           id="header-icon"
           src="/assets/images/header_logo.svg"
           alt="header logo"


### PR DESCRIPTION
# Fixes 
Fixes issue reported in #1930 

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
When clicking on the site's logo on the header, the click is handled by a `goBack()` function that when not in the report card page, it calls `window.history.back()`. Because of this, users get redirected to Google (or whatever page they were on before) when on the homepage.


## Describe the new behavior?
Now the function checks that the pathname is not `/` (i.e., the homepage) before going back in history. 

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [X] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [X] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
