### PR TITLE
Add placeholder styles

### DIFF
--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -53,6 +53,11 @@ export class AndroidForm extends LitElement {
           color: var(--font-color);
         }
 
+        input::placeholder {
+          color: var(--placeholder-color);
+          font-style: italic;
+        }
+
         #generate-submit {
           background: transparent;
           color: var(--button-font-color);

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -152,6 +152,11 @@ export class AppManifest extends LitElement {
           border-color: rgb(229, 229, 229);
         }
 
+        fast-text-field::part(control)::placeholder {
+          color: var(--placeholder-color);
+          font-style: italic;
+        }
+
         fast-text-field,
         app-dropdown::part(layout) {
           width: 300px;

--- a/src/script/components/windows-form.ts
+++ b/src/script/components/windows-form.ts
@@ -38,6 +38,11 @@ export class WindowsForm extends LitElement {
           color: var(--font-color);
         }
 
+        input::placeholder {
+          color: var(--placeholder-color);
+          font-style: italic;
+        }
+
         #generate-submit {
           background: transparent;
           color: var(--button-font-color);

--- a/styles/global.css
+++ b/styles/global.css
@@ -23,6 +23,7 @@
   font-display: swap;
 }
 
+/* Platform fonts used for the manifest previewer */
 @font-face {
   font-family: 'Segoe';
   src: url('/assets/fonts/SegoeUI.ttf');
@@ -86,6 +87,8 @@
 
   --list-border: 0.67681px solid #e5e5e5;
   --light-primary-color: rgba(255, 255, 255, 0.6);
+
+  --placeholder-color: #A9A9A9;
 }
 
 * {


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
Code style update (formatting) 
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The style of placeholders in input text fields is quite similar to the input text, making them hard to distinguish. 

## Describe the new behavior?
The placeholder text now has a lighter shade of grey (but not too light since it should still be readable). To further remark the difference between placeholders and the input text without sacrificing accessibility, the placeholders are also italicized. For example, here are the first 2 fields from the manifest options form:
<img width="547" alt="Screenshot 2021-08-02 112945" src="https://user-images.githubusercontent.com/85251504/127887822-3353394e-1b37-4842-b8d8-916a3038299e.png">

## PR Checklist

- [X] Test: run `npm run test` and ensure that all tests pass
- [X] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [X] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
