### PR TITLE
Lazy load report page

### DIFF
--- a/src/script/pages/app-index.ts
+++ b/src/script/pages/app-index.ts
@@ -90,7 +90,6 @@ export class AppIndex extends LitElement {
     // For more info on using the @vaadin/router check here https://vaadin.com/router
     const router = new Router(this.shadowRoot?.querySelector('#router-outlet'));
     router.setRoutes([
-      // temporarily cast to any because of a Type bug with the router
       {
         path: '',
         animate: true,

--- a/src/script/pages/app-index.ts
+++ b/src/script/pages/app-index.ts
@@ -1,8 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { Router } from '@vaadin/router';
+import { Router, Route } from '@vaadin/router';
 import './app-home';
-import './app-report';
 
 import '../components/app-footer';
 import '../components/app-header';
@@ -102,11 +101,14 @@ export class AppIndex extends LitElement {
             component: 'app-testing',
             action: async () => {
               await import('./app-testing.js');
-            },
+            }
           },
           {
             path: '/reportcard',
             component: 'app-report',
+            action: async () => {
+              await import('./app-report.js');
+            }
           },
           {
             path: '/publish',
@@ -143,8 +145,8 @@ export class AppIndex extends LitElement {
               await import('./portals-publish.js');
             }
           }
-        ],
-      } as any,
+        ] as Route[]
+      }
     ]);
   }
 

--- a/src/script/utils/url.ts
+++ b/src/script/utils/url.ts
@@ -1,4 +1,4 @@
-export function isUrl(url: string): boolean {
+export function isUrl(url: string) {
   try {
     return typeof new URL(url).hostname === 'string';
   } catch (e) {

--- a/src/script/utils/url.ts
+++ b/src/script/utils/url.ts
@@ -1,4 +1,4 @@
-export function isUrl(url: string) {
+export function isUrl(url: string): boolean {
   try {
     return typeof new URL(url).hostname === 'string';
   } catch (e) {


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
When refreshing the page from the report card page, the page goes blank with an error message of "The resource you are looking for has been removed, had its name changed, or is temporarily unavailable."

## Describe the new behavior?
The report card is now also lazy-loaded by the router.

## PR Checklist

- [X] Test: run `npm run test` and ensure that all tests pass
- [X] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [X] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
