### PR TITLE
fix(): generate button enabled in input event

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -794,6 +794,12 @@ export class AppManifest extends LitElement {
     `;
   }
 
+  handleScreenshotButtonEnabled() {
+    if (this.generateScreenshotButtonDisabled === true) {
+      this.generateScreenshotButtonDisabled = false;
+    }
+  }
+
   renderScreenshotInputUrlList() {
     const renderFn = (url: string | undefined, index: number) => {
       const isValid = this.screenshotListValid[index];
@@ -806,6 +812,7 @@ export class AppManifest extends LitElement {
           })}"
           placeholder="https://www.example.com/screenshot"
           value="${url || ''}"
+          @input=${this.handleScreenshotButtonEnabled}
           @change=${this.handleScreenshotUrlChange}
           data-index=${index}
         ></fast-text-field>


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Currently, the generate button for the screenshots was disabled until the "change" event of the URL input was fired. The change event (just the built in onchange event for html inputs) does not fire until the user has hit enter or has tapped outside of the input, and therefore the generate button was not enabled until the user had done one of those actions.

## Describe the new behavior?
We now enable the generate button on the `input` event. This does mean that a user could potentially try to generate screenshots on an unfinished URL, but that would require the user to intentionally do that, and you wouldn't say that Twitter is broken cause you cant log in just because you hit login before you finished your password.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
