### PR TITLE
New generate manifest function is used

### DIFF
--- a/src/script/services/manifest.ts
+++ b/src/script/services/manifest.ts
@@ -66,7 +66,7 @@ export function manifestGenerated() {
 async function getManifestViaFilePost(
   url: string
 ): Promise<ManifestDetectionResult> {
-  const manifestTestUrl = `${env.testAPIUrl
+  const manifestTestUrl = `${env.api
     }/WebManifest?site=${encodeURIComponent(url)}`;
   const response = await fetch(manifestTestUrl, {
     method: 'POST',
@@ -287,12 +287,9 @@ async function generateManifest(url: string): Promise<ManifestDetectionResult> {
   sessionStorage.setItem(PWABuilderSession.manifestGenerated, 'true');
 
   try {
-    const response = await fetch(`${env.api}/manifests`, {
+    const response = await fetch(`${env.api}/GenerateManifest?site=${url}`, {
       method: 'POST',
       headers: new Headers({ 'content-type': 'application/json' }),
-      body: JSON.stringify({
-        siteUrl: url,
-      }),
     });
 
     const data = await response.json();

--- a/src/script/services/tests/security.ts
+++ b/src/script/services/tests/security.ts
@@ -27,7 +27,7 @@ export async function testSecurity(url: string): Promise<Array<TestResult>> {
   );
 
   const encodedUrl = encodeURIComponent(url);
-  const securityUrl = `${env.testAPIUrl}/Security?site=${encodedUrl}`;
+  const securityUrl = `${env.api}/Security?site=${encodedUrl}`;
   const fetchResult = fetch(securityUrl);
 
   const fetchResultOrTimeout: void | Response = await Promise.race([

--- a/src/script/services/tests/service-worker.ts
+++ b/src/script/services/tests/service-worker.ts
@@ -130,7 +130,7 @@ async function detectOfflineSupportPuppeteer(url: string) {
 
 async function detectOfflineSupportLighthouse(url: string) {
   const fetchResult = await fetch(
-    `${env.testAPIUrl}/offline/?site=${encodeURIComponent(url)}`
+    `${env.api}/offline/?site=${encodeURIComponent(url)}`
   );
   if (!fetchResult.ok) {
     console.warn(

--- a/src/script/utils/environment.ts
+++ b/src/script/utils/environment.ts
@@ -3,8 +3,7 @@ export const env = {
     'https://pwabuilder-manifest-finder.azurewebsites.net/api/findmanifest',
   serviceWorkerUrl:
     'https://pwabuilder-serviceworker-finder.centralus.cloudapp.azure.com',
-  api: 'https://pwabuilder-api-prod.azurewebsites.net',
-  testAPIUrl: 'https://pwabuilder-tests.azurewebsites.net/api',
+  api: 'https://pwabuilder-tests.azurewebsites.net/api',
   windowsPackageGeneratorUrl:
     'https://pwabuilder-win-chromium-platform.centralus.cloudapp.azure.com/msix/generatezip',
   androidPackageGeneratorUrl: 'https://pwabuilder-cloudapk.azurewebsites.net',


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

-  We were still calling the old API to generate a manifest, since we want to shut down the old API this change was needed. 
-  Also, the call to the old API to generate the manifest was slow, and was a big part of why sites like msn.com are slow.

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
We were still calling the old API to generate a manifest, since we want to shut down the old API this change was needed. 

## Describe the new behavior?
Changes:
- We now call the new function I deployed this morning which generates manifests using the pwabuilder-lib (just like the old API). 
- The old API url is not even in the codebase anymore since this was the last usage of it.

This fixes two issues:
- Sites like MSN are horribly slow to test (the video below shows the new speed)
- This was our last connection to the old API

https://user-images.githubusercontent.com/8823093/127059989-8387253f-ab2e-4731-9f52-3c41e11fc292.mp4


## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
