### PR TITLE
fix(): header width now matches when the font loads

### DIFF
--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -124,6 +124,10 @@ export class AppHome extends LitElement {
           width: 100%;
         }
 
+        #home-header {
+          max-width: 498px;
+        }
+
         ${smallBreakPoint(css`
           content-header::part(grid-container) {
             display: none;
@@ -328,7 +332,7 @@ export class AppHome extends LitElement {
   render() {
     return html`
       <content-header class="home">
-        <h1 slot="hero-container">
+        <h1 id="home-header" slot="hero-container">
           Ship your PWA to the app stores at lightning speed.
         </h1>
 


### PR DESCRIPTION
# Fixes 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
 Other... Please describe: UI improvement


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
We use a custom font as specified by our design. While this font loads, we display the default sans-serif font. Unfortunately, this font has some slight width differences from our custom font which caused the header width to change when the custom font loaded in, causing the page to "jump" on certain sized devices.

## Describe the new behavior?
The max-width of the header on the home page is tweaked slightly so that the header width stays constant when the custom font has loaded in (which can take a second on slow networks)

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
