### PR TITLE
resize observer implementation

### DIFF
--- a/src/script/components/code-editor.ts
+++ b/src/script/components/code-editor.ts
@@ -4,7 +4,7 @@ import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import debounce from 'lodash-es/debounce';
 import { getEditorState, emitter } from '../utils/codemirror';
-import { domEventEmitter } from '../utils/events';
+import { resizeObserver } from '../utils/events';
 
 import { Lazy } from '../utils/interfaces';
 import {
@@ -13,7 +13,7 @@ import {
 } from '../utils/interfaces.codemirror';
 import { increment } from '../utils/id';
 
-import "./app-button";
+import './app-button';
 
 @customElement('code-editor')
 export class CodeEditor extends LitElement {
@@ -29,7 +29,7 @@ export class CodeEditor extends LitElement {
   @state() editorEmitter = emitter;
 
   @state() copied = false;
-  @state() copyText = "Copy Manifest";
+  @state() copyText = 'Copy Manifest';
 
   protected static editorIdGenerator = increment();
 
@@ -67,9 +67,7 @@ export class CodeEditor extends LitElement {
       })
     );
 
-    domEventEmitter.addEventListener('resize', () => {
-      this.requestUpdate();
-    });
+    resizeObserver.observe(this);
   }
 
   firstUpdated() {
@@ -82,13 +80,12 @@ export class CodeEditor extends LitElement {
     if (doc) {
       try {
         await navigator.clipboard.writeText(doc.toString());
-        this.copyText = "Copied";
+        this.copyText = 'Copied';
         this.copied = true;
-      }
-      catch (err) {
+      } catch (err) {
         // We should never really end up here but just in case
         // lets put the error in the console
-        console.warn("Copying failed with the following err", err);
+        console.warn('Copying failed with the following err', err);
       }
     }
   }
@@ -96,16 +93,22 @@ export class CodeEditor extends LitElement {
   render() {
     return html`
       <div id="copy-block">
-        <app-button ?disabled="${this.copied}" @click="${() => this.copyManifest()}" appearance="outline" class="secondary">
-          ${this.copyText}</app-button>
+        <app-button
+          ?disabled="${this.copied}"
+          @click="${() => this.copyManifest()}"
+          appearance="outline"
+          class="secondary"
+        >
+          ${this.copyText}</app-button
+        >
       </div>
-      
+
       <div id=${this.editorId} class="editor-container ${this.className}"></div>
     `;
   }
 
   updateEditor = debounce(() => {
-    this.editorState = getEditorState(this.startText || "", 'json');
+    this.editorState = getEditorState(this.startText || '', 'json');
 
     if (this.editorView) {
       this.editorView.setState(this.editorState);

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -8,14 +8,12 @@ import { localeStrings, languageCodes, langCodes } from '../../locales';
 import ErrorStyles from '../../../styles/error-styles.css';
 
 import {
-  emitter as manifestEmitter,
   getManifestGuarded,
   updateManifest,
 } from '../services/manifest';
 import { arrayHasChanged } from '../utils/hasChanged';
 import { resolveUrl } from '../utils/url';
 import {
-  AppEvents,
   FileInputDetails,
   Icon,
   Screenshot,
@@ -36,6 +34,7 @@ import {
   fastMenuCss,
   fastRadioCss,
 } from '../utils/css/fast-elements';
+import { resizeObserver } from '../utils/events';
 
 import './loading-button';
 import './app-modal';
@@ -431,18 +430,11 @@ export class AppManifest extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    manifestEmitter.addEventListener(
-      AppEvents.manifestUpdate,
-      this.handleManifestUpdate
-    );
+    resizeObserver.observe(this);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    manifestEmitter.removeEventListener(
-      AppEvents.manifestUpdate,
-      this.handleManifestUpdate
-    );
   }
 
   render() {
@@ -892,7 +884,6 @@ export class AppManifest extends LitElement {
 
   updateManifest(changes: Partial<Manifest>) {
     updateManifest(changes).then(manifest => {
-
       editorDispatchEvent(
         new CustomEvent<CodeEditorSyncEvent>(CodeEditorEvents.sync, {
           detail: {

--- a/src/script/pages/app-congrats.ts
+++ b/src/script/pages/app-congrats.ts
@@ -12,7 +12,7 @@ import {
   customBreakPoint,
 } from '../utils/css/breakpoints';
 import { hidden_all } from '../utils/css/hidden';
-import { domEventEmitter } from '../utils/events';
+import { resizeObserver } from '../utils/events';
 
 // @ts-ignore
 import style from '../../../styles/layout-defaults.css';
@@ -24,7 +24,10 @@ import '../components/app-modal';
 import '../components/app-card';
 import '../components/resource-hub';
 
-import { getPlatformsGenerated, GeneratedPlatforms } from '../services/congrats';
+import {
+  getPlatformsGenerated,
+  GeneratedPlatforms,
+} from '../services/congrats';
 import { fileSave } from 'browser-fs-access';
 import { Router } from '@vaadin/router';
 import { generatePackage, Platform } from '../services/publish';
@@ -442,9 +445,7 @@ export class AppCongrats extends LitElement {
   constructor() {
     super();
 
-    domEventEmitter.addEventListener('resize', () => {
-      this.requestUpdate();
-    });
+    resizeObserver.observe(this);
   }
 
   firstUpdated() {
@@ -609,7 +610,8 @@ export class AppCongrats extends LitElement {
         <windows-form
           slot="modal-form"
           .generating=${this.generating}
-          @init-windows-gen="${(ev: CustomEvent) => this.generate('windows', ev.detail.form)}"
+          @init-windows-gen="${(ev: CustomEvent) =>
+            this.generate('windows', ev.detail.form)}"
         ></windows-form>
       </app-modal>
 
@@ -622,7 +624,8 @@ export class AppCongrats extends LitElement {
         <android-form
           slot="modal-form"
           .generating=${this.generating}
-          @init-android-gen="${(ev: CustomEvent) => this.generate('android', ev.detail.form)}"
+          @init-android-gen="${(ev: CustomEvent) =>
+            this.generate('android', ev.detail.form)}"
         ></android-form>
       </app-modal>
 
@@ -766,7 +769,10 @@ export class AppCongrats extends LitElement {
               </div>
 
               <div id="anchor-block">
-                <fast-anchor href="https://blog.pwabuilder.com" target="_blank" appearance="hypertext"
+                <fast-anchor
+                  href="https://blog.pwabuilder.com"
+                  target="_blank"
+                  appearance="hypertext"
                   >View more blog posts</fast-anchor
                 >
               </div>

--- a/src/script/utils/events.ts
+++ b/src/script/utils/events.ts
@@ -1,10 +1,13 @@
-import debounce from 'lodash-es/debounce';
+// import debounce from 'lodash-es/debounce';
+import { LitElement } from 'lit';
 
-export const domEventEmitter = new EventTarget();
+export const resizeObserver = new ResizeObserver(ResizeObserverHandler);
 
-window.addEventListener(
-  'resize',
-  debounce((e: Event) => {
-    domEventEmitter.dispatchEvent(e);
-  }, 1000)
-);
+function ResizeObserverHandler(entries: Array<ResizeObserverEntry>) {
+  for (let entry of entries) {
+    // Can use this to replace media queries and content box resizing. Greater perf, before paint takes place :)
+    if (entry.target instanceof LitElement) {
+      entry.target.requestUpdate();
+    }
+  }
+}


### PR DESCRIPTION
## PR Type

- Feature

## Describe the current behavior?

Errors in the console because the debounce is being overloaded.

## Describe the new behavior?

No error, performance improvement by using the observer to trigger paints during the resize event rather than the usual after paint.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
