### PR TITLE
fix(): ensure short_name and name double checks test the right value

### DIFF
--- a/src/script/services/app-info.ts
+++ b/src/script/services/app-info.ts
@@ -164,8 +164,7 @@ export async function baseOrPublish(): Promise<'base' | 'publish'> {
     generatedFlag === false &&
     editedFlag === false    &&
     doubleCheckResults.icon &&
-    doubleCheckResults.name &&
-    doubleCheckResults.shortName &&
+    (doubleCheckResults.name || doubleCheckResults.shortName) &&
     doubleCheckResults.startURL
   ) {
     // User already has a manifest
@@ -288,10 +287,10 @@ async function doubleCheckManifest(maniContext: ManifestContext): Promise<{
     if (test.infoString.includes('start_url')) {
       startURL = test.result;
     }
-    if (test.infoString.includes('short_name')) {
+    if (test.infoString.includes('short_name') && test.infoString.toLowerCase().includes('name') === false) {
       shortName = test.result;
     }
-    if (test.infoString.includes('name')) {
+    if (test.infoString.includes('name') && test.infoString.toLowerCase().includes('short_name') === false) {
       name = test.result;
     }
     if (test.infoString.includes('512')) {


### PR DESCRIPTION
# Fixes #2127 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Turns out the above issues is not actually caused by the service worker, but instead their manifest lacking the short_name property. After checking with @JudahGabriel  on if the short_name AND name properties are required for Windows packages, it turns out only one of them is required. 

## Describe the new behavior?
Because of the above info, I updated the double check to be `(short_name || name)` and then had to make an update to the test logic to ensure that the correct value is being tested. Otherwise, if the user only had name or short_name, but not the other, it would still return false because of the `includes(name)` check.

This has been tested with the PWA from the issue, a glitch PWA that I used to test combinations of having one prop but not the other, Webboard (a "known good" PWA) and then our standard tests.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
