### PR TITLE
fix(): improve error handling + new error modal for testing page

### DIFF
--- a/src/script/pages/app-testing.ts
+++ b/src/script/pages/app-testing.ts
@@ -5,7 +5,9 @@ import { Router } from '@vaadin/router';
 import { smallBreakPoint } from '../utils/css/breakpoints';
 
 import { runAllTests } from '../services/tests';
+
 import '../components/app-header';
+import '../components/app-modal';
 
 // have to use ts-ignore here as typescript does not understand
 // this import yet
@@ -17,6 +19,9 @@ import style from '../../../styles/animations.css';
 export class AppTesting extends LitElement {
   @state() loading = false;
   @state() currentPhrase = 'PWABuilder is loading your PWA in the background';
+
+  @state() errored: boolean = false;
+  @state() errorMessage: string | undefined;
 
   static get styles() {
     return [
@@ -110,6 +115,17 @@ export class AppTesting extends LitElement {
           z-index: 2;
         }
 
+        .modal-image {
+          width: 50px;
+        }
+
+        #report-link {
+          color: white;
+          border-radius: var(--button-radius);
+          box-shadow: var(--button-shadow);
+          width: 10em;
+        }
+
         @keyframes fadeIn {
           from {
             opacity: 0;
@@ -145,7 +161,12 @@ export class AppTesting extends LitElement {
       this.loading = true;
       this.phrasePager();
 
-      await this.runTests(site);
+      try {
+        await this.runTests(site);
+      } catch (err: unknown) {
+        this.errored = true;
+        this.errorMessage = (err as Error).message || (err as Error).toString();
+      }
     }
   }
 
@@ -168,11 +189,13 @@ export class AppTesting extends LitElement {
         }, 300);
       } else {
         this.loading = false;
-        throw new Error(`Test results could not be gathered for: ${site}`);
+        throw new Error(`Test results could not be gathered for ${site}`);
       }
     } catch (err) {
-      console.error('Tests errored out', err);
       this.loading = false;
+      throw new Error(
+        `Test results could not be gathered for ${site} because ${err}`
+      );
     }
   }
 
@@ -204,7 +227,34 @@ export class AppTesting extends LitElement {
   };
 
   render() {
-    return html`<app-header></app-header>
+    return html` <app-header></app-header>
+
+      <app-modal
+        heading="Uh Oh!"
+        .body="${this.errorMessage ||
+        'There was an error running the tests. Please open an issue using the below link.'}"
+        ?open="${this.errored}"
+        id="error-modal"
+      >
+        <img
+          class="modal-image"
+          slot="modal-image"
+          src="/assets/warning.svg"
+          alt="warning icon"
+        />
+
+        <div slot="modal-actions">
+          <fast-anchor
+            target="_blank"
+            rel="noopener"
+            href="https://github.com/pwa-builder/PWABuilder/issues/new/choose"
+            id="report-link"
+            appearance="button"
+            >Report an Issue</fast-anchor
+          >
+        </div>
+      </app-modal>
+
       <div id="glass">
         <div id="testing-container">
           <span>${this.currentPhrase}</span>

--- a/src/script/services/tests/index.ts
+++ b/src/script/services/tests/index.ts
@@ -15,25 +15,29 @@ export async function runAllTests(url: string): Promise<RawTestResult> {
   // here for this function to work properly
   // this is also valid JavaScript
   // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async resolve => {
-    const maniTestResult = testManifest(url);
-    const serviceWorkerTestResult = testServiceWorker(url);
-    const securityTestResult = testSecurity(url);
+  return new Promise(async (resolve, reject) => {
+    try {
+      const maniTestResult = testManifest(url);
+      const serviceWorkerTestResult = testServiceWorker(url);
+      const securityTestResult = testSecurity(url);
 
-    const resultsObject: RawTestResult = {
-      manifest: await maniTestResult,
-      service_worker: await serviceWorkerTestResult,
-      security: await securityTestResult,
-    };
+      const resultsObject: RawTestResult = {
+        manifest: await maniTestResult,
+        service_worker: await serviceWorkerTestResult,
+        security: await securityTestResult,
+      };
 
-    setResults(resultsObject);
+      setResults(resultsObject);
 
-    const progress = getProgress();
-    updateProgress(progress, resultsObject);
+      const progress = getProgress();
+      updateProgress(progress, resultsObject);
 
-    giveOutBadges();
+      giveOutBadges();
 
-    resolve(resultsObject);
+      resolve(resultsObject);
+    } catch (err) {
+      reject(err);
+    }
   });
 }
 


### PR DESCRIPTION
# Fixes 
<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
There was recently a discussion with @JudahGabriel about the potential for people to get stuck on the testing page in certain error situations. While this hang is alot harder to reproduce nowadays, we still have one case where a user is wanting to use an IP address as their URL (which points to our need for local tooling) that will cause an error. To ensure that no one ever gets stuck on the testing page without some kind of user feedback, I have implemented new behavior.

## Describe the new behavior?
We now use our error modal on the testing page.  This ended up requiring two changes:
1. Using the scenario described above I discovered we had one key place where we were not catching errors, the runAllTests function. I improved the error handling of this function to makes sure that the promise rejects.
2. I improved the logic on the testing page to catch these types of errors
3. I added an error modal so that, in the rare event that a user encounters a hang up, they will be shown an error modal with the error itself and a link to open a new issue on our repo.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
