### PR TITLE
fix(accessibility): logo can now be tabbed to and acted on with keyboard

### DIFF
--- a/src/script/components/app-header.ts
+++ b/src/script/components/app-header.ts
@@ -155,6 +155,18 @@ export class AppHeader extends LitElement {
     super();
   }
 
+  firstUpdated() {
+    // Cant seem to type `event` as a KeyboardEvent without TypeScript complaining
+    // with an error I dont fully understand.
+    // revisit: Justin
+    this.shadowRoot?.querySelector('#header-icon')?.addEventListener("keydown" , (event) => {
+      // casting here because of type problem described above
+      if ((event as KeyboardEvent).key === "Enter") {
+        this.goBack();
+      }
+    })
+  }
+
   goBack() {
     const pathName = location.pathname;
 
@@ -170,6 +182,7 @@ export class AppHeader extends LitElement {
       <header part="header">
         <img
           @click="${this.goBack}"
+          tabindex="0"
           id="header-icon"
           src="/assets/images/header_logo.svg"
           alt="header logo"
@@ -193,13 +206,6 @@ export class AppHeader extends LitElement {
             <ion-icon name="logo-github"></ion-icon>
           </fast-anchor>
         </nav>
-
-        <!-- temporarily removing this based on design feedback -->
-        <!--<nav id="mobile-nav">
-          <fast-button appearance="lightweight">
-            <ion-icon name="menu-outline"></ion-icon>
-          </fast-button>
-        </nav>-->
       </header>
     `;
   }

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -379,7 +379,6 @@ export class AppHome extends LitElement {
               name="url-input"
               class="${classMap({ error: this.errorGettingURL })}"
               @input="${(e: InputEvent) => this.handleURL(e)}"
-              autofocus
             ></fast-text-field>
 
             ${this.errorMessage && this.errorMessage.length > 0


### PR DESCRIPTION
# Fixes 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
https://dev.azure.com/microsoft/OS/_workitems/edit/35285856/

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
- Header logo could not be tabbed to by default
- Enter URL should not have autofocus so it does not steal focus
- Header logo should be able to be acted on by the keyboard

## Describe the new behavior?
- Header logo is now tabIndex=0 as it is the top left element on the document.
- Removed autofocus from Enter URL input.
- Header logo now handles the keydown event so that it can be acted on with the keyboard in the expected manner.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
