### PR TITLE
fix(): screenshots and icons are hidden until they exist on mobile

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -525,11 +525,16 @@ export class AppManifest extends LitElement {
                 return undefined;
               })}
             </div>
-            <app-gallery
-              class="show-sm"
-              .images=${this.iconSrcListParse()}
-            ></app-gallery>
 
+            ${this.manifest &&
+            this.manifest.icons &&
+            this.manifest.icons.length > 0
+              ? html`<app-gallery
+                  class="show-sm"
+                  .images=${this.iconSrcListParse()}
+                ></app-gallery>`
+              : null}
+              
             ${this.manifest &&
             this.manifest.icons &&
             this.manifest.icons.length > 0
@@ -568,11 +573,18 @@ export class AppManifest extends LitElement {
               >
             </div>
           </div>
-          <div class="collection screenshot-items hidde-sm">
+          <div class="collection screenshot-items hidden-sm">
             ${this.renderScreenshots()}
           </div>
-          <app-gallery class="show-sm" .images=${this.screenshotSrcListParse()}>
-          </app-gallery>
+
+          ${(this.screenshotsList && this.screenshotsList.length > 0) ||
+          (this.manifest?.screenshots && this.manifest.screenshots.length > 0)
+            ? html`<app-gallery
+                class="show-sm"
+                .images=${this.screenshotSrcListParse()}
+              >
+              </app-gallery>`
+            : null}
 
           <div class="screenshots-actions">
             <loading-button


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
As opened on ADO, we had an issue where the screenshots and icons were trying to be shown before they were being generated.

## Describe the new behavior?
The app-gallery (the component we use on mobile to show the icons and screenshots) is now hidden until those assets actually exist.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
