### PR TITLE
Adding image delete to manifest, for both screenshots and icons 

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -290,14 +290,24 @@ export class AppManifest extends LitElement {
           max-width: 200px;
         }
 
-        .image p {
-          text-align: center;
+        .image .info {
+          display: flex;
+          flex-flow: row;
+          justify-content: center;
+          align-items: center;
         }
 
-        .screenshot,
+        .screenshot {
+          max-width: 230px;
+        }
         .screenshot img {
           max-width: 205px;
           max-height: 135px;
+        }
+
+        .delete-button {
+          --button-font-color: var(--font-color);
+          margin: 0;
         }
 
         fast-accordion-item::part(icon) {
@@ -554,7 +564,7 @@ export class AppManifest extends LitElement {
               </app-modal>
             </div>
             <div class="collection image-items hidden-sm">
-              ${this.iconsList?.map(icon => {
+              ${this.iconsList?.map((icon, i) => {
                 const url = this.handleImageUrl(icon);
 
                 if (url) {
@@ -565,7 +575,10 @@ export class AppManifest extends LitElement {
                       decoding="async"
                       loading="lazy"
                     />
-                    <p>${icon.sizes}</p>
+                    <div class="info">
+                      <p>${icon.sizes}</p>
+                      ${this.renderDeleteImageButton('icons', i)}
+                    </div>
                   </div>`;
                 }
 
@@ -843,12 +856,13 @@ export class AppManifest extends LitElement {
   }
 
   renderScreenshots() {
-    return this.screenshotsList.map(screenshot => {
+    return this.screenshotsList.map((screenshot, i) => {
       const url = this.handleImageUrl(screenshot);
 
       if (url) {
         return html`<div class="image-item screenshot">
           <img src="${url}" alt="image text" />
+          ${this.renderDeleteImageButton('screenshots', i)}
         </div>`;
       } else {
         return undefined;
@@ -1087,16 +1101,46 @@ export class AppManifest extends LitElement {
     this.uploadImageObjectUrl = '';
   }
 
-  async handleDeleteImage(event: Event) {
+  renderDeleteImageButton(list: 'icons' | 'screenshots', index: number) {
+    return html`
+      <app-button
+        class="delete-button"
+        appearance="lightweight"
+        data-list=${list}
+        data-index=${index}
+        @click=${this.handleDeleteImage}
+      >
+        <ion-icon
+          name="trash-outline"
+          data-list=${list}
+          data-index=${index}
+        ></ion-icon>
+      </app-button>
+    `;
+  }
+
+  handleDeleteImage(event: Event) {
     try {
-      const input = <HTMLInputElement>event.target;
-      const list = Number(input.dataset['list']);
+      const input = <HTMLButtonElement>event.target;
+      const list = input.dataset['list'] as 'icons' | 'screenshots';
       const index = Number(input.dataset['index']);
-      const imageList: Array<Icon> = this.manifest ? this.manifest[list] : null;
+      const imageList: Array<Icon> =
+        (this.manifest && this.manifest[list]) ?? [];
+      const updatedList = imageList
+        .slice(0, index)
+        .concat(imageList.slice(index + 1));
 
       this.updateManifest({
-        [list]: imageList.slice(0, index).concat(imageList.slice(index + 1)),
+        [list]: updatedList,
       });
+
+      if (list === 'icons') {
+        this.iconsList = updatedList;
+      }
+
+      if (list === 'screenshots') {
+        this.screenshotsList = updatedList;
+      }
     } catch (e) {
       console.error(e);
     }

--- a/src/script/services/manifest.ts
+++ b/src/script/services/manifest.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const deepmerge: any;
-
 import { env } from '../utils/environment';
 import {
   AppEvents,
@@ -34,7 +31,7 @@ let maniURL: Lazy<string>;
 let fetchAttempted = false;
 
 // export to use as a flag for generation
-// this is needed to decide to go to the 
+// this is needed to decide to go to the
 // publish page or base_package
 export let generated = false;
 
@@ -66,8 +63,9 @@ export function manifestGenerated() {
 async function getManifestViaFilePost(
   url: string
 ): Promise<ManifestDetectionResult> {
-  const manifestTestUrl = `${env.api
-    }/WebManifest?site=${encodeURIComponent(url)}`;
+  const manifestTestUrl = `${env.api}/WebManifest?site=${encodeURIComponent(
+    url
+  )}`;
   const response = await fetch(manifestTestUrl, {
     method: 'POST',
   });
@@ -148,7 +146,7 @@ async function getManifestViaHtmlParse(
     errors: [],
     suggestions: [],
     warnings: [],
-    manifestContainsInvalidJson: responseData.manifestContainsInvalidJson
+    manifestContainsInvalidJson: responseData.manifestContainsInvalidJson,
   };
 }
 
@@ -304,14 +302,7 @@ async function generateManifest(url: string): Promise<ManifestDetectionResult> {
 export async function updateManifest(
   manifestUpdates: Partial<Manifest>
 ): Promise<Manifest> {
-  // @ts-ignore
-  // using a dynamic import here as this is a large library
-  // so we should only load it once its actually needed
-  await import('https://unpkg.com/deepmerge@4.2.2/dist/umd.js');
-
-  manifest = deepmerge(manifest, manifestUpdates as Partial<Manifest>, {
-    // customMerge: customManifestMerge, // NOTE: need to manually concat with editor changes.
-  });
+  manifest = Object.assign(manifest, manifestUpdates as Partial<Manifest>);
 
   sessionStorage.setItem(PWABuilderSession.manifest, JSON.stringify(manifest)); // would it make sense to make this async?
 


### PR DESCRIPTION
## PR Type

- Bugfix
- Feature

## Describe the current behavior?

There was not way to delete the icons and screenshots, had the code to, but wanted a design just to double check.

## Describe the new behavior?

Adding the staple ion-icon trash symbol button.
Also removed deepmerge usage, which has indeed improved object merging performance and stability.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
