### PR TITLE
Propagating manifest warnings to front-end

### DIFF
--- a/src/script/services/manifest.ts
+++ b/src/script/services/manifest.ts
@@ -77,6 +77,8 @@ async function getManifestViaHtmlParse(
     manifestContents: Manifest | null;
     error: string | null;
     manifestContainsInvalidJson: boolean;
+    manifestScore: { [key: keyof Manifest | "manifest"]: number }; // e.g. { "categories": 2, ... }
+    warnings: { [key: keyof Manifest | string]: string }; // e.g. { "categories": "Must be an array" }
   };
 
   const manifestTestUrl = `${env.manifestFinderUrl}?url=${encodeURIComponent(
@@ -111,9 +113,10 @@ async function getManifestViaHtmlParse(
     },
     id: '',
     generated: responseData.manifestContents ? false : true,
-    errors: [],
+    errors: responseData.error ? [responseData.error] : [],
     suggestions: [],
-    warnings: [],
+    warnings: Object.entries(responseData.warnings)
+      .map(keyVal => `${keyVal[0]}: ${keyVal[1]}`), // e.g. "categories: Must be an array"
     manifestContainsInvalidJson: responseData.manifestContainsInvalidJson,
   };
 }

--- a/src/script/utils/interfaces.ts
+++ b/src/script/utils/interfaces.ts
@@ -127,10 +127,9 @@ export interface ManifestDetectionResult {
   };
   id: string;
   generated: boolean;
-  errors: [];
-  suggestions: [];
-  warnings: [];
-  error?: string;
+  errors: string[];
+  suggestions: string[];
+  warnings: string[];
   manifestContainsInvalidJson?: boolean;
 }
 


### PR DESCRIPTION
## PR Type
Refactoring

## Describe the current behavior?
Warnings and errors from manifest detection service are ignored.

## Describe the new behavior?
Warnings and errors from manifest detection service are returned in the response. No UI right now to show them, though we should do this when implementing #1575