### PR TITLE
Delete extra scrollbars

### DIFF
--- a/src/script/components/dropdown-menu.ts
+++ b/src/script/components/dropdown-menu.ts
@@ -43,8 +43,11 @@ export class DropdownMenu extends LitElement {
           z-index: 20;
 
           max-height: 15em;
-          overflow-y: scroll;
           overflow-x: hidden;
+        }
+
+        fast-button:hover {
+          background: none;
         }
 
         fast-button::part(control) {
@@ -66,6 +69,7 @@ export class DropdownMenu extends LitElement {
           background-color: var(--primary-background-color);
           color: var(--font-color);
           width: 100%;
+          overflow-y: scroll;
         }
 
         fast-menu-item {


### PR DESCRIPTION
# Fixes 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
Removes extra scrollbars in the dropdown menu of the manifest options form, as well as the hover background color of those same fields (issue was visible in Firefox).

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The dropdown menus of the manifest options form (eg the one for selecting the language) have needless scrollbars for each menu item. Also, when hovering over these fields on Firefox, the background color darkens.

## Describe the new behavior?
No extra scrollbars and no background color change. 

## PR Checklist

- [X] Test: run `npm run test` and ensure that all tests pass
- [X] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [X] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
