### PR TITLE
Replace lit-element import by lit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Fixes #
+# Fixes 
 <!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
 
 ## PR Type

--- a/src/script/components/app-gallery.ts
+++ b/src/script/components/app-gallery.ts
@@ -1,12 +1,5 @@
-import {
-  LitElement,
-  css,
-  html,
-  customElement,
-  property,
-  internalProperty,
-  query,
-} from 'lit-element';
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state, query } from 'lit/decorators.js';
 import { Lazy } from '../utils/interfaces';
 
 import './app-modal';
@@ -16,7 +9,7 @@ import './app-button';
 export class AppGallery extends LitElement {
   @property({ attribute: 'images', type: Array }) images: Lazy<Array<string>>;
   @property({ type: Number }) index = 0;
-  @internalProperty() modalOpened = false;
+  @state() modalOpened = false;
 
   @query('.gallery') gallery: Lazy<HTMLElement>;
 
@@ -68,7 +61,7 @@ export class AppGallery extends LitElement {
             alt="current image selected"
             decoding="async"
             loading="lazy"
-            .src=${this.currentImage}
+            src=${this.currentImage}
           />
         </div>
         <app-button
@@ -88,7 +81,7 @@ export class AppGallery extends LitElement {
             alt="current image selected in a modal"
             decoding="async"
             loading="lazy"
-            .src=${this.currentImage}
+            src=${this.currentImage}
           />
           <div slot="modal-actions">
             <app-button @click=${this.closeModal}> Close </app-button>


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
In the app-gallery file, lit elements are currently being imported from `lit-element` instead of `lit`, and the deprecated `internalProperty` decorator is being used. This is the only file that uses `lit-element`.

## Describe the new behavior?
Import elements from `lit` and replaced `internalProperty` by `state`, as suggested by the docs.

## PR Checklist

- [X] Test: run `npm run test` and ensure that all tests pass
- [X] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [X] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
