### PR TITLE
links at bottom of home page now focusable

### DIFF
--- a/src/script/components/app-card.ts
+++ b/src/script/components/app-card.ts
@@ -142,6 +142,10 @@ export class AppCard extends LitElement {
           cursor: pointer;
         }
 
+        card-actions a:focus {
+          outline: 1px solid black;
+        }
+
         .card-actions a span {
           display: inline-block;
           height: 28px;
@@ -541,7 +545,7 @@ export class AppCard extends LitElement {
         <p>${this.description}</p>
       
         <div class="card-actions">
-          <a @click=${this.route}><span>View ${this.cardTitle}</span></a>
+          <a @click=${this.route} tabindex="0"><span>View ${this.cardTitle}</span></a>
         </div>
       </fast-card>
     `;


### PR DESCRIPTION
# Fixes 
https://microsoft.visualstudio.com/OS/_sprints/backlog/PWA%20Builder%20Team/OS/2110?workitem=35228696

## PR Type
Bugfix

## Describe the current behavior?
Links not focusable by keyboard at all.


## Describe the new behavior?
Added tabindex=0, links now focusable by tabbing through the page

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
