### PR TITLE
fix(): check if icon actually loads before we try to display it

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -60,6 +60,7 @@ import {
   AppModalElement,
   FileInputElement,
 } from '../utils/interfaces.components';
+import { checkImageUrl } from '../utils/icons';
 
 type ColorRadioValues = 'none' | 'custom';
 
@@ -1225,7 +1226,11 @@ export class AppManifest extends LitElement {
     url = resolveUrl(url?.href, icon.src);
 
     if (url) {
-      return url.href;
+      const iconCheck = checkImageUrl(url.href);
+
+      if (iconCheck === true) {
+        return url.href;
+      }
     }
 
     return undefined;

--- a/src/script/utils/icons.ts
+++ b/src/script/utils/icons.ts
@@ -83,6 +83,26 @@ export function findBestAppIcon(icons: Icon[] | null | undefined): Icon | null {
   );
 }
 
+/**
+ * Check if an image succesfully loads.
+ * @param icon_url The url to the icon to test.
+ * @returns An boolean value based on whether the image loads or nothing if the image never
+ * fires the load or error event.
+ */
+export function checkImageUrl(icon_url: string): boolean | void {
+  const image = new Image();
+
+  image.onload = () => {
+    return true;
+  };
+  image.onerror = () => {
+    return false;
+  };
+
+  image.src = icon_url;
+}
+
+
 function hasPurpose(icon: Icon, purpose: string | null | undefined): boolean {
   if (!purpose) {
     return true;


### PR DESCRIPTION
Fixes #
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
(This is related to the Alibaba issue). There are edge cases, so far only identified with one site, where we have an icon URL but that URL may not actually load.

## Describe the new behavior?
I added a new function to the icon utils that does a quick check to see if the URL actually loads before displaying the icon. Before we displayed a broken image instead. This also makes it more clear to the user that they would need to upload an icon still.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
