### PR TITLE
fix(): check icons, start_url, short_name and name

### DIFF
--- a/src/script/services/tests/manifest.ts
+++ b/src/script/services/tests/manifest.ts
@@ -122,7 +122,7 @@ export async function testManifest(
   }
 }
 
-function doTest(context: ManifestContext) {
+export function doTest(context: ManifestContext) {
   if (context.isGenerated === true) {
     return default_results;
   } else {


### PR DESCRIPTION
# Fixes 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
If you came into PWABuilder with a manifest already, we were assuming it had icons etc and therefore they would be taken to the publish page. However, this assumption has been proven to be wrong.

## Describe the new behavior?
When deciding to send the user to the publish or base_package route we now double check that their custom manifest has the following: 
- 512 icon
- start_url
- name
- short name

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
