### PR TITLE
fix(): color inputs should not have padding

### DIFF
--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -53,6 +53,10 @@ export class AndroidForm extends LitElement {
           color: var(--font-color);
         }
 
+        input[type="color"] {
+          padding: 0px;
+        }
+
         input::placeholder {
           color: var(--placeholder-color);
           font-style: italic;


### PR DESCRIPTION
# Fixes 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->
ADO Issue: 36689050

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Color inputs had the standard padding we had on all inputs on this page. Unfortunately, this meant that the color inputs would not be able to show the custom color well as there was too much padding (shown in the ADO issue for this).

## Describe the new behavior?
input[type="color"] now has 0 padding.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
