### PR TITLE
bug(): edited manifests send to base package

### DIFF
--- a/src/script/utils/interfaces.ts
+++ b/src/script/utils/interfaces.ts
@@ -142,7 +142,9 @@ export interface ManifestContext {
   siteUrl: string;
   manifestUrl: string;
   manifest: Manifest;
+  initialManifest: Manifest;
   isGenerated: boolean;
+  isEdited: boolean;
 }
 
 export interface RawTestResult {


### PR DESCRIPTION
# Fixes 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
If you already had a manifest, but then used the manifest editor to edit it, you would not be sent to the base package page, therefore you could not download your edited manifest.

## Describe the new behavior?
PWAs that edit their manifest will now be sent to the base_package flow.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
