### PR TITLE
Start errors a11y

### DIFF
--- a/src/script/components/app-modal.ts
+++ b/src/script/components/app-modal.ts
@@ -211,7 +211,7 @@ export class AppModal extends LitElement implements AppModalElement {
   render() {
     if (this.open) {
       return html`
-        <div id="background">
+        <div id="background" role="alert" aria-live="polite">
           <div part="modal-layout" id="modal">
             <div id="back-button-block">
               <fast-button @click="${this.close}" appearance="stealth">

--- a/src/script/components/app-modal.ts
+++ b/src/script/components/app-modal.ts
@@ -211,7 +211,7 @@ export class AppModal extends LitElement implements AppModalElement {
   render() {
     if (this.open) {
       return html`
-        <div id="background" role="alert" aria-live="polite">
+        <div id="background" role="alert">
           <div part="modal-layout" id="modal">
             <div id="back-button-block">
               <fast-button @click="${this.close}" appearance="stealth">

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -281,6 +281,7 @@ export class AppHome extends LitElement {
       this.gettingManifest = true;
       const isValidUrl = isValidURL(this.siteURL);
       recordPageAction('analysis-started', { url: this.siteURL, valid: isValidUrl });
+
       if (isValidUrl) {
         try {
           const manifestContext = await fetchOrCreateManifest(this.siteURL);
@@ -312,6 +313,10 @@ export class AppHome extends LitElement {
       } else {
         this.errorMessage = localeStrings.input.home.error.invalidURL;
         this.errorGettingURL = true;
+
+        await this.updateComplete;
+
+        (this.shadowRoot?.querySelector('.error-message')as HTMLSpanElement)?.focus();
       }
 
       // HACK: Lit 2.0 crashes on Safari 14 desktop on the following line:
@@ -371,13 +376,13 @@ export class AppHome extends LitElement {
         </section>
       
         <form id="input-form" slot="input-container" @submit="${(e: InputEvent) => this.start(e)}">
-          <div id="input-block">
+          <div id="input-block" role="region">
             <fast-text-field slot="input-container" type="text" placeholder="Enter the URL to your PWA" name="url-input"
               class="${classMap({ error: this.errorGettingURL })}" @input="${(e: InputEvent) => this.handleURL(e)}">
             </fast-text-field>
       
             ${this.errorMessage && this.errorMessage.length > 0
-      ? html`<span class="error-message">${this.errorMessage}</span>`
+      ? html`<span role="alert" aria-live="polite" class="error-message">${this.errorMessage}</span>`
       : null}
           </div>
       


### PR DESCRIPTION
# Fixes 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
https://dev.azure.com/microsoft/OS/_workitems/edit/35345688/

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Error prompt on homepage was not being focused as it should and also did not have the right aria attributes.

## Describe the new behavior?
Both the error prompt setup on the home page and our modals (which includes the error modal) now have the correct aria attributes. I also focus the error prompt manually for the user when there is an actual error.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
