### PR TITLE
feat(): check if icons load successfully

### DIFF
--- a/src/script/services/tests/manifest.ts
+++ b/src/script/services/tests/manifest.ts
@@ -339,7 +339,7 @@ function iconCanLoadSuccesfully(): Promise<boolean> {
   return new Promise(resolve => {
     if (mainIcon) {
       const imageEl = new Image();
-      imageEl.src = `https://pwabuilder-safe-url.azurewebsites.net/api/getSafeUrl?checkExistsOnly=true&url=${new URL(
+      imageEl.src = `https://pwabuilder-safe-url.azurewebsites.net/api/getSafeUrl?checkExistsOnly=false&url=${new URL(
         mainIcon.src,
         getManifestContext().manifestUrl
       ).toString()}`;

--- a/src/script/services/tests/manifest.ts
+++ b/src/script/services/tests/manifest.ts
@@ -336,10 +336,13 @@ function isStandardOrientation(orientation: string) {
 }
 
 function iconCanLoadSuccesfully(): Promise<boolean> {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     if (mainIcon) {
       const imageEl = new Image();
-      imageEl.src = new URL(mainIcon.src, getManifestContext().manifestUrl).toString();
+      imageEl.src = `https://pwabuilder-safe-url.azurewebsites.net/api/getSafeUrl?checkExistsOnly=true&url=${new URL(
+        mainIcon.src,
+        getManifestContext().manifestUrl
+      ).toString()}`;
 
       imageEl.onload = () => {
         if (imageEl.complete && imageEl.naturalHeight > 0) {

--- a/src/script/services/tests/manifest.ts
+++ b/src/script/services/tests/manifest.ts
@@ -1,7 +1,8 @@
 import { default_timeout } from '../../utils/api';
 import { findSuitableIcon } from '../../utils/icons';
-import { ManifestContext, TestResult } from '../../utils/interfaces';
+import { ManifestContext, TestResult, Icon } from '../../utils/interfaces';
 import { fetchOrCreateManifest } from '../manifest';
+import { getManifestContext } from '../app-info';
 
 const default_results = [
   {
@@ -110,7 +111,7 @@ export async function testManifest(
         console.error('Could not test manifest, returning default results');
         return manifest as Array<TestResult>;
       } else {
-        return doTest(manifest);
+        return await doTest(manifest);
       }
     } else {
       console.error('Could not get manifest data');
@@ -122,10 +123,31 @@ export async function testManifest(
   }
 }
 
-export function doTest(context: ManifestContext) {
+let mainIcon: Icon | null;
+export async function doTest(context: ManifestContext) {
   if (context.isGenerated === true) {
     return default_results;
   } else {
+
+    // go ahead and try to find mainIcon
+    // so we can use it for the below check
+    mainIcon = findSuitableIcon(
+      context.manifest.icons,
+      null,
+      512,
+      512,
+      'image/png'
+    );
+
+    // checking if the icon can be succesfully loaded
+    let iconCanBeLoadedFlag;
+    try {
+      iconCanBeLoadedFlag = await iconCanLoadSuccesfully();
+    }
+    catch (err) {
+      iconCanBeLoadedFlag = false;
+    }
+
     return [
       {
         infoString: 'Web Manifest Properly Attached',
@@ -168,9 +190,9 @@ export function doTest(context: ManifestContext) {
         infoString: 'Specifies a display mode',
         result:
           context.manifest.display &&
-            ['fullscreen', 'standalone', 'minimal-ui', 'browser'].includes(
-              context.manifest.display
-            )
+          ['fullscreen', 'standalone', 'minimal-ui', 'browser'].includes(
+            context.manifest.display
+          )
             ? true
             : false,
         category: 'recommended',
@@ -189,7 +211,7 @@ export function doTest(context: ManifestContext) {
         infoString: 'Specifies an orientation mode',
         result:
           context.manifest.orientation &&
-            isStandardOrientation(context.manifest.orientation)
+          isStandardOrientation(context.manifest.orientation)
             ? true
             : false,
         category: 'recommended',
@@ -198,23 +220,22 @@ export function doTest(context: ManifestContext) {
         infoString: 'Contains screenshots for app store listings',
         result:
           context.manifest.screenshots &&
-            context.manifest.screenshots.length > 0
+          context.manifest.screenshots.length > 0
             ? true
             : false,
         category: 'recommended',
       },
       {
         infoString: 'Has a square PNG icon 512x512 or larger',
-        result: findSuitableIcon(
-          context.manifest.icons,
-          null,
-          512,
-          512,
-          'image/png'
-        )
+        result: mainIcon
           ? true
           : false,
         category: 'required',
+      },
+      {
+        infoString: '512x512 or larger icon can be loaded succesfully from the network',
+        result: iconCanBeLoadedFlag,
+        category: 'required'
       },
       {
         infoString: 'Has a maskable PNG icon',
@@ -241,8 +262,8 @@ export function doTest(context: ManifestContext) {
         infoString: 'Contains categories to classify the app',
         result:
           context.manifest.categories &&
-            context.manifest.categories.length > 0 &&
-            containsStandardCategory(context.manifest.categories)
+          context.manifest.categories.length > 0 &&
+          containsStandardCategory(context.manifest.categories)
             ? true
             : false,
         category: 'recommended',
@@ -256,7 +277,7 @@ export function doTest(context: ManifestContext) {
         infoString: 'Specifies related_applications',
         result:
           context.manifest.related_applications &&
-            context.manifest.related_applications.length > 0
+          context.manifest.related_applications.length > 0
             ? true
             : false,
         category: 'optional',
@@ -312,4 +333,26 @@ function isStandardOrientation(orientation: string) {
     'portrait-secondary',
   ];
   return standardOrientations.includes(orientation);
+}
+
+function iconCanLoadSuccesfully(): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (mainIcon) {
+      const imageEl = new Image();
+      imageEl.src = new URL(mainIcon.src, getManifestContext().manifestUrl).toString();
+
+      imageEl.onload = () => {
+        if (imageEl.complete && imageEl.naturalHeight > 0) {
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      };
+      imageEl.onerror = () => {
+        resolve(false);
+      };
+    } else {
+      resolve(false);
+    }
+  });
 }


### PR DESCRIPTION
# Fixes 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
While we checked for the correct size for the main app icon (512x512 or larger), if that icon were found we never actually checked if it could be successfully loaded. This leads to a situation where a user can make it to the publish page with a busted icon link.

## Describe the new behavior?
For the main app icon, the 512x512 or larger icon, we now have an additional test (that is reflected in the report-card page in the manifest section) that checks to see if the 512x512 or larger icon can successfully load. The next step in this path will be surfacing this check in our "errors UI" if it does error out, along with some other key problems identified here https://github.com/pwa-builder/PWABuilder/issues/1575.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
