### PR TITLE
Allow space in Android app name

### DIFF
--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -275,7 +275,7 @@ export class AndroidForm extends AppPackageFormBase {
                 placeholder="My Awesome PWA"
                 value="${this.defaultOptions.name || 'My Awesome PWA'}"
                 required
-                pattern="[a-zA-Z0-9._]*$"
+                pattern="[a-zA-Z0-9._ ]*$"
                 name="appName"
               />
             </div>


### PR DESCRIPTION
# Fixes 
Fixes an issue where Android App Name wrongly disallowed a space in the name.

## PR Type
Bugfix

## Describe the current behavior?
Android app name can't contain a space. Android form control says the value is invalid.


## Describe the new behavior?
Android app name allows a space.