### PR TITLE
Change button hover color for Firefox

### DIFF
--- a/src/script/components/app-file-input.ts
+++ b/src/script/components/app-file-input.ts
@@ -22,6 +22,9 @@ export class FileInput extends LitElement implements FileInputElement {
         [appearance='lightweight'] {
           box-shadow: none;
         }
+        :hover {
+          background-color: transparent;
+        }
       `,
       hidden,
       fastButtonCss,

--- a/src/script/components/app-modal.ts
+++ b/src/script/components/app-modal.ts
@@ -214,7 +214,7 @@ export class AppModal extends LitElement implements AppModalElement {
         <div id="background">
           <div part="modal-layout" id="modal">
             <div id="back-button-block">
-              <fast-button @click="${() => this.close()}" appearance="stealth">
+              <fast-button @click="${this.close}" appearance="stealth">
                 <ion-icon name="close"></ion-icon>
               </fast-button>
             </div>


### PR DESCRIPTION
# Fixes
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
Background hover color of modal button

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->
Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The button on the "Upload icons" dialog has a dark background color when hovering, making the text unreadable. 

## Describe the new behavior?
The background color remains transparent.

## PR Checklist

- [X] Test: run `npm run test` and ensure that all tests pass
- [X] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [X] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
