### PR TITLE
fix(): package id for windows has a max length of 40

### DIFF
--- a/src/script/components/windows-form.ts
+++ b/src/script/components/windows-form.ts
@@ -203,7 +203,7 @@ export class WindowsForm extends LitElement {
                 type="text"
                 name="packageId"
                 pattern="[a-zA-Z0-9.-]*$"
-                maxlength="50"
+                maxlength="39"
                 required
               />
             </div>

--- a/src/script/utils/win-validation.ts
+++ b/src/script/utils/win-validation.ts
@@ -76,7 +76,7 @@ export function generateWindowsPackageId(host: string): string {
     .filter(p => p.length > 0)
     .map(p => p.replace(DISALLOWED_WINDOWS_PACKAGE_CHARS_REGEX, '-'));
   parts.push('edge');
-  return parts.join('.');
+  return parts.join('.').substring(0, 39);
 }
 
 export function validateWindowsOptions(


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
A partner was having issues using the test-package button for the Windows platform. It would error out and they would see our error modal. After debugging, I realized that the generated package IDs we use for the test package can be too long and that the max length for a package ID is 40 chars, not 50.

## Describe the new behavior?
- Generated IDs will now get substringed to 39 characters as the max length.
- The package ID input's max-length is now 39

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [ x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
