### PR TITLE
Fix score refresh

### DIFF
--- a/src/script/utils/interfaces.ts
+++ b/src/script/utils/interfaces.ts
@@ -98,6 +98,7 @@ export interface ManifestDetectionResult {
   content: Manifest;
   format: 'w3c' | 'chromeos' | 'edgeextension' | 'windows10' | 'firefox';
   generatedUrl: string;
+  siteUrl: string;
   default: {
     short_name: string;
   };


### PR DESCRIPTION
# Fixes 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
When analyzing several websites consecutively, scores are not properly updated.

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
When analyzing different websites one after the other, the manifest and the score aren't properly updated. To reproduce:
- Enter "pwabuilder.com"
- Once in the report card page, click the "go back" browser button until you reach the home page again.
- Enter "bbc.com"
- The report card page is still using PWABuilder's manifest and score. If you only try "bbc.com" in a new tab, you will see that their score is 30.

## Describe the new behavior?
The score is properly updated when the site changes. Sometimes (I haven't been able to recognize exactly when) the manifest options form still reflects an old manifest, so this should continue being investigated. 

## PR Checklist

- [X] Test: run `npm run test` and ensure that all tests pass
- [X] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [X] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
