### PR TITLE
Accessibility of links on home page.

### DIFF
--- a/src/script/components/app-card.ts
+++ b/src/script/components/app-card.ts
@@ -145,11 +145,7 @@ export class AppCard extends LitElement {
         .card-actions a span {
           display: inline-block;
           height: 28px;
-          border-bottom: 1px solid transparent
-        }
-
-        .card-actions a:hover span {
-          border-color: var(--link-color);
+          border-bottom: 1px solid var(--link-color);
         }
       `,
       // overlay


### PR DESCRIPTION
# Fixes 
https://microsoft.visualstudio.com/OS/_sprints/backlog/PWA%20Builder%20Team/OS/2110?workitem=35228696

## PR Type
 Bugfix

## Describe the current behavior?
The links in the bottom of the home page in the app-card component only showed the underline on hover. 

## Describe the new behavior?
The links in the bottom of the home page in the app-card component now show a permanent underline, making it more clear that it is a link.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
