### PR TITLE
Accessibility bug 35223716

### DIFF
--- a/src/script/components/app-header.ts
+++ b/src/script/components/app-header.ts
@@ -185,7 +185,7 @@ export class AppHeader extends LitElement {
           tabindex="0"
           id="header-icon"
           src="/assets/images/header_logo.svg"
-          alt="header logo"
+          alt="PWA Builder logo"
         />
 
         <nav id="desktop-nav">
@@ -193,6 +193,7 @@ export class AppHeader extends LitElement {
             appearance="hypertext"
             href="https://blog.pwabuilder.com"
             target="__blank"
+            aria-label="Link will open in separate tab"
             rel="noopener"
             >Resources</fast-anchor
           >
@@ -201,6 +202,7 @@ export class AppHeader extends LitElement {
             appearance="hypertext"
             href="https://github.com/pwa-builder/PWABuilder"
             target="__blank"
+            aria-label="Link will open in separate tab"
             rel="noopener"
           >
             <ion-icon name="logo-github"></ion-icon>

--- a/src/script/components/content-header.ts
+++ b/src/script/components/content-header.ts
@@ -75,7 +75,7 @@ export class ContentHeader extends LitElement {
         padding-left: 2em;
       }
 
-      :host ::slotted(h2) {
+      :host ::slotted(h1) {
         margin-bottom: 0;
         line-height: 40px;
 

--- a/src/script/pages/app-congrats.ts
+++ b/src/script/pages/app-congrats.ts
@@ -83,12 +83,12 @@ export class AppCongrats extends LitElement {
           max-width: 767px;
         }
 
-        h2 {
+        h1 {
           font-size: var(--xlarge-font-size);
           line-height: 46px;
         }
 
-        h3 {
+        h2 {
           font-size: var(--medium-font-size);
           margin-bottom: 8px;
         }
@@ -116,7 +116,7 @@ export class AppCongrats extends LitElement {
           border-bottom: var(--list-border);
         }
 
-        li h4 {
+        li h3 {
           font-size: var(--small-medium-font-size);
           margin-bottom: 8px;
           margin-top: 0px;
@@ -143,14 +143,14 @@ export class AppCongrats extends LitElement {
           grid-gap: 23px;
         }
 
-        #tools-section h3 {
+        #tools-section h2 {
           margin-top: 36px;
           margin-bottom: 32px;
 
           text-align: center;
         }
 
-        #blog-section h3 {
+        #blog-section h2 {
           margin-top: 36px;
           margin-bottom: 32px;
         }
@@ -173,7 +173,7 @@ export class AppCongrats extends LitElement {
           margin-right: 24px;
         }
 
-        #tools-section h3 {
+        #tools-section h2 {
           text-align: center;
         }
 
@@ -242,7 +242,7 @@ export class AppCongrats extends LitElement {
             margin-right: initial;
           }
 
-          .congrats h2 {
+          .congrats h1 {
             font-size: 33px;
             max-width: 10em;
 
@@ -275,7 +275,7 @@ export class AppCongrats extends LitElement {
             margin-top: 2em;
           }
 
-          #other-stores li h2 {
+          #other-stores li h1 {
             font-size: 33px;
 
             margin-top: 0;
@@ -295,7 +295,7 @@ export class AppCongrats extends LitElement {
             display: none;
           }
 
-          .congrats h2 {
+          .congrats h1 {
             font-size: 33px;
 
             margin-top: 0;
@@ -328,7 +328,7 @@ export class AppCongrats extends LitElement {
             margin-left: 0;
           }
 
-          #other-stores li h2 {
+          #other-stores li h1 {
             font-size: 33px;
 
             margin-top: 0;
@@ -642,7 +642,7 @@ export class AppCongrats extends LitElement {
 
           <div>
             <content-header class="congrats">
-              <h2 slot="hero-container">Awesome!</h2>
+              <h1 slot="hero-container">Awesome!</h1>
               <p id="hero-p" slot="hero-container">
                 You have taken your PWA to the app stores!
               </p>
@@ -651,7 +651,7 @@ export class AppCongrats extends LitElement {
             <app-sidebar id="tablet-sidebar"></app-sidebar>
 
             <section id="summary-block">
-              <h3>Nice</h3>
+              <h2>Nice</h2>
 
               <p>
                 Check below to package your PWA for another store and visit our
@@ -660,7 +660,7 @@ export class AppCongrats extends LitElement {
             </section>
 
             <section id="other-stores">
-              <h3>Publish your PWA to other stores?</h3>
+              <h2>Publish your PWA to other stores?</h2>
 
               <ul>
                 ${this.generatedPlatforms &&
@@ -668,7 +668,7 @@ export class AppCongrats extends LitElement {
                   ? html`
                       <li>
                         <div id="title-block">
-                          <h4>Windows</h4>
+                          <h3>Windows</h3>
                           <p>
                             <a
                               href="https://blog.pwabuilder.com/posts/bringing-chromium-edge-pwas-to-the-microsoft-store/"
@@ -704,7 +704,7 @@ export class AppCongrats extends LitElement {
                 ? html`
                     <li>
                       <div id="title-block">
-                        <h4>Android</h4>
+                        <h3>Android</h3>
                         <p>
                           Want to ship your PWA to Android? PWAs also work great
                           on Android and are accepted in the Google Play Store.
@@ -726,7 +726,7 @@ export class AppCongrats extends LitElement {
             </section>
 
             <section id="blog-section">
-              <h3>Learn more on our Blog…</h3>
+              <h2>Learn more on our Blog…</h2>
 
               <div id="blog-block">
                 ${this.featuredPost
@@ -780,7 +780,7 @@ export class AppCongrats extends LitElement {
 
             <section id="tools-section">
               <resource-hub page="complete">
-                <h3 slot="title">Helpful tools for you...</h3>
+                <h2 slot="title">Helpful tools for you...</h2>
               </resource-hub>
             </section>
           </div>

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -53,15 +53,17 @@ export class AppHome extends LitElement {
           --header-border: none;
         }
 
-        h2 {
+        h1 {
           font-size: var(--xlarge-font-size);
           line-height: 48px;
           letter-spacing: -0.015em;
           margin-bottom: 0;
         }
 
-        h3 {
+        h2 {
           font-size: var(--medium-font-size);
+          margin-block: 1em;
+          margin-bottom: 5px;
         }
 
         #hero-p {
@@ -131,7 +133,7 @@ export class AppHome extends LitElement {
             padding-left: 0;
           }
 
-          h2 {
+          h1 {
             margin-top: 0;
             font-size: var(--large-font-size);
           }
@@ -173,7 +175,7 @@ export class AppHome extends LitElement {
             padding-left: 0;
           }
 
-          h2 {
+          h1 {
             font-size: var(--large-font-size);
             margin-top: 0;
           }
@@ -224,7 +226,7 @@ export class AppHome extends LitElement {
             max-width: 280px;
           }
 
-          h2 {
+          h1 {
             max-width: 600px;
           }
 
@@ -326,13 +328,13 @@ export class AppHome extends LitElement {
   render() {
     return html`
       <content-header class="home">
-        <h2 slot="hero-container">
+        <h1 slot="hero-container">
           Ship your PWA to the app stores at lightning speed.
-        </h2>
+        </h1>
 
         <section id="content-grid" slot="grid-container">
           <div class="intro-grid-item">
-            <h3>Test</h3>
+            <h2>Test</h2>
 
             <p>
               PWABuilder will make sure your web app is a PWA and ready for the
@@ -341,7 +343,7 @@ export class AppHome extends LitElement {
           </div>
 
           <div class="intro-grid-item">
-            <h3>Manage</h3>
+            <h2>Manage</h2>
 
             <p>
               Our Report Card will let you know if your PWA is store-ready. If
@@ -350,7 +352,7 @@ export class AppHome extends LitElement {
           </div>
 
           <div class="intro-grid-item">
-            <h3>Package</h3>
+            <h2>Package</h2>
 
             <p>
               Once you are ready, PWABuilder can package your PWA for the app
@@ -359,7 +361,7 @@ export class AppHome extends LitElement {
           </div>
 
           <div class="intro-grid-item">
-            <h3>Explore</h3>
+            <h2>Explore</h2>
 
             <p>
               PWAs are moving forward fast, learn about new web APIs, store
@@ -400,7 +402,7 @@ export class AppHome extends LitElement {
       </content-header>
 
       <resource-hub page="home" all>
-        <h2 slot="title">PWABuilder Resource Hub</h2>
+        <h1 slot="title">PWABuilder Resource Hub</h1>
         <p slot="description">
           Jump to our blog, find our documentation and check out demos and
           components from the PWABuilder team!

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -96,7 +96,7 @@ export class AppPublish extends LitElement {
           margin-right: 2em;
         }
 
-        h2 {
+        h1 {
           font-size: var(--xlarge-font-size);
           line-height: 46px;
         }
@@ -107,13 +107,13 @@ export class AppPublish extends LitElement {
           max-width: 406px;
         }
 
-        h3,
-        h5 {
+        h2,
+        h4 {
           font-size: var(--medium-font-size);
           margin-bottom: 8px;
         }
 
-        h4 {
+        h3 {
           margin-bottom: 8px;
           margin-top: 0;
         }
@@ -175,7 +175,7 @@ export class AppPublish extends LitElement {
           border-bottom: var(--list-border);
         }
 
-        li h4 {
+        li h3 {
           font-size: var(--small-medium-font-size);
         }
 
@@ -290,7 +290,7 @@ export class AppPublish extends LitElement {
       ),
       mediumBreakPoint(
         css`
-          .publish h2 {
+          .publish h1 {
             font-size: 33px;
             max-width: 10em;
 
@@ -373,7 +373,7 @@ export class AppPublish extends LitElement {
           margin-top: 2em;
         }
 
-        .publish h2 {
+        .publish h1 {
           font-size: 33px;
 
           margin-top: 0;
@@ -541,7 +541,7 @@ export class AppPublish extends LitElement {
         html`<li>
           <div id="title-block">
             <img src="${platform.icon}" alt="platform icon" />
-            <h4>${platform.title}</h4>
+            <h3>${platform.title}</h3>
             <p>${platform.description}</p>
           </div>
 
@@ -752,7 +752,7 @@ export class AppPublish extends LitElement {
 
           <div>
             <content-header class="publish">
-              <h2 slot="hero-container">Your PWA is Store Ready!</h2>
+              <h1 slot="hero-container">Your PWA is Store Ready!</h1>
               <p id="hero-p" slot="hero-container">
                 You are now ready to ship your PWA to the app stores!
               </p>
@@ -761,7 +761,7 @@ export class AppPublish extends LitElement {
             <app-sidebar id="tablet-sidebar"></app-sidebar>
 
             <section id="summary-block">
-              <h3>Publish your PWA to stores</h3>
+              <h2>Publish your PWA to stores</h2>
 
               <p>
                 Generate store-ready packages for the Microsoft Store, Google
@@ -775,7 +775,7 @@ export class AppPublish extends LitElement {
               </ul>
 
               <div id="up-next">
-                <h5>Congrats!</h5>
+                <h4>Congrats!</h4>
 
                 <p>
                   Make sure you check our documentation for help submitting your

--- a/src/script/pages/app-report.ts
+++ b/src/script/pages/app-report.ts
@@ -61,7 +61,7 @@ export class AppReport extends LitElement {
     return [
       style,
       css`
-        h2 {
+        h1 {
           font-size: 44px;
           line-height: 46px;
         }
@@ -160,7 +160,7 @@ export class AppReport extends LitElement {
 
         ${mediumBreakPoint(
           css`
-            .reportCard h2 {
+            .reportCard h1 {
               font-size: 33px;
               margin-top: 0;
               margin-bottom: 1em;
@@ -186,7 +186,7 @@ export class AppReport extends LitElement {
               display: none;
             }
 
-            .reportCard h2 {
+            .reportCard h1 {
               font-size: 33px;
               margin-top: 0;
               margin-bottom: 1em;
@@ -288,7 +288,7 @@ export class AppReport extends LitElement {
 
         <section id="report">
           <content-header class="reportCard ${this.selectedTab}">
-            <h2 slot="hero-container">${this.currentHeader}</h2>
+            <h1 slot="hero-container">${this.currentHeader}</h1>
             <p id="hero-p" slot="hero-container">${this.currentSupporting}</p>
           </content-header>
 


### PR DESCRIPTION
# Fixes 
Fixing h1, h2, h3, h4 hierarchy for screen readers

## PR Type
Bugfix 

## Describe the current behavior?
missing h1 on all our pages, moving the tree to 1 level up


## Describe the new behavior?
Screen readers can now see H1s on each page

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
