### PR TITLE
Fixed Android form. Better tooltip component.

### DIFF
--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -1,39 +1,30 @@
-import { css, html } from 'lit';
+import { css, html, TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import '../components/loading-button';
-import '../components/hover-tooltip';
 import { fetchOrCreateManifest } from '../services/manifest';
 import { createAndroidPackageOptionsFromManifest, emptyAndroidPackageOptions } from '../services/publish/android-publish';
-import { AndroidApkOptions } from '../utils/android-validation';
-import { Manifest } from '../utils/interfaces';
+import { ManifestContext } from '../utils/interfaces';
 import { localeStrings } from '../../locales';
 import { AppPackageFormBase } from './app-package-form-base';
+import { getManifestContext } from '../services/app-info';
+import { maxSigningKeySizeInBytes } from '../utils/android-validation';
 
 @customElement('android-form')
 export class AndroidForm extends AppPackageFormBase {
   @property({ type: Boolean }) generating = false;
-
   @state() showAdvanced = false;
-
-  // manifest form props
-  @state() signingKeyFullName = 'John Doe';
-  @state() organization = 'My Company';
-  @state() organizationalUnit = 'Engineering';
-  @state() countryCode = 'US';
-  @state() keyPassword = '';
-  @state() storePassword = '';
-  @state() alias = 'my-key-alias';
-  @state() file: string | undefined = undefined;
-  @state() signingMode = 'new';
-  @state() defaultOptions: AndroidApkOptions = emptyAndroidPackageOptions();
-
-  form: HTMLFormElement | undefined;
-  currentManifest: Manifest | undefined;
-  maxKeyFileSizeInBytes = 2097152;
+  @state() packageOptions = emptyAndroidPackageOptions();
+  @state() manifestContext: ManifestContext = getManifestContext();
 
   static get styles() {
     const localStyles = css`
+      .signing-key-fields {
+        margin-left: 30px;
+      }
+
+      #signing-key-file-input {
+        border: none;
+      }
     `;
     return [
       super.styles,
@@ -46,44 +37,22 @@ export class AndroidForm extends AppPackageFormBase {
   }
 
   async firstUpdated() {
-    const form = this.shadowRoot?.querySelector(
-      '#android-options-form'
-    ) as HTMLFormElement;
-
-    if (form) {
-      this.form = form;
+    if (this.manifestContext.isGenerated) {
+      this.manifestContext = await fetchOrCreateManifest();
     }
 
-    const manifestContext = await fetchOrCreateManifest();
-    this.currentManifest = manifestContext.manifest;
-
-    this.defaultOptions = await createAndroidPackageOptionsFromManifest(manifestContext.manifest);
+    this.packageOptions = createAndroidPackageOptionsFromManifest(this.manifestContext);
   }
 
   initGenerate(ev: InputEvent) {
     ev.preventDefault();
 
-    this.dispatchEvent(
-      new CustomEvent('init-android-gen', {
-        detail: {
-          form: this.form,
-          signingFile: this.file,
-        },
-        composed: true,
-        bubbles: true,
-      })
-    );
-  }
-
-  validatePackageId() {
-    const packageIdInput = this.form?.packageId;
-
-    if (packageIdInput?.value?.indexOf('if') !== -1) {
-      packageIdInput?.setCustomValidity("Package ID cannot include 'if'");
-    } else {
-      packageIdInput?.setCustomValidity('');
-    }
-    packageIdInput?.reportValidity();
+    const eventArgs = new CustomEvent('init-android-gen', {
+      detail: this.packageOptions,
+      composed: true,
+      bubbles: true,
+    });
+    this.dispatchEvent(eventArgs);      
   }
 
   toggleSettings(settingsToggleValue: 'basic' | 'advanced') {
@@ -96,73 +65,62 @@ export class AndroidForm extends AppPackageFormBase {
     }
   }
 
-
   /**
    * Called when the user changes the signing mode.
    */
   androidSigningModeChanged(mode: 'mine' | 'new' | 'none') {
-    if (!this.form) {
-      return;
-    }
+    this.packageOptions.signingMode = mode;
 
-    this.signingMode = mode;
-
-    // If the user chose "mine", clear out existing values.
+    // Reset the values as needed.
     if (mode === 'mine' || mode === 'none') {
-      this.alias = '';
-      this.signingKeyFullName = '';
-      this.organization = '';
-      this.organizationalUnit = '';
-      this.countryCode = '';
-      this.keyPassword = '';
-      this.storePassword = '';
+      this.packageOptions.signing.alias = '';
+      this.packageOptions.signing.fullName = '';
+      this.packageOptions.signing.organization = '';
+      this.packageOptions.signing.organizationalUnit = '';
+      this.packageOptions.signing.countryCode = '';
+      this.packageOptions.signing.keyPassword = '';
+      this.packageOptions.signing.storePassword = '';
     } else if (mode === 'new') {
-      this.alias = 'my-key-alias';
-      this.signingKeyFullName = `${
-        this.currentManifest?.short_name || this.currentManifest?.name || 'App'
-      } Admin`;
-      this.organization = this.currentManifest?.name || 'PWABuilder';
-      this.organizationalUnit = 'Engineering';
-      this.countryCode = 'US';
-      this.keyPassword = '';
-      this.storePassword = '';
-      this.file = undefined;
+      this.packageOptions.signing.alias = 'my-key-alias';
+      this.packageOptions.signing.fullName = (this.manifestContext.manifest.short_name || this.manifestContext.manifest.name || 'My PWA') + ' Admin';
+      this.packageOptions.signing.organization = this.manifestContext.manifest.name || 'PWABuilder';
+      this.packageOptions.signing.organizationalUnit = 'Engineering';
+      this.packageOptions.signing.countryCode = 'US';
+      this.packageOptions.signing.keyPassword = '';
+      this.packageOptions.signing.storePassword = '';
+      this.packageOptions.signing.file = null;
     }
+
+    // We need to re-render because Lit isn't watching packageOptions.signing, as it's a nested object.
+    this.requestUpdate();
   }
 
   androidSigningKeyUploaded(event: any) {
-    if (!this.form) {
-      return;
-    }
-
     const filePicker = event as HTMLInputElement;
-
     if (filePicker && filePicker.files && filePicker.files.length > 0) {
       const keyFile = filePicker.files[0];
       // Make sure it's a reasonable size.
-      if (keyFile && keyFile.size > this.maxKeyFileSizeInBytes) {
-        console.error('Keystore file is too large.', {
-          maxSize: this.maxKeyFileSizeInBytes,
+      if (keyFile && keyFile.size > maxSigningKeySizeInBytes) {
+        console.error('Android signing key file is too large. Max size:', {
+          maxSize: maxSigningKeySizeInBytes,
           fileSize: keyFile.size,
         });
-        this.signingMode = 'none';
+        this.packageOptions.signingMode = 'none';
       }
       // Read it in as a Uint8Array and store it in our signing object.
       const fileReader = new FileReader();
       fileReader.onload = () => {
-        this.file = fileReader.result as string;
-        return;
+        this.packageOptions.signing.file = fileReader.result as string;
       };
+
       fileReader.onerror = progressEvent => {
         console.error(
-          'Unable to read keystore file',
+          'Unable to read Android signing key file',
           fileReader.error,
           progressEvent
         );
-        this.file = undefined;
-        if (this.form) {
-          this.signingMode = 'none';
-        }
+        this.packageOptions.signing.file = null;
+        this.packageOptions.signingMode = 'none';
       };
       fileReader.readAsDataURL(keyFile as Blob);
     }
@@ -175,95 +133,64 @@ export class AndroidForm extends AppPackageFormBase {
         slot="modal-form"
         style="width: 100%"
         @submit="${(ev: InputEvent) => this.initGenerate(ev)}"
-        title=""
       >
         <div id="form-layout">
           <div class="basic-settings">
+            
             <div class="form-group">
-              <label for="packageIdInput">
-                Package ID
-                <i
-                  class="fas fa-info-circle"
-                  title="The unique identifier of your app. It should contain only letters, numbers, and periods. Example: com.companyname.appname"
-                  aria-label="The unique identifier of your app. It should contain only letters, numbers, and periods. Example: com.companyname.appname"
-                  role="definition"
-                ></i>
-
-                <hover-tooltip
-                  text="The unique identifier of your app. It should contain only letters, numbers, and periods. Example: com.companyname.appname"
-                  link="https://blog.pwabuilder.com/docs/android-platform"
-                >
-                </hover-tooltip>
-              </label>
-              <input
-                id="packageIdInput"
-                class="form-control"
-                placeholder="com.contoso.app"
-                value="${this.defaultOptions.packageId || 'com.contoso.app'}"
-                type="text"
-                required
-                pattern="[a-zA-Z0-9._]*$"
-                name="packageId"
-                @change="${() => this.validatePackageId()}"
-              />
+              ${this.renderFormInput({
+                label: 'Package ID',
+                tooltip: `The ID of your app on Google Play. Google recommends a reverse-domain style string: com.domainname.appname. Letters, numbers, periods, hyphens, and underscores are allowed.`,
+                tooltipLink: 'https://developer.android.com/guide/topics/manifest/manifest-element.html#package',
+                inputId: 'package-id-input',
+                required: true,
+                placeholder: 'MyCompany.MyApp',
+                value: this.packageOptions.packageId,
+                minLength: 3,
+                maxLength: 50,
+                spellcheck: false,
+                pattern: "[a-zA-Z0-9.-_]*$",
+                validationErrorMessage: "Package ID must contain only letters, numbers, periods, hyphens, and underscores.",
+                inputHandler: (val: string) => this.packageOptions.packageId = val
+              })}
             </div>
 
             <div class="form-group">
-              <label for="appNameInput">
-                App name
-                <i
-                  class="fas fa-info-circle"
-                  title="Please do not include special characters in your app name."
-                  aria-label="Please do not include special characters in your app name."
-                  role="definition"
-                ></i>
-
-                <hover-tooltip
-                  text="Please do not include special characters in your app name."
-                  link="https://blog.pwabuilder.com/docs/android-platform"
-                >
-                </hover-tooltip>
-              </label>
-              <input
-                type="text"
-                class="form-control"
-                id="appNameInput"
-                placeholder="My Awesome PWA"
-                value="${this.defaultOptions.name || 'My Awesome PWA'}"
-                required
-                name="appName" 
-              />
+              ${this.renderFormInput({
+                label: 'App name',
+                tooltip: `The full name of your app as displayed to end users`,
+                tooltipLink: 'https://support.google.com/googleplay/android-developer/answer/9859152?hl=en&visit_id=637726158830539690-3630173317&rd=1#details&zippy=%2Cproduct-details',
+                inputId: 'app-name-input',
+                required: true,
+                placeholder: 'My Awesome PWA',
+                value: this.packageOptions.name,
+                minLength: 3,
+                maxLength: 50,
+                spellcheck: false,
+                validationErrorMessage: "App name must be between 3 and 50 characters in length",
+                inputHandler: (val: string) => this.packageOptions.name = val
+              })}
             </div>
 
             <div class="form-group">
-              <label for="appLauncherNameInput">
-                Launcher name
-                <i
-                  class="fas fa-info-circle"
-                  title="The app name used on the Android launch screen. Typically, this is the short name of the app."
-                  aria-label="The app name used on the Android launch screen. Typically, this is the short name of the app."
-                  role="definition"
-                ></i>
-
-                <hover-tooltip
-                  text="The app name used on the Android launch screen. Typically, this is the short name of the app."
-                  link="https://blog.pwabuilder.com/docs/android-platform"
-                >
-                </hover-tooltip>
-              </label>
-              <input
-                type="text"
-                class="form-control"
-                id="appLauncherNameInput"
-                placeholder="Awesome PWA"
-                value="${this.defaultOptions.launcherName || 'Awesome PWA'}"
-                required
-                name="launcherName"
-              />
+              ${this.renderFormInput({
+                label: 'Short name',
+                tooltip: `The shorter version of your app name displayed on the Android home screen. Google recommends no more than 12 characters.`,
+                tooltipLink: 'https://developer.chrome.com/apps/manifest/name#short_name',
+                inputId: 'short-name-input',
+                required: true,
+                placeholder: 'My PWA',
+                value: this.packageOptions.launcherName,
+                minLength: 3,
+                maxLength: 30,
+                spellcheck: false,
+                validationErrorMessage: "Short name must be between 3 and 30 characters in length. Google recommends 12 characters or fewer.",
+                inputHandler: (val: string) => this.packageOptions.launcherName = val
+              })}
             </div>
           </div>
 
-          <!-- right half of the options dialog -->
+          <!-- The "all settings" section of the options dialog -->
           <fast-accordion>
             <fast-accordion-item
               @click="${(ev: Event) => this.toggleAccordion(ev.target)}"
@@ -277,930 +204,410 @@ export class AndroidForm extends AppPackageFormBase {
               </div>
 
               <div class="adv-settings">
-                <div>
-                  <div class="">
-                    <div class="form-group">
-                      <label for="appVersionInput">
-                        App version
-                        <i
-                          class="fas fa-info-circle"
-                          title="The version of your app displayed to users. This is a string, typically in the form of '1.0.0.0'. Maps to android:versionName."
-                          aria-label
-                          role="definition"
-                        ></i>
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Version',
+                    tooltip: `The version of your app displayed to users. This is a string, typically in the form of '1.0.0.0'. Maps to android:versionName.`,
+                    tooltipLink: 'https://developer.android.com/guide/topics/manifest/manifest-element.html#vname',
+                    inputId: 'version-input',
+                    required: true,
+                    placeholder: '1.0.0.0',
+                    value: this.packageOptions.appVersion,
+                    spellcheck: false,
+                    inputHandler: (val: string) => this.packageOptions.appVersion = val
+                  })}
+                </div>
+                
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Version code',
+                    tooltip: `A positive integer used as an internal version number. This is not shown to users. This number is used by Google Play to determine whether one version is more recent than another, with higher numbers indicating more recent versions. Maps to android:versionCode.`,
+                    tooltipLink: 'https://developer.android.com/guide/topics/manifest/manifest-element.html#vcode',
+                    inputId: 'version-code-input',
+                    type: 'number',
+                    minValue: 1,
+                    maxValue: 2100000000,
+                    required: true,
+                    placeholder: '1',
+                    value: this.packageOptions.appVersionCode.toString(),
+                    inputHandler: (val: string) => this.packageOptions.appVersionCode = parseInt(val, 10)
+                  })}
+                </div>
 
-                        <hover-tooltip
-                          text="The version of your app displayed to users. This is a string, typically in the form of '1.0.0.0'. Maps to android:versionName."
-                          link="https://blog.pwabuilder.com/docs/android-platform"
-                        >
-                        </hover-tooltip>
-                      </label>
-                      <input
-                        type="text"
-                        class="form-control"
-                        id="appVersionInput"
-                        placeholder="1.0.0.0"
-                        value="${this.defaultOptions.appVersion || '1.0.0.0'}"
-                        required
-                        name="appVersion"
-                      />
-                    </div>
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Host',
+                    tooltip: `The host portion of your PWA's URL. For example, mypwa.com`,
+                    inputId: 'host-input',
+                    required: true,
+                    placeholder: 'mypwa.com',
+                    value: this.packageOptions.host,
+                    minLength: 3,
+                    spellcheck: false,
+                    inputHandler: (val: string) => this.packageOptions.host = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Start URL',
+                    tooltip: `The start path for your PWA. Must be relative to the Host URL. If Host URL contains your PWA, you can use '/' to specify a default`,
+                    tooltipLink: 'https://developer.mozilla.org/en-US/docs/Web/Manifest/start_url',
+                    inputId: 'start-url-input',
+                    required: true,
+                    placeholder: '/index.html',
+                    value: this.packageOptions.startUrl,
+                    spellcheck: false,
+                    validationErrorMessage: "You must specify a relative start URL. If you don't have a start URL, use '/'",
+                    inputHandler: (val: string) => this.packageOptions.startUrl = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Theme color',
+                    tooltip: `The theme color used for the Android status bar in your app. Typically, this should be set to your manifest's theme_color.`,
+                    inputId: 'theme-color-input',
+                    type: 'color',
+                    value: this.packageOptions.themeColor,
+                    inputHandler: (val: string) => this.packageOptions.themeColor = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Background color',
+                    tooltip: `The background color to use for your app's splash screen. Typically this is set to your manifest's background_color.`,
+                    inputId: 'background-color-input',
+                    type: 'color',
+                    value: this.packageOptions.backgroundColor,
+                    inputHandler: (val: string) => this.packageOptions.backgroundColor = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Nav color',
+                    tooltip: `The color of the Android navigation bar in your app. Typically this is set to your manifest's theme_color`,
+                    inputId: 'nav-color-input',
+                    type: 'color',
+                    value: this.packageOptions.navigationColor,
+                    inputHandler: (val: string) => this.packageOptions.navigationColor = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Nav dark color',
+                    tooltip: `The color of the Android navigation bar in your app when the Android device is in dark mode.`,
+                    inputId: 'nav-dark-color-input',
+                    type: 'color',
+                    value: this.packageOptions.navigationColorDark,
+                    inputHandler: (val: string) => this.packageOptions.navigationColorDark = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Nav divider color',
+                    tooltip: `The color of the Android navigation bar divider in your app.`,
+                    inputId: 'nav-divider-color-input',
+                    type: 'color',
+                    value: this.packageOptions.navigationDividerColor,
+                    inputHandler: (val: string) => this.packageOptions.navigationDividerColor = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Nav divider dark color',
+                    tooltip: `The color of the Android navigation bar divider in your app when the Android device is in dark mode.`,
+                    inputId: 'nav-divider-dark-color-input',
+                    type: 'color',
+                    value: this.packageOptions.navigationDividerColorDark,
+                    inputHandler: (val: string) => this.packageOptions.navigationDividerColorDark = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Icon URL',
+                    tooltip: `The URL to a square PNG image to use for your app's icon. Can be absolute or relative to your manifest. Google recommends a 512x512 PNG without shadows.`,
+                    tooltipLink: 'https://developer.android.com/distribute/google-play/resources/icon-design-specifications',
+                    inputId: 'icon-url-input',
+                    required: true,
+                    spellcheck: false,
+                    value: this.packageOptions.iconUrl,
+                    placeholder: '/icons/512x512.png',
+                    inputHandler: (val: string) => this.packageOptions.iconUrl = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Maskable icon URL',
+                    tooltip: `Optional. The URL to a PNG image with a minimum safe zone of trimmable padding, enabling rounded icons on certain Android versions. Google recommends a 512x512 PNG without shadows.`,
+                    tooltipLink: 'https://web.dev/maskable-icon',
+                    inputId: 'maskable-icon-url-input',
+                    spellcheck: false,
+                    value: this.packageOptions.maskableIconUrl || '',
+                    placeholder: '/icons/512x512-maskable.png',
+                    inputHandler: (val: string) => this.packageOptions.maskableIconUrl = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Monochrome icon URL',
+                    tooltip: `Optional. The URL to a PNG image containing only white and black colors, enabling Android to fill the icon with user-specified color or
+                    gradient depending on theme, color mode, or Android ontrast settings.`,
+                    tooltipLink: 'https://w3c.github.io/manifest/#monochrome-icons-and-solid-fills',
+                    inputId: 'monochrome-icon-url-input',
+                    spellcheck: false,
+                    value: this.packageOptions.monochromeIconUrl || '',
+                    placeholder: '/icons/512x512-monochrome.png',
+                    inputHandler: (val: string) => this.packageOptions.monochromeIconUrl = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Manifest URL',
+                    tooltip: `The absolute URL of your web manifest.`,
+                    inputId: 'manifest-url-input',
+                    type: 'url',
+                    value: this.packageOptions.webManifestUrl,
+                    placeholder: 'https://myawesomepwa.com/manifest.json',
+                    inputHandler: (val: string) => this.packageOptions.webManifestUrl = val
+                  })}
+                </div>
+
+                <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Splash fade out duration (ms)',
+                    tooltip: `How long the splash screen fade out animation should last in milliseconds.`,
+                    inputId: 'splash-fade-out-input',
+                    type: 'number',
+                    value: (this.packageOptions.splashScreenFadeOutDuration || 0).toString(),
+                    placeholder: '300',
+                    inputHandler: (val: string) => this.packageOptions.splashScreenFadeOutDuration = parseInt(val, 10)
+                  })}
+                </div>
+
+                <div class="form-group">
+                  <label>${localeStrings.text.android.titles.fallback}</label>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Custom Tabs',
+                      tooltip: `When Trusted Web Activity (TWA) is unavailable, use Chrome Custom Tabs as a fallback to run your app.`,
+                      tooltipLink: 'https://developer.chrome.com/docs/android/custom-tabs/',
+                      inputId: 'chrome-custom-tab-fallback-input',
+                      type: 'radio',
+                      name: 'fallbackType',
+                      value: 'customtabs',
+                      checked: this.packageOptions.fallbackType === 'customtabs',
+                      inputHandler: () => this.packageOptions.fallbackType = 'customtabs'
+                    })}
+                  </div>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Web View',
+                      tooltip: `When Trusted Web Activity (TWA) is unavailable, use a web view as a fallback to run your app.`,
+                      tooltipLink: 'https://developer.chrome.com/docs/android/custom-tabs/',
+                      inputId: 'web-view-fallback-input',
+                      type: 'radio',
+                      name: 'fallbackType',
+                      value: 'webview',
+                      checked: this.packageOptions.fallbackType === 'webview',
+                      inputHandler: () => this.packageOptions.fallbackType = 'webview'
+                    })}
                   </div>
                 </div>
-              </div>
 
-              <div>
-                <div class="">
-                  <div class="form-group">
-                    <label for="appVersionCodeInput">
-                      <a
-                        href="https://developer.android.com/studio/publish/versioning#appversioning"
-                        target="_blank"
-                        rel="noopener"
-                        tabindex="-1"
-                        >App version code</a
-                      >
-                      <i
-                        class="fas fa-info-circle"
-                        title="A positive integer used as an internal version number. This is not shown to users. Android uses this value to protect against downgrades. Maps to android:versionCode."
-                        aria-label="A positive integer used as an internal version number. This is not shown to users. Android uses this value to protect against downgrades. Maps to android:versionCode."
-                        role="definition"
-                        style="margin-left: 5px;"
-                      ></i>
-
-                      <hover-tooltip
-                        text="A positive integer used as an internal version number. This is not shown to users. Android uses this value to protect against downgrades. Maps to android:versionCode."
-                        link="https://blog.pwabuilder.com/docs/android-platform"
-                      >
-                      </hover-tooltip>
-                    </label>
-                    <input
-                      type="number"
-                      min="1"
-                      max="2100000000"
-                      class="form-control"
-                      id="appVersionCodeInput"
-                      name="appVersionCode"
-                      placeholder="1"
-                      required
-                      value="${this.defaultOptions.appVersionCode || 1}"
-                    />
+                <div class="form-group">
+                  <label>${localeStrings.text.android.titles.display_mode}</label>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Standalone',
+                      tooltip: 'Recommended for most apps. The Android status bar and navigation bar will be shown while your app is running.',
+                      tooltipLink: 'https://developer.android.com/training/system-ui/immersive',
+                      inputId: 'display-standalone-input',
+                      type: 'radio',
+                      name: 'displayMode',
+                      value: 'standalone',
+                      checked: this.packageOptions.display === 'standalone',
+                      inputHandler: () => this.packageOptions.display = 'standalone'
+                    })}
+                  </div>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Fullscreen',
+                      tooltip: `The Android status bar and navigation bar will be hidden while your app is running. Suitable for immersive experiences such as games or media apps.`,
+                      tooltipLink: 'https://developer.android.com/training/system-ui/immersive#immersive',
+                      inputId: 'display-fullscreen-input',
+                      type: 'radio',
+                      name: 'displayMode',
+                      value: 'fullscreen',
+                      checked: this.packageOptions.display === 'fullscreen',
+                      inputHandler: () => this.packageOptions.display = 'fullscreen'
+                    })}
+                  </div>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Fullscreen sticky',
+                      tooltip: `The Android status bar and navigation bar will be hidden while your app is running, and if the user swipes from the edge of the Android device, the system bars will be semi-transparent, and the touch gesture will be passed to your app. Recommended for drawing apps, and games that require lots of swiping.`,
+                      tooltipLink: 'https://developer.android.com/training/system-ui/immersive#sticky-immersive',
+                      inputId: 'display-fullscreen-sticky-input',
+                      type: 'radio',
+                      name: 'displayMode',
+                      value: 'fullscreen-sticky',
+                      checked: this.packageOptions.display === 'fullscreen-sticky',
+                      inputHandler: () => this.packageOptions.display = 'fullscreen-sticky'
+                    })}
                   </div>
                 </div>
-              </div>
 
-              <div>
-                <div class="">
-                  <div class="form-group">
-                    <label for="hostInput">Host</label>
-                    <input
-                      type="url"
-                      class="form-control"
-                      id="hostInput"
-                      placeholder="https://mysite.com"
-                      required
-                      name="host"
-                      value="${this.defaultOptions.host || 'https://mysite.com'}"
-                    />
+                <div class="form-group">
+                  <label>${localeStrings.text.android.titles.notification}</label>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Enable',
+                      tooltip: `If enabled, your PWA can send push notifications without browser permission prompts.`,
+                      tooltipLink: 'https://github.com/GoogleChromeLabs/svgomg-twa/issues/60',
+                      inputId: 'notification-delegation-input',
+                      type: 'checkbox',
+                      checked: this.packageOptions.enableNotifications === true,
+                      inputHandler: (_, checked) => this.packageOptions.enableNotifications = checked
+                    })}
                   </div>
                 </div>
-              </div>
 
-              <div class="form-group">
-                <label for="startUrlInput">
-                  Start URL
-                  <i
-                    class="fas fa-info-circle"
-                    title="The start path for the TWA. Must be relative to the Host URL. You can specify '/' if you don't have a start URL different from Host."
-                    aria-label="The start path for the TWA. Must be relative to the Host URL."
-                    role="definition"
-                  ></i>
-
-                  <hover-tooltip
-                    text="The start path for the TWA. Must be relative to the Host URL. You can specify '/' if you don't have a start URL different from Host."
-                    link="https://blog.pwabuilder.com/docs/android-platform"
-                  >
-                  </hover-tooltip>
-                </label>
-                <!-- has to be a text type as / is not a valid URL in the input in the spec -->
-                <input
-                  type="text"
-                  class="form-control"
-                  id="startUrlInput"
-                  placeholder="/index.html"
-                  required
-                  name="startUrl"
-                  value="${this.defaultOptions.startUrl || '/'}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="themeColorInput">
-                  Status bar color
-                  <i
-                    class="fas fa-info-circle"
-                    title="Also known as the theme color, this is the color of the Android status bar in your app. Note: the status bar will be hidden if Display Mode is set to fullscreen."
-                    aria-label="Also known as the theme color, this is the color of the Android status bar in your app. Note: the status bar will be hidden if Display Mode is set to fullscreen."
-                    role="definition"
-                  ></i>
-
-                  <hover-tooltip
-                    text="Also known as the theme color, this is the color of the Android status bar in your app. Note: the status bar will be hidden if Display Mode is set to fullscreen."
-                    link="https://blog.pwabuilder.com/docs/android-platform"
-                  >
-                  </hover-tooltip>
-                </label>
-                <input
-                  type="color"
-                  class="form-control"
-                  id="themeColorInput"
-                  name="themeColor"
-                  value="${this.defaultOptions.themeColor || 'black'}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="bgColorInput">
-                  Splash color
-                  <i
-                    class="fas fa-info-circle"
-                    title="Also known as background color, this is the color of the splash screen for your app."
-                    aria-label="Also known as background color, this is the color of the splash screen for your app."
-                    role="definition"
-                  ></i>
-
-                  <hover-tooltip
-                    text="Also known as background color, this is the color of the splash screen for your app."
-                    link="https://blog.pwabuilder.com/docs/android-platform"
-                  >
-                  </hover-tooltip>
-                </label>
-                <input
-                  type="color"
-                  class="form-control"
-                  id="bgColorInput"
-                  name="backgroundColor"
-                  value="${this.defaultOptions.backgroundColor || 'black'}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="navigationColorInput">
-                  Nav color
-                  <i
-                    class="fas fa-info-circle"
-                    title="The color of the Android navigation bar in your app. Note: the navigation bar will be hidden if Display Mode is set to fullscreen."
-                    aria-label="The color of the Android navigation bar in your app. Note: the navigation bar will be hidden if Display Mode is set to fullscreen."
-                    role="definition"
-                  ></i>
-
-                  <hover-tooltip
-                    text="The color of the Android navigation bar in your app. Note: the navigation bar will be hidden if Display Mode is set to fullscreen."
-                    link="https://blog.pwabuilder.com/docs/android-platform"
-                  >
-                  </hover-tooltip>
-                </label>
-                <input
-                  type="color"
-                  class="form-control"
-                  id="navigationColorInput"
-                  name="navigationColor"
-                  value="${this.defaultOptions.navigationColor || 'black'}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="navigationColorDarkInput">
-                  Nav dark color
-                  <i
-                    class="fas fa-info-circle"
-                    title="The color of the Android navigation bar in your app when Android is in dark mode."
-                    aria-label="The color of the Android navigation bar in your app when Android is in dark mode."
-                    role="definition"
-                  ></i>
-
-                  <hover-tooltip
-                    text="The color of the Android navigation bar in your app when Android is in dark mode."
-                    link="https://blog.pwabuilder.com/docs/android-platform"
-                  >
-                  </hover-tooltip>
-                </label>
-                <input
-                  type="color"
-                  class="form-control"
-                  id="navigationColorDarkInput"
-                  name="navigationColorDark"
-                  value="${this.defaultOptions.navigationColorDark || 'black'}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="navigationDividerColorInput">
-                  Nav divider color
-                  <i
-                    class="fas fa-info-circle"
-                    title="The color of the Android navigation bar divider in your app."
-                    aria-label="The color of the Android navigation bar divider in your app."
-                    role="definition"
-                  ></i>
-
-                  <hover-tooltip
-                    text="The color of the Android navigation bar divider in your app."
-                    link="https://blog.pwabuilder.com/docs/android-platform"
-                  >
-                  </hover-tooltip>
-                </label>
-                <input
-                  type="color"
-                  class="form-control"
-                  id="navigationDividerColorInput"
-                  name="navigationDividerColor"
-                  value="${this.defaultOptions.navigationDividerColor || 'black'}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="navigationDividerColorDarkInput">
-                  Nav divider dark color
-                  <i
-                    class="fas fa-info-circle"
-                    title="The color of the Android navigation navigation bar divider in your app when Android is in dark mode."
-                    aria-label="The color of the Android navigation bar divider in your app when Android is in dark mode."
-                    role="definition"
-                  ></i>
-
-                  <hover-tooltip
-                    text="The color of the Android navigation navigation bar divider in your app when Android is in dark mode."
-                    link="https://blog.pwabuilder.com/docs/android-platform"
-                  >
-                  </hover-tooltip>
-                </label>
-                <input
-                  type="color"
-                  class="form-control"
-                  id="navigationDividerColorDarkInput"
-                  name="navigationDividerColorDark"
-                  value="${this.defaultOptions.navigationDividerColorDark || 'black'}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="iconUrlInput">Icon URL</label>
-                <input
-                  type="url"
-                  class="form-control"
-                  id="iconUrlInput"
-                  placeholder="https://myawesomepwa.com/512x512.png"
-                  name="iconUrl"
-                  value="${this.defaultOptions.iconUrl || ''}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="maskIconUrlInput">
-                  <a
-                    href="https://web.dev/maskable-icon"
-                    title="Read more about maskable icons"
-                    target="_blank"
-                    rel="noopener"
-                    aria-label="Read more about maskable icons"
-                    tabindex="-1"
-                  >
-                    Maskable icon URL
-                  </a>
-                  <i
-                    class="fas fa-info-circle"
-                    title="Optional. The URL to an icon with a minimum safe zone of trimmable padding, enabling rounded icons on certain Android platforms."
-                    aria-label="Optional. The URL to an icon with a minimum safe zone of trimmable padding, enabling rounded icons on certain Android platforms."
-                    role="definition"
-                  ></i>
-
-                  <hover-tooltip
-                    text="Optional. The URL to an icon with a minimum safe zone of trimmable padding, enabling rounded icons on certain Android platforms."
-                    link="https://blog.pwabuilder.com/docs/android-platform"
-                  >
-                  </hover-tooltip>
-                </label>
-                <input
-                  type="url"
-                  class="form-control"
-                  id="maskIconUrlInput"
-                  placeholder="https://myawesomepwa.com/512x512-maskable.png"
-                  name="maskableIconUrl"
-                  .value="${this.defaultOptions.maskableIconUrl || ''}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="monochromeIconUrlInput">
-                  <a
-                    href="https://w3c.github.io/manifest/#monochrome-icons-and-solid-fills"
-                    target="_blank"
-                    rel="noopener"
-                    tabindex="-1"
-                    >Monochrome icon URL</a
-                  >
-                  <i
-                    class="fas fa-info-circle"
-                    title="Optional. The URL to an icon containing only white and black colors, enabling Android to fill the icon with user-specified color or gradient depending on theme, color mode, or contrast settings."
-                    aria-label="Optional. The URL to an icon containing only white and black colors, enabling Android to fill the icon with user-specified color or gradient depending on theme, color mode, or contrast settings."
-                    role="definition"
-                  ></i>
-
-                  <hover-tooltip
-                    text="Optional. The URL to an icon containing only white and black colors, enabling Android to fill the icon with user-specified color or gradient depending on theme, color mode, or contrast settings."
-                    link="https://blog.pwabuilder.com/docs/android-platform"
-                  >
-                  </hover-tooltip>
-                </label>
-                <input
-                  type="url"
-                  class="form-control"
-                  id="monochromeIconUrlInput"
-                  placeholder="https://myawesomepwa.com/512x512-monochrome.png"
-                  name="monochromeIconUrl"
-                  .value="${this.defaultOptions.monochromeIconUrl || ''}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="webManifestUrlInput"> Manifest URL </label>
-                <input
-                  type="url"
-                  class="form-control"
-                  id="webManifestUrlInput"
-                  placeholder="https://myawesomepwa.com/manifest.json"
-                  name="webManifestUrl"
-                  .value="${this.defaultOptions.webManifestUrl || ''}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label for="splashFadeoutInput"
-                  >Splash screen fade out duration (ms)</label
-                >
-                <input
-                  type="number"
-                  class="form-control"
-                  id="splashFadeoutInput"
-                  placeholder="300"
-                  name="splashScreenFadeOutDuration"
-                  value="${this.defaultOptions.splashScreenFadeOutDuration || '300'}"
-                />
-              </div>
-
-              <div class="form-group">
-                <label>${localeStrings.text.android.titles.fallback}</label>
-                <div class="form-check">
-                  <input
-                    .defaultChecked="${true}"
-                    value="customtabs"
-                    class="form-check-input"
-                    type="radio"
-                    name="fallbackType"
-                    id="fallbackCustomTabsInput"
-                    name="fallbackType"
-                  />
-                  <label class="form-check-label" for="fallbackCustomTabsInput">
-                    Custom Tabs
-                    <i
-                      class="fas fa-info-circle"
-                      title="Use Chrome Custom Tabs as a fallback for your PWA when the full trusted web activity (TWA) experience is unavailable."
-                      aria-label="When trusted web activity (TWA) is unavailable, use Chrome Custom Tabs as a fallback for your PWA."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="Use Chrome Custom Tabs as a fallback for your PWA when the full trusted web activity (TWA) experience is unavailable."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-                <div class="form-check">
-                  <input
-                    .defaultChecked="${false}"
-                    value="webview"
-                    class="form-check-input"
-                    type="radio"
-                    name="fallbackType"
-                    id="fallbackWebViewInput"
-                    value="webview"
-                    name="fallbackType"
-                  />
-                  <label class="form-check-label" for="fallbackWebViewInput">
-                    Web View
-                    <i
-                      class="fas fa-info-circle"
-                      title="Use a web view as the fallback for your PWA when the full trusted web activity (TWA) experience is unavailable."
-                      aria-label="When trusted web activity (TWA) is unavailable, use a web view as the fallback for your PWA."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="Use a web view as the fallback for your PWA when the full trusted web activity (TWA) experience is unavailable."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-              </div>
-
-              <div class="form-group">
-                <label>${localeStrings.text.android.titles.display_mode}</label>
-                <div class="form-check">
-                  <input
-                    class="form-check-input"
-                    type="radio"
-                    name="displayMode"
-                    id="standaloneDisplayModeInput"
-                    .defaultChecked="${this.defaultOptions.display === 'standalone'}"
-                    value="standalone"
-                    name="display"
-                  />
+                <div class="form-group">
                   <label
-                    class="form-check-label"
-                    for="standaloneDisplayModeInput"
+                    >${localeStrings.text.android.titles
+                      .location_delegation}</label
                   >
-                    Standalone
-                    <i
-                      class="fas fa-info-circle"
-                      title="Your PWA will use the whole screen but keep the Android status bar and navigation bar."
-                      aria-label="Your PWA will use the whole screen but keep the Android status bar and navigation bar."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="Your PWA will use the whole screen but keep the Android status bar and navigation bar."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Enable',
+                      tooltip: 'If enabled, your PWA can access navigator.geolocation without browser permission prompts.',
+                      inputId: 'location-delegation-input',
+                      type: 'checkbox',
+                      checked: this.packageOptions.features.locationDelegation?.enabled === true,
+                      inputHandler: (_, checked) => this.packageOptions.features.locationDelegation!.enabled = checked
+                    })}
+                  </div>
                 </div>
-                <div class="form-check">
-                  <input
-                    class="form-check-input"
-                    type="radio"
-                    name="displayMode"
-                    id="fullscreenDisplayModeInput"
-                    .defaultChecked="${this.defaultOptions.display === 'fullscreen'}"
-                    value="fullscreen"
-                    name="display"
-                  />
+
+                <div class="form-group">
                   <label
-                    class="form-check-label"
-                    for="fullscreenDisplayModeInput"
+                    >${localeStrings.text.android.titles
+                      .google_play_billing}</label
                   >
-                    Fullscreen
-                    <i
-                      class="fas fa-info-circle"
-                      title="Your PWA will use the whole screen and remove the Android status bar and navigation bar. Suitable for immersive experiences such as games or media apps."
-                      aria-label="Your PWA will use the whole screen and remove the Android status bar and navigation bar. Suitable for immersive experiences such as games or media apps."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="Your PWA will use the whole screen and remove the Android status bar and navigation bar. Suitable for immersive experiences such as games or media apps."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Enable',
+                      tooltip: 'If enabled, your PWA can sell in-app purchases and subscriptions via the Digital Goods API.',
+                      tooltipLink: 'https://developer.chrome.com/docs/android/trusted-web-activity/receive-payments-play-billing/',
+                      inputId: 'google-play-billing-input',
+                      type: 'checkbox',
+                      checked: this.packageOptions.features.playBilling?.enabled === true,
+                      inputHandler: (_, checked) => this.packageOptions.features.playBilling!.enabled = checked
+                    })}
+                  </div>
                 </div>
+
+                <div class="form-group">
+                  <label>
+                    ${localeStrings.text.android.titles.settings_shortcut}
+                  </label>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Enable',
+                      tooltip: 'If enabled, users can long-press on your app tile and a Settings menu item will appear, letting users manage space for your app.',
+                      tooltipLink: 'https://github.com/pwa-builder/PWABuilder/issues/1113',
+                      inputId: 'site-settings-shortcut-input',
+                      type: 'checkbox',
+                      checked: this.packageOptions.enableSiteSettingsShortcut === true,
+                      inputHandler: (_, checked) => this.packageOptions.enableSiteSettingsShortcut = checked
+                    })}
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label>
+                    ${localeStrings.text.android.titles.chromeos_only}
+                  </label>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Enable',
+                      tooltip: 'If enabled, your Android package will only run on ChromeOS devices.',
+                      inputId: 'chromeos-only-input',
+                      type: 'checkbox',
+                      checked: this.packageOptions.isChromeOSOnly === true,
+                      inputHandler: (_, checked) => this.packageOptions.isChromeOSOnly = checked
+                    })}
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label>${localeStrings.text.android.titles.source_code}</label>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Enable',
+                      tooltip: 'If enabled, your download will include the source code for your Android app.',
+                      inputId: 'include-src-input',
+                      type: 'checkbox',
+                      checked: this.packageOptions.includeSourceCode === true,
+                      inputHandler: (_, checked) => this.packageOptions.includeSourceCode = checked
+                    })}
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label>${localeStrings.text.android.titles.signing_key}</label>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'New',
+                      tooltip: `Recommended for new apps in Google Play. PWABuilder will generate a new signing key for you and sign your package with it. Your download will contain the new signing details.`,
+                      inputId: 'signing-new-input',
+                      name: 'signingMode',
+                      value: 'new',
+                      type: 'radio',
+                      checked: this.packageOptions.signingMode === 'new',
+                      inputHandler: () => this.androidSigningModeChanged('new')
+                    })}
+                  </div>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'Use mine',
+                      tooltip: 'Recommended for existing apps in Google Play. Use this option if you already have a signing key and you want to publish a new version of an existing app in Google Play.',
+                      inputId: 'signing-mine-input',
+                      name: 'signingMode',
+                      value: 'mine',
+                      type: 'radio',
+                      checked: this.packageOptions.signingMode === 'mine',
+                      inputHandler: () => this.androidSigningModeChanged('mine')
+                    })}
+                  </div>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'None',
+                      tooltip: 'PWABuilder will generate a raw, unsigned APK. Raw, unsigned APKs cannot be uploaded to the Google Play Store.',
+                      inputId: 'signing-none-input',
+                      name: 'signingMode',
+                      value: 'none',
+                      type: 'radio',
+                      checked: this.packageOptions.signingMode === 'none',
+                      inputHandler: () => this.androidSigningModeChanged('none')
+                    })}
+                  </div>
+                </div>
+
+                ${this.renderSigningKeyFields()}
+                
               </div>
 
-              <div class="form-group">
-                <label>${localeStrings.text.android.titles.notification}</label>
-                <div class="form-check">
-                  <input
-                    .defaultChecked="${true}"
-                    class="form-check-input"
-                    type="checkbox"
-                    id="enableNotificationsInput"
-                    name="enableNotifications"
-                  />
-                  <label
-                    class="form-check-label"
-                    for="enableNotificationsInput"
-                  >
-                    Enable
-                    <i
-                      class="fas fa-info-circle"
-                      title="Whether to enable Push Notification Delegation. If enabled, your PWA can send push notifications without browser permission prompts."
-                      aria-label="Whether to enable Push Notification Delegation. If enabled, your PWA can send push notifications without browser permission prompts."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="Whether to enable Push Notification Delegation. If enabled, your PWA can send push notifications without browser permission prompts."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-              </div>
-
-              <div class="form-group">
-                <label
-                  >${localeStrings.text.android.titles
-                    .location_delegation}</label
-                >
-                <div class="form-check">
-                  <input
-                    .defaultChecked="${true}"
-                    class="form-check-input"
-                    type="checkbox"
-                    id="enableLocationInput"
-                    name="locationDelegation"
-                  />
-                  <label class="form-check-label" for="enableLocationInput">
-                    Enable
-                    <i
-                      class="fas fa-info-circle"
-                      title="Whether to enable Location Delegation. If enabled, your PWA can acess navigator.geolocation without browser permission prompts."
-                      aria-label="Whether to enable Location Delegation. If enabled, your PWA can acess navigator.geolocation without browser permission prompts."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="Whether to enable Location Delegation. If enabled, your PWA can acess navigator.geolocation without browser permission prompts."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-              </div>
-
-              <div class="form-group">
-                <label
-                  >${localeStrings.text.android.titles
-                    .google_play_billing}</label
-                >
-                <div class="form-check">
-                  <input
-                    .defaultChecked="${false}"
-                    class="form-check-input"
-                    type="checkbox"
-                    id="enablePlayBillingInput"
-                    name="playBilling"
-                  />
-                  <label class="form-check-label" for="enablePlayBillingInput">
-                    Enable
-                    <i
-                      class="fas fa-info-circle"
-                      title="Whether to enable in-app purchases through Google Play Billing and the Digital Goods API."
-                      aria-label="Whether to enable in-app purchases through Google Play Billing and the Digital Goods API."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="Whether to enable in-app purchases through Google Play Billing and the Digital Goods API."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-              </div>
-
-              <div class="form-group">
-                <label
-                  >${localeStrings.text.android.titles.settings_shortcut}</label
-                >
-                <div class="form-check">
-                  <input
-                    .defaultChecked="${true}"
-                    class="form-check-input"
-                    type="checkbox"
-                    id="enableSettingsShortcutInput"
-                    name="enableSiteSettingsShortcut"
-                  />
-                  <label
-                    class="form-check-label"
-                    for="enableSettingsShortcutInput"
-                  >
-                    Enable
-                    <i
-                      class="fas fa-info-circle"
-                      title="If enabled, users can long-press on your app tile and a Settings menu item will appear, letting users manage space for your app."
-                      aria-label="If enabled, users can long-press on your app tile and a Settings menu item will appear, letting users manage space for your app."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="If enabled, users can long-press on your app tile and a Settings menu item will appear, letting users manage space for your app."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-              </div>
-
-              <div class="form-group">
-                <label
-                  >${localeStrings.text.android.titles.chromeos_only}</label
-                >
-                <div class="form-check">
-                  <input
-                    .defaultChecked="${false}"
-                    class="form-check-input"
-                    type="checkbox"
-                    id="chromeOSOnlyInput"
-                    name="isChromeOSOnly"
-                  />
-                  <label class="form-check-label" for="chromeOSOnlyInput">
-                    Enable
-                    <i
-                      class="fas fa-info-circle"
-                      title="If enabled, your Android package will only run on ChromeOS devices"
-                      aria-label="If enabled, your Android package will only run on ChromeOS devices"
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="If enabled, your Android package will only run on ChromeOS devices"
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-              </div>
-
-              <div class="form-group">
-                <label>${localeStrings.text.android.titles.source_code}</label>
-                <div class="form-check">
-                  <input
-                    .defaultChecked="${false}"
-                    class="form-check-input"
-                    type="checkbox"
-                    id="includeSourceCodeInput"
-                    name="includeSourceCode"
-                  />
-                  <label class="form-check-label" for="includeSourceCodeInput">
-                    Enable
-                    <i
-                      class="fas fa-info-circle"
-                      title="If enabled, your download will include the source code for your Android app."
-                      aria-label="If enabled, your download will include the source code for your Android app."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="If enabled, your download will include the source code for your Android app."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-              </div>
-
-              <div class="form-group">
-                <label>${localeStrings.text.android.titles.signing_key}</label>
-                <div class="form-check">
-                  <input
-                    class="form-check-input"
-                    type="radio"
-                    id="generateSigningKeyInput"
-                    value="new"
-                    name="signingMode"
-                    @change="${(ev: Event) =>
-                      this.androidSigningModeChanged((ev.target as any).value)}"
-                    .defaultChecked="${true}"
-                  />
-                  <label class="form-check-label" for="generateSigningKeyInput">
-                    Create new
-                    <i
-                      class="fas fa-info-circle"
-                      title="PWABuilder will generate a new signing key for you and sign your APK with it. Your download will contain the new signing key and passwords."
-                      aria-label="PWABuilder will generate a new signing key for you and sign your APK with it. Your download will contain the new signing key and passwords."
-                      role="definition"
-                    ></i>
-                    <hover-tooltip
-                      text="PWABuilder will generate a new signing key for you and sign your APK with it. Your download will contain the new signing key and passwords."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-                <div class="form-check">
-                  <input
-                    class="form-check-input"
-                    type="radio"
-                    id="unsignedInput"
-                    value="none"
-                    name="signingMode"
-                    @change="${(ev: Event) =>
-                      this.androidSigningModeChanged((ev.target as any).value)}"
-                  />
-                  <label class="form-check-label" for="unsignedInput">
-                    None
-                    <i
-                      class="fas fa-info-circle"
-                      title="PWABuilder will generate an unsigned APK. Google Play Store will sign your package. This is Google's recommended approach."
-                      aria-label="PWABuilder will generate an unsigned APK. Google Play Store will sign your package. This is Google's recommended approach."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="PWABuilder will generate an unsigned APK. Google Play Store will sign your package. This is Google's recommended approach."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-                <div class="form-check">
-                  <input
-                    class="form-check-input"
-                    type="radio"
-                    id="useMySigningInput"
-                    value="mine"
-                    name="signingMode"
-                    @change="${(ev: Event) =>
-                      this.androidSigningModeChanged((ev.target as any).value)}"
-                  />
-                  <label class="form-check-label" for="useMySigningInput">
-                    Use mine
-                    <i
-                      class="fas fa-info-circle"
-                      title="Upload your existing signing key. Use this option if you already have a signing key and you want to publish a new version of an existing app in Google Play."
-                      aria-label="Upload your existing signing key. Use this option if you already have a signing key and you want to publish a new version of an existing app in Google Play."
-                      role="definition"
-                    ></i>
-
-                    <hover-tooltip
-                      text="Upload your existing signing key. Use this option if you already have a signing key and you want to publish a new version of an existing app in Google Play."
-                      link="https://blog.pwabuilder.com/docs/android-platform"
-                    >
-                    </hover-tooltip>
-                  </label>
-                </div>
-              </div>
-
-              ${this.signingMode === 'mine' || this.signingMode === 'new'
-                ? html`
-                    <div style="margin-left: 15px;">
-                      ${this.signingMode === 'mine'
-                        ? html`
-                            <div class="form-group">
-                              <label for="signingKeyInput">Key file</label>
-                              <input
-                                type="file"
-                                class="form-control"
-                                id="signingKeyInput"
-                                @change="${(ev: Event) =>
-                                  this.androidSigningKeyUploaded(ev.target)}"
-                                accept=".keystore"
-                                required
-                                style="border: none;"
-                                value="${ifDefined(this.file)}"
-                              />
-                            </div>
-                          `
-                        : null}
-
-                      <div class="form-group">
-                        <label for="signingKeyAliasInput">Key alias</label>
-                        <input
-                          type="text"
-                          class="form-control"
-                          id="signingKeyAliasInput"
-                          placeholder="my-key-alias"
-                          required
-                          name="alias"
-                          value="${this.alias}"
-                        />
-                      </div>
-
-                      ${this.signingMode === 'new'
-                        ? html`
-                            <div class="form-group">
-                              <label for="signingKeyFullNameInput"
-                                >Key full name</label
-                              >
-                              <input
-                                type="text"
-                                class="form-control"
-                                id="signingKeyFullNameInput"
-                                required
-                                placeholder="John Doe"
-                                name="fullName"
-                                value="${this.signingKeyFullName}"
-                              />
-                            </div>
-
-                            <div class="form-group">
-                              <label for="signingKeyOrgInput"
-                                >Key organization</label
-                              >
-                              <input
-                                type="text"
-                                class="form-control"
-                                id="signingKeyOrgInput"
-                                required
-                                placeholder="My Company"
-                                name="organization"
-                                value="${this.organization}"
-                              />
-                            </div>
-
-                            <div class="form-group">
-                              <label for="signingKeyOrgUnitInput"
-                                >Key organizational unit</label
-                              >
-                              <input
-                                type="text"
-                                class="form-control"
-                                id="signingKeyOrgUnitInput"
-                                required
-                                placeholder="Engineering Department"
-                                name="organizationalUnit"
-                                value="${this.organizationalUnit}"
-                              />
-                            </div>
-
-                            <div class="form-group">
-                              <label for="signingKeyCountryCodeInput">
-                                Key country code
-                                <i
-                                  class="fas fa-info-circle"
-                                  title="The 2 letter country code to list on the signing key"
-                                  aria-label="The 2 letter country code to list on the signing key"
-                                  role="definition"
-                                ></i>
-
-                                <hover-tooltip
-                                  text="The 2 letter country code to list on the signing key"
-                                  link="https://blog.pwabuilder.com/docs/android-platform"
-                                >
-                                </hover-tooltip>
-                              </label>
-                              <input
-                                type="text"
-                                class="form-control"
-                                id="signingKeyCountryCodeInput"
-                                required
-                                placeholder="US"
-                                name="countryCode"
-                                value="${this.countryCode}"
-                              />
-                            </div>
-                          `
-                        : null}
-
-                      <div class="form-group">
-                        <label for="signingKeyPasswordInput">
-                          Key password
-                          <i
-                            class="fas fa-info-circle"
-                            title="The password for the signing key. Type a new password or leave empty to use a generated password."
-                            aria-label="The password for the signing key. Type a new password or leave empty to use a generated password."
-                            role="definition"
-                          ></i>
-
-                          <hover-tooltip
-                            text="The 2 letter country code to list on the signing key"
-                            link="The password for the signing key. Type a new password or leave empty to use a generated password."
-                          >
-                          </hover-tooltip>
-                        </label>
-                        <input
-                          type="password"
-                          class="form-control"
-                          id="signingKeyPasswordInput"
-                          name="keyPassword"
-                          placeholder="Password to your signing key"
-                          minlength="6"
-                          value="${this.keyPassword}"
-                        />
-                      </div>
-
-                      <div class="form-group">
-                        <label for="signingKeyStorePasswordInput">
-                          Key store password
-                          <i
-                            class="fas fa-info-circle"
-                            title="The password for the key store. Type a new password or leave empty to use a generated password."
-                            aria-label="The password for the key store. Type a new password or leave empty to use a generated password."
-                            role="definition"
-                          ></i>
-
-                          <hover-tooltip
-                            text="The 2 letter country code to list on the signing key"
-                            link="The password for the key store. Type a new password or leave empty to use a generated password."
-                          >
-                          </hover-tooltip>
-                        </label>
-                        <input
-                          type="password"
-                          class="form-control"
-                          id="signingKeyStorePasswordInput"
-                          name="storePassword"
-                          placeholder="Password to your key store"
-                          minlength="6"
-                          value="${this.storePassword}"
-                        />
-                      </div>
-                    </div>
-                  `
-                : null}
             </fast-accordion-item>
           </fast-accordion>
         </div>
@@ -1215,6 +622,173 @@ export class AndroidForm extends AppPackageFormBase {
           </loading-button>
         </div>
       </form>
+    `;
+  }
+
+  renderSigningKeyFields(): TemplateResult {
+    if (this.packageOptions.signingMode === 'new') {
+      return this.renderNewSigningKeyFields();
+    }
+
+    if (this.packageOptions.signingMode === 'mine') {
+      return this.renderExistingSigningKeyFields();
+    }
+
+    // Otherwise, nothing to render.
+    return html``;
+  }
+
+  renderNewSigningKeyFields(): TemplateResult {
+    return html`
+      <div class="signing-key-fields">
+        <div class="form-group">
+          ${this.renderKeyAlias()}
+        </div>
+
+        <div class="form-group">
+          ${this.renderFormInput({
+            label: 'Key full name',
+            tooltip: `Your full name. Used when create the new signing key.`,
+            tooltipLink: 'https://developer.android.com/studio/publish/app-signing',
+            inputId: 'key-full-name-input',
+            required: true,
+            placeholder: 'John Doe',
+            value: this.packageOptions.signing.fullName || '',
+            spellcheck: false,
+            inputHandler: (val: string) => this.packageOptions.signing.fullName = val
+          })}
+        </div>
+
+        <div class="form-group">
+          ${this.renderFormInput({
+            label: 'Key organization',
+            tooltip: `The name of your company or organization. Used as the organization of the new signing key.`,
+            tooltipLink: 'https://developer.android.com/studio/publish/app-signing',
+            inputId: 'key-org-input',
+            required: true,
+            placeholder: 'My Company',
+            value: this.packageOptions.signing.organization || '',
+            spellcheck: false,
+            inputHandler: (val: string) => this.packageOptions.signing.organization = val
+          })}
+        </div>
+
+        <div class="form-group">
+          ${this.renderFormInput({
+            label: 'Key organizational unit',
+            tooltip: `The department you work in, e.g. "Engineering". Used as the organizational unit of the new signing key.`,
+            tooltipLink: 'https://developer.android.com/studio/publish/app-signing',
+            inputId: 'key-org-unit-input',
+            required: true,
+            placeholder: 'Engineering Department',
+            value: this.packageOptions.signing.organizationalUnit,
+            spellcheck: false,
+            inputHandler: (val: string) => this.packageOptions.signing.organizationalUnit = val
+          })}
+        </div>
+
+        <div class="form-group">
+          ${this.renderFormInput({
+            label: 'Key country code',
+            tooltip: `Your country's 2 letter code (e.g. "US"). Used as the country of the new signing key.`,
+            tooltipLink: 'https://developer.android.com/studio/publish/app-signing',
+            inputId: 'key-org-unit-input',
+            required: true,
+            placeholder: 'US',
+            value: this.packageOptions.signing.countryCode,
+            spellcheck: false,
+            minLength: 2,
+            maxLength: 2,
+            validationErrorMessage: 'Country code must be 2 characters in length',
+            inputHandler: (val: string) => this.packageOptions.signing.countryCode = val
+          })}
+        </div>
+      </div>
+    `;
+  }
+
+  renderExistingSigningKeyFields(): TemplateResult {
+    return html`
+      <div class="signing-key-fields">
+        <div class="form-group">
+          <label for="signingKeyInput">Key file</label>
+          <input
+            type="file"
+            class="form-control"
+            id="signing-key-file-input"
+            @change="${(e: Event) =>
+              this.androidSigningKeyUploaded(e.target)}"
+            accept=".keystore"
+            required
+          />
+        </div>
+        ${this.renderKeyAlias()}
+        ${this.renderKeyPassword()}
+        ${this.renderKeyStorePassword()}
+      </div>
+    `;
+  }
+
+  renderKeyAlias(): TemplateResult {
+    const tooltip = this.packageOptions.signingMode === 'new' ?
+      'The alias to use in the new signing key.' :
+      'The alias of your existing signing key.'
+    return html`
+      <div class="form-group">
+        ${this.renderFormInput({
+          label: 'Key alias',
+          tooltip: tooltip,
+          tooltipLink: 'https://developer.android.com/studio/publish/app-signing',
+          inputId: 'key-alias-input',
+          required: true,
+          placeholder: 'my-key-alias',
+          value: this.packageOptions.signing.alias || '',
+          spellcheck: false,
+          inputHandler: (val: string) => this.packageOptions.signing.alias = val
+        })}
+      </div>
+    `;
+  }
+
+  renderKeyPassword(): TemplateResult {
+    const tooltip = this.packageOptions.signingMode === 'new' ?
+      'The password to use for the new signing key. Leave blank to let PWABuilder generate a strong password for you.' :
+      'Your existing key password'
+    return html`
+      <div class="form-group">
+        ${this.renderFormInput({
+          label: 'Key password',
+          tooltip: tooltip,
+          tooltipLink: 'https://developer.android.com/studio/publish/app-signing',
+          inputId: 'key-password-input',
+          type: 'password',
+          minLength: 6,
+          required: this.packageOptions.signingMode === 'mine',
+          value: this.packageOptions.signing.keyPassword,
+          inputHandler: (val: string) => this.packageOptions.signing.keyPassword = val
+        })}
+      </div>
+    `;
+  }
+
+  renderKeyStorePassword(): TemplateResult {
+    const tooltip = this.packageOptions.signingMode === 'new' ?
+      'The key store password to use in the new signing key. Leave blank to let PWABuilder generate a strong key store password for you.' :
+      'Your existing key store password'
+    return html`
+      <div class="form-group">
+        ${this.renderFormInput({
+          label: 'Key store password',
+          tooltip: tooltip,
+          tooltipLink: 'https://developer.android.com/studio/publish/app-signing',
+          inputId: 'key-store-password-input',
+          type: 'password',
+          minLength: 6,
+          required: this.packageOptions.signingMode === 'mine',
+          value: this.packageOptions.signing.storePassword,
+          inputHandler: (val: string) => this.packageOptions.signing.storePassword = val
+        })}
+      </div>
     `;
   }
 }

--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -711,7 +711,7 @@ export class AndroidForm extends AppPackageFormBase {
     return html`
       <div class="signing-key-fields">
         <div class="form-group">
-          <label for="signingKeyInput">Key file</label>
+          <label for="signing-key-file-input">Key file</label>
           <input
             type="file"
             class="form-control"

--- a/src/script/components/hover-tooltip.ts
+++ b/src/script/components/hover-tooltip.ts
@@ -1,63 +1,76 @@
-import { LitElement, html, css } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { css, html, LitElement, TemplateResult } from "lit";
+import { customElement, state, property } from 'lit/decorators.js';
+import { smallBreakPoint } from "../utils/css/breakpoints";
 
+/**
+ * A tooltip that can receive focus or contain clickable elements.
+ * Usage: 
+ *  <hover-tooltip anchor="my-button-id" text="hello, world" link="https://test.com"></hover-tooltip>
+ */
 @customElement('hover-tooltip')
 export class HoverTooltip extends LitElement {
-  @property({ type: String }) text: string = '';
-  @property({ type: String }) link: string = '';
-
+  // The selector of the element for which to show the focusable tooltip.
+  @property() anchor: string = '';
+  @property({ type: String }) text = '';
+  @property({ type: String }) link = '';
+  @state() tooltipVisible = false;
+  @state() tooltipLocation: [number, number] = [0, 0];
+  
+  anchorElement: HTMLElement | null | undefined = null;
+  tooltipContainsFocus = false;
+  tooltipContainsHover = false;
+  anchorContainsFocus = false;
+  anchorContainsHover = false;  
+  hideTooltipTimeoutHandle = 0;
+  mouseEnterListener = () => this.anchorMouseEntered();
+  focusInListner = () => this.anchorFocused();
+  mouseLeaveListener = () => this.anchorMouseLeave();
+  focusOutListener = () => this.anchorBlurred();
+  
   static get styles() {
     return css`
-      #hover-tooltip {
-        display: none;
-
-        position: relative;
-
-        flex-direction: column;
-        justify-content: space-around;
-
-        padding: 8px;
-        border-radius: 6px;
+      .tooltip-dialog {
         position: absolute;
+        margin: 0px;
+        box-shadow: 0 0 5px gray;
+        background-color: #000;
+        opacity: 0;
+        transform: translate(10px, 5px); /* shift it down and to the right a bit */
+        transition: opacity 0.2s ease-in-out;
+        visibility: collapse;
+        border-radius: 0.25rem;
         z-index: 1000;
-
-        white-space: break-spaces;
-        width: 14em;
-
-        background: var(--font-color);
-        left: 0em;
-        top: 0em;
-
-        color: #fff;
-        font-weight: initial;
-
-        line-height: initial;
-        font-size: 14px;
+        width: max-content;
+        max-width: 250px;
       }
 
-      #hover-tooltip a {
-        color: #fff;
-        text-decoration: underline;
+      .tooltip-dialog.show {
+        opacity: 0.8;
+        pointer-events: auto;
+        visibility: visible;
       }
 
-      #tooltip-block {
+      .tooltip-inner {
         position: relative;
-        cursor: pointer;
-
-        display: flex;
+        color: #fff;
+        font-size: 14px;
+        font-weight: normal;
+        padding: 0px 15px 0px 15px;
+        line-height: 21px;
       }
 
-      #tooltip-block img {
-        height: 12px;
-        width: 12px;
-        border-radius: 50%;
-        background: var(--neutral-fill-stealth-rest);
-        padding: 4px;
-        margin-left: 6px;
-      }
+      ${smallBreakPoint(
+        css`
+          .tooltip-inner {
+            max-width: 200px;
+          }
+        `
+      )}
 
-      #tooltip-block:hover #hover-tooltip {
-        display: flex;
+      a, a:hover, a:active {
+        color: white;
+        display: block;
+        margin-bottom: 15px;
       }
     `;
   }
@@ -66,27 +79,178 @@ export class HoverTooltip extends LitElement {
     super();
   }
 
-  render() {
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    if (!this.anchor) {
+      console.error("Attempted to use a <hover-tooltip>, but didn't set the anchor. It should be set to the ID of the element the tooltip is for.");
+      return;
+    }
+
+    this.anchorElement = this.parentNode?.querySelector(`#${this.anchor}`);
+    if (this.anchorElement) {
+      this.anchorElement.addEventListener("mouseenter", this.mouseEnterListener, { passive: true });
+      this.anchorElement.addEventListener("mouseleave", this.mouseLeaveListener, { passive: true });
+      this.anchorElement.addEventListener("focusin", this.focusInListner, { passive: true });
+      this.anchorElement.addEventListener("focusout", this.focusOutListener, { passive: true });
+    }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.anchorElement) {
+      this.anchorElement.removeEventListener("mouseenter", this.mouseEnterListener);
+      this.anchorElement.removeEventListener("mouseleave", this.focusInListner);
+      this.anchorElement.removeEventListener("focusin", this.mouseEnterListener);
+      this.anchorElement.removeEventListener("focusout", this.focusOutListener);
+    }
+
+    clearTimeout(this.hideTooltipTimeoutHandle);
+  }
+
+  showTooltip() {
+    if (this.anchorElement) {
+      // Position the tooltip.
+      // This is a little tricky:
+      //  - If the element is affected by the body's scrollbar,
+      //    then we need to account for that in the tooltip position.      
+
+      // If there's not an absolute or fixed position parent (i.e. we're not in a modal)
+      // then we need to offset the Y by the window scroll amount.
+      let scrollOffset = 0;
+      const isInModal = !!this.getAbsoluteOrFixedOffsetParent(this.anchorElement);
+      if (!isInModal) {
+        scrollOffset = window.scrollY;
+      }
+
+      // Grab the cumulative offset of the parents.
+      const boundingRect = this.anchorElement.getBoundingClientRect();
+      const [parentOffsetLeft, parentOffsetTop] = this.getCumulativeOffset(this.anchorElement);
+      const tooltipX = boundingRect.top + scrollOffset - parentOffsetTop;
+      const tooltipY = boundingRect.right - parentOffsetLeft;
+      this.tooltipLocation = [tooltipX, tooltipY];
+      this.tooltipVisible = true;
+    }
+  }
+
+  getCumulativeOffset(element: HTMLElement): [left: number, top: number] {
+    let top = 0;
+    let left = 0;
+    let parent = element.offsetParent as HTMLElement;
+    while (parent != null) {
+      top += parent.offsetTop;
+      left += parent.offsetLeft;
+      parent = parent.offsetParent as HTMLElement;
+    }
+    
+    return [
+      left,
+      top
+    ];
+  }
+
+  getAbsoluteOrFixedOffsetParent(el: HTMLElement): HTMLElement | null {
+    if (!el) {
+      return null;
+    }
+
+    // Walk up the offsetParent tree until we find an absolute or fixed position parent.
+    let parent = el.offsetParent as HTMLElement;
+    while (parent != null && parent !== document.body) {
+      const parentPositionStyle = window.getComputedStyle(parent, null).position;
+      if (parent.style && (parentPositionStyle === "absolute" || parentPositionStyle === 'fixed')) {
+        return parent;
+      }
+
+      parent = parent.offsetParent as HTMLElement;
+    }
+
+    return null;
+  }
+
+  hideTooltipIfNecessary() {    
+    // Don't hide the tooltip if any of these conditions are met:
+    //  - the anchor element contain focus
+    //  - the tooltip contains focus
+    //  - the mouse is over the anchor element
+    //  - the mouse is over the tooltip
+    const checkIfShouldBeHidden = () => {
+      this.tooltipVisible = 
+        this.anchorContainsFocus || 
+        this.anchorContainsHover ||
+        this.tooltipContainsFocus ||
+        this.tooltipContainsHover;
+    };
+
+    // Set a timer - if, after a brief moment, the mouse isn't on our target and isn't on the tooltip, hide it.
+    clearTimeout(this.hideTooltipTimeoutHandle);
+    this.hideTooltipTimeoutHandle = window.setTimeout(() => checkIfShouldBeHidden(), 350);
+  }
+
+  anchorMouseEntered() {
+    this.anchorContainsHover = true;
+    this.showTooltip();
+  }
+
+  anchorMouseLeave() {
+    this.anchorContainsHover = false;
+    this.hideTooltipIfNecessary();
+  }
+
+  anchorFocused() {
+    this.anchorContainsFocus = true;
+    this.showTooltip();
+  }
+
+  anchorBlurred() {
+    this.anchorContainsFocus = false;
+    this.hideTooltipIfNecessary();
+  }
+
+  tooltipMouseEntered() {
+    this.tooltipContainsHover = true;
+  }
+
+  tooltipMouseLeave() {
+    this.tooltipContainsHover = false;
+    this.hideTooltipIfNecessary();
+  }
+
+  tooltipFocused() {
+    this.tooltipContainsFocus = true;
+  }
+
+  tooltipBlurred() {
+    this.tooltipContainsFocus = false;
+    this.hideTooltipIfNecessary();
+  }
+
+  render(): TemplateResult {
+    const tooltipClass = this.tooltipVisible ? 'tooltip-dialog show' : 'tooltip-dialog';
     return html`
-      <div id="tooltip-block">
-        <img part="tooltip-image" src="assets/images/help-outline.svg" alt="help outline" aria-hidden="true"
-          id="tooltip-image" />
-      
-        ${this.renderLinkOrSpan()}
+      <div class="${tooltipClass}" 
+        style="top: ${this.tooltipLocation[0]}px; left: ${this.tooltipLocation[1]}px;"
+        @mouseover="${this.tooltipMouseEntered}"
+        @mouseleave="${this.tooltipMouseLeave}"
+        @focusin="${this.tooltipFocused}"
+        @focusout="${this.tooltipBlurred}">
+        <div class="tooltip-inner">
+          <p>${this.text}</p>
+          ${this.renderLink()}
+        </div>
       </div>
     `;
   }
 
-  renderLinkOrSpan() {
-    if (this.link) {
-      return html`
-        <p id="hover-tooltip">
-          ${this.text}
-          <a target="_blank" href="${this.link}"><i class="fas fa-external-link-square-alt"></i>Read more...</a>
-        </p>
-      `;
+  renderLink(): TemplateResult {
+    if (!this.link) {
+      return html``;
     }
 
-    return html`<span id="hover-tooltip">${this.text}</span>`;
+    return html`
+      <a target="_blank" href="${this.link}">
+        Read more...
+      </a>
+    `;
   }
 }

--- a/src/script/components/info-circle-tooltip.ts
+++ b/src/script/components/info-circle-tooltip.ts
@@ -1,0 +1,42 @@
+import { css, html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import '../components/hover-tooltip';
+
+/**
+ * A component that renders a round circle with a question mark in it.
+ * When hovered or focused, a <hover-tooltip> will be shown.
+ */
+ @customElement('info-circle-tooltip')
+ export class InfoCircleTooltip extends LitElement {
+  @property({ type: String }) text = '';
+  @property({ type: String }) link = '';
+  readonly circleId = Math.random().toString(36).replace('0.', 'info-circle-');
+
+  static get styles() {
+    return css`
+      .info-circle-img {
+        height: 12px;
+        width: 12px;
+        border-radius: 50%;
+        background: var(--neutral-fill-stealth-rest);
+        padding: 4px;
+        margin-left: 6px;
+      }
+    `;
+  }
+
+  constructor() {
+    super();
+  }
+
+  render(): TemplateResult {
+    return html`
+      <img id="${this.circleId}" class="info-circle-img" src="assets/images/help-outline.svg" alt="help outline"
+        aria-hidden="true" />
+      
+      <hover-tooltip anchor="${this.circleId}" text="${this.text}" link="${ifDefined(this.link)}">
+      </hover-tooltip>
+    `;
+  }
+ }

--- a/src/script/components/ios-form.ts
+++ b/src/script/components/ios-form.ts
@@ -2,7 +2,6 @@ import { css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import '../components/loading-button';
 import { fetchOrCreateManifest } from '../services/manifest';
-import { ManifestContext } from '../utils/interfaces';
 import { AppPackageFormBase } from './app-package-form-base';
 import { createIOSPackageOptionsFromManifest, emptyIOSPackageOptions } from '../services/publish/ios-publish';
 import { getManifestContext } from '../services/app-info';
@@ -12,7 +11,6 @@ export class IOSForm extends AppPackageFormBase {
   @property({ type: Boolean }) generating: boolean = false;
   @state() showAllSettings = false;
   @state() packageOptions = emptyIOSPackageOptions();
-  private manifestContext: ManifestContext | null = null;
 
   static get styles() {
     const localStyles = css`
@@ -28,12 +26,12 @@ export class IOSForm extends AppPackageFormBase {
   }
 
   async firstUpdated() {
-    this.manifestContext = getManifestContext();
-    if (this.manifestContext.isGenerated) {
-      this.manifestContext = await fetchOrCreateManifest();
+    let manifestContext = getManifestContext();
+    if (manifestContext.isGenerated) {
+      manifestContext = await fetchOrCreateManifest();
     }
     
-    this.packageOptions = createIOSPackageOptionsFromManifest(this.manifestContext);
+    this.packageOptions = createIOSPackageOptionsFromManifest(manifestContext);
   }
 
   initGenerate(ev: InputEvent) {

--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -42,7 +42,7 @@ import './app-file-input';
 import './app-gallery';
 import './code-editor';
 import './flipper-button';
-import './hover-tooltip';
+import './info-circle-tooltip';
 import { generateMissingImagesBase64 } from '../services/icon_generator';
 import { generateScreenshots } from '../services/screenshots';
 import { validateScreenshotUrlsList } from '../utils/manifest-validation';
@@ -547,10 +547,10 @@ export class AppManifest extends LitElement {
             <div class="images-header">
               <div class="item-top">
                 <h3>${localeStrings.text.manifest_options.images.icons.h3}</h3>
-                <hover-tooltip
+                <info-circle-tooltip 
                   .text="${localeStrings.tooltip.manifest_options.upload}"
-                  link="https://developer.mozilla.org/en-US/docs/Web/Manifest/icons"
-                ></hover-tooltip>
+                  link="https://developer.mozilla.org/en-US/docs/Web/Manifest/icons">
+                </info-circle-tooltip>
               </div>
               <app-button appearance="outline" @click=${this.openUploadModal}
                 >${localeStrings.button.upload}</app-button
@@ -558,7 +558,7 @@ export class AppManifest extends LitElement {
               <app-modal
                 id="uploadModal"
                 modalId="uploadModal"
-                title="Upload information"
+                heading="Upload information"
                 body="Choose an Icon to upload. For the best results, we recommend choosing a 512x512 size icon."
                 ?open=${this.uploadModalOpen}
                 @app-modal-close=${this.uploadModalClose}
@@ -628,11 +628,10 @@ export class AppManifest extends LitElement {
                 <h3>
                   ${localeStrings.text.manifest_options.images.screenshots.h3}
                 </h3>
-
-                <hover-tooltip
+                <info-circle-tooltip 
                   .text="${localeStrings.tooltip.manifest_options.generate}"
-                  link="https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots"
-                ></hover-tooltip>
+                  link="https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots">
+                </info-circle-tooltip>
               </div>
               <p>${localeStrings.text.manifest_options.images.screenshots.p}</p>
 
@@ -741,10 +740,10 @@ export class AppManifest extends LitElement {
         <div class="setting-item">
           <div class="item-top">
             <h3>${item.title}</h3>
-            <hover-tooltip
+            <info-circle-tooltip 
               .text="${item.tooltipText}"
-              link="https://developer.mozilla.org/en-US/docs/Web/Manifest"
-            ></hover-tooltip>
+              link="https://developer.mozilla.org/en-US/docs/Web/Manifest">
+            </info-circle-tooltip>
           </div>
           <p>${item.description}</p>
           ${field}
@@ -766,10 +765,10 @@ export class AppManifest extends LitElement {
                 .h3}
             </h3>
 
-            <hover-tooltip
+            <info-circle-tooltip 
               .text="${localeStrings.tooltip.manifest_options.background_color}"
-              link="https://developer.mozilla.org/en-US/docs/Web/Manifest/background_color"
-            ></hover-tooltip>
+              link="https://developer.mozilla.org/en-US/docs/Web/Manifest/background_color">
+            </info-circle-tooltip>
           </div>
           <fast-radio-group
             value=${this.setBackgroundColorRadio()}
@@ -805,11 +804,10 @@ export class AppManifest extends LitElement {
             <h3>
               ${localeStrings.text.manifest_options.settings.theme_color.h3}
             </h3>
-
-            <hover-tooltip
+            <info-circle-tooltip 
               .text="${localeStrings.tooltip.manifest_options.theme_color}"
-              link="https://developer.mozilla.org/en-US/docs/Web/Manifest/theme_color"
-            ></hover-tooltip>
+              link="https://developer.mozilla.org/en-US/docs/Web/Manifest/theme_color">
+            </info-circle-tooltip>
           </div>
           <fast-radio-group
             value=${this.setThemeColorRadio()}

--- a/src/script/components/windows-form.ts
+++ b/src/script/components/windows-form.ts
@@ -1,22 +1,18 @@
 import { css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import '../components/loading-button';
-import '../components/hover-tooltip';
 import { getManifestContext, getManifestUrl } from '../services/app-info';
 import { createWindowsPackageOptionsFromManifest, emptyWindowsPackageOptions } from '../services/publish/windows-publish';
 import { WindowsPackageOptions } from '../utils/win-validation';
 import { localeStrings } from '../../locales';
 import { AppPackageFormBase } from './app-package-form-base';
 import { fetchOrCreateManifest } from '../services/manifest';
-import { ManifestContext } from '../utils/interfaces';
 
 @customElement('windows-form')
 export class WindowsForm extends AppPackageFormBase {
   @property({ type: Boolean }) generating: boolean = false;
-
   @state() showAdvanced = false;
   @state() packageOptions: WindowsPackageOptions = emptyWindowsPackageOptions();
-  private manifestContext: ManifestContext | null = null;
 
   static get styles() {
     const localStyles = css`
@@ -32,12 +28,12 @@ export class WindowsForm extends AppPackageFormBase {
   }
 
   async firstUpdated() {
-    this.manifestContext = getManifestContext();
-    if (this.manifestContext.isGenerated) {
-      this.manifestContext = await fetchOrCreateManifest();
+    let manifestContext = getManifestContext();
+    if (manifestContext.isGenerated) {
+      manifestContext = await fetchOrCreateManifest();
     }
 
-    this.packageOptions = createWindowsPackageOptionsFromManifest(this.manifestContext.manifest);
+    this.packageOptions = createWindowsPackageOptionsFromManifest(manifestContext.manifest);
   }
 
   initGenerate(ev: InputEvent) {
@@ -77,7 +73,7 @@ export class WindowsForm extends AppPackageFormBase {
                 label: 'Package ID',
                 tooltip: `The Package ID uniquely identifying your app in the Microsoft Store. Get this value from Windows Partner Center.`,
                 tooltipLink: 'https://blog.pwabuilder.com/docs/finding-your-windows-publisher-info/',
-                inputId: 'packageIdInput',
+                inputId: 'package-id-input',
                 required: true,
                 placeholder: 'MyCompany.MyApp',
                 minLength: 3,
@@ -94,7 +90,7 @@ export class WindowsForm extends AppPackageFormBase {
                 label: 'Publisher display name',
                 tooltip: `The display name of your app's publisher. Gets this value from Windows Partner Center.`,
                 tooltipLink: 'https://blog.pwabuilder.com/docs/finding-your-windows-publisher-info/',
-                inputId: 'publisherDisplayNameInput',
+                inputId: 'publisher-display-name-input',
                 required: true,
                 minLength: 3,
                 spellcheck: false,
@@ -109,7 +105,7 @@ export class WindowsForm extends AppPackageFormBase {
                 label: 'Publisher ID',
                 tooltip: `The ID of your app's publisher. Get this value from Windows Partner Center.`,
                 tooltipLink: 'https://blog.pwabuilder.com/docs/finding-your-windows-publisher-info/',
-                inputId: 'publisherIdInput',
+                inputId: 'publisher-id-input',
                 placeholder: 'CN=3a54a224-05dd-42aa-85bd-3f3c1478fdca',
                 validationErrorMessage: 'Publisher ID must be in the format CN=XXXX. Get your publisher ID from Partner Center.',
                 pattern: 'CN=.+',
@@ -139,7 +135,7 @@ export class WindowsForm extends AppPackageFormBase {
                     label: 'App name',
                     tooltip: `The name of your app. This is displayed to users in the Store.`,
                     tooltipLink: 'https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-displayname',
-                    inputId: 'appNameInput',
+                    inputId: 'app-name-input',
                     required: true,
                     minLength: 1,
                     maxLength: 256,
@@ -155,7 +151,7 @@ export class WindowsForm extends AppPackageFormBase {
                     label: 'App version',
                     tooltip: `Your app version in the form of '1.0.0'. It must not start with zero and must be greater than classic package version. For new apps, this should be set to 1.0.1`,
                     tooltipLink: 'https://blog.pwabuilder.com/docs/what-is-a-classic-package/',
-                    inputId: 'versionInput',
+                    inputId: 'version-input',
                     required: true,
                     minLength: 5,
                     value: this.packageOptions.version,
@@ -172,7 +168,7 @@ export class WindowsForm extends AppPackageFormBase {
                     label: 'Classic app version',
                     tooltip: `The version of your app that runs on older versions of Windows. Must be in the form of '1.0.0', it cannot start with zero, and must be less than app version. For new apps, this should be set to 1.0.0`,
                     tooltipLink: 'https://blog.pwabuilder.com/docs/what-is-a-classic-package/',
-                    inputId: 'classicVersionInput',
+                    inputId: 'classic-version-input',
                     required: true,
                     minLength: 5,
                     value: this.packageOptions.classicPackage?.version,
@@ -188,7 +184,7 @@ export class WindowsForm extends AppPackageFormBase {
                     label: 'Icon URL',
                     tooltip: `The URL of an icon to use for your app. This should be a 512x512 or larger, square PNG image. Additional Windows image sizes will be fetched from your manifest, and any missing Windows image sizes will be generated by PWABuilder. The URL can be an absolute path or relative to your manifest.`,
                     tooltipLink: 'https://blog.pwabuilder.com/docs/image-recommendations-for-windows-pwa-packages/',
-                    inputId: 'iconUrlInput',
+                    inputId: 'icon-url-input',
                     required: true,
                     type: 'text', // NOTE: can't use URL here, because we allow relative paths.
                     minLength: 2,
@@ -204,7 +200,7 @@ export class WindowsForm extends AppPackageFormBase {
                     label: 'Language',
                     tooltip: `Optional. The primary language for your app package. Additional languages can be specified in Windows Partner Center. If empty, EN-US will beused.`,
                     tooltipLink: 'https://docs.microsoft.com/en-us/windows/uwp/publish/supported-languages',
-                    inputId: 'languageInput',
+                    inputId: 'language-input',
                     value: this.packageOptions.resourceLanguage,
                     placeholder: 'EN-US',
                     inputHandler: (val: string) => this.packageOptions.resourceLanguage = val

--- a/src/script/pages/app-congrats.ts
+++ b/src/script/pages/app-congrats.ts
@@ -39,6 +39,7 @@ import { BlogPost, allPosts } from '../services/blog';
 import { localeStrings } from '../../locales';
 import { WindowsPackageOptions } from '../utils/win-validation';
 import { IOSAppPackageOptions } from '../utils/ios-validation';
+import { AndroidPackageOptions } from '../utils/android-validation';
 
 @customElement('app-congrats')
 export class AppCongrats extends LitElement {
@@ -494,10 +495,10 @@ export class AppCongrats extends LitElement {
     }
   }
 
-  async generateApp(type: Platform, form?: HTMLFormElement | WindowsPackageOptions | IOSAppPackageOptions) {
+  async generateApp(type: Platform, packageOptions?: AndroidPackageOptions | WindowsPackageOptions | IOSAppPackageOptions) {
     try {
       this.generating = true;
-      const packageData = await generatePackage(type, form);
+      const packageData = await generatePackage(type, packageOptions);
       if (packageData) {
         if (packageData.type === 'test') {
           this.testBlob = packageData.blob || undefined;
@@ -624,7 +625,7 @@ export class AppCongrats extends LitElement {
           slot="modal-form"
           .generating=${this.generating}
           @init-android-gen="${(ev: CustomEvent) =>
-            this.generateApp('android', ev.detail.form)}"
+            this.generateApp('android', ev.detail as AndroidPackageOptions)}"
         ></android-form>
       </app-modal>
 

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -10,7 +10,7 @@ import '../components/loading-button';
 import '../components/windows-form';
 import '../components/android-form';
 import '../components/ios-form';
-import '../components/hover-tooltip';
+import '../components/info-circle-tooltip';
 import { Router } from '@vaadin/router';
 
 import {
@@ -39,6 +39,7 @@ import { IOSAppPackageOptions } from '../utils/ios-validation';
 import { WindowsPackageOptions } from '../utils/win-validation';
 import { fetchOrCreateManifest } from '../services/manifest';
 import { createWindowsPackageOptionsFromManifest } from '../services/publish/windows-publish';
+import { AndroidPackageOptions } from '../utils/android-validation';
 @customElement('app-publish')
 export class AppPublish extends LitElement {
   @state() errored = false;
@@ -498,7 +499,7 @@ export class AppPublish extends LitElement {
     await this.generate("windows", options);
   }
 
-  async generate(platform: Platform, form?: HTMLFormElement | IOSAppPackageOptions | WindowsPackageOptions, signingFile?: string) {
+  async generate(platform: Platform, options?: AndroidPackageOptions | IOSAppPackageOptions | WindowsPackageOptions) {
     // Record analysis results to our analytics portal.
     recordProcessStep(
       'analyze-and-package-pwa',
@@ -508,7 +509,7 @@ export class AppPublish extends LitElement {
 
     try {
       this.generating = true;
-      const packageData = await generatePackage(platform, form as HTMLFormElement, signingFile);
+      const packageData = await generatePackage(platform, options);
 
       if (packageData) {
         this.downloadFileName = `${packageData.appName}.zip`;
@@ -614,14 +615,15 @@ export class AppPublish extends LitElement {
         Store Package
       </app-button>
       <div>
-        <loading-button class="navigation secondary" ?loading=${this.generating} id="test-package-button"
+        <loading-button id="windows-test-pkg-btn" class="navigation secondary" ?loading=${this.generating} id="test-package-button"
           @click="${this.generateWindowsTestPackage}">
           Test Package
-          <hover-tooltip
-            text="Generate a package you can use to test your app on your Windows Device before going to the Microsoft Store."
-            link="https://github.com/pwa-builder/pwabuilder-windows-chromium-docs/blob/master/next-steps.md#1-test-your-app-on-your-windows-machine">
-          </hover-tooltip>
         </loading-button>
+        <hover-tooltip
+          anchor="windows-test-pkg-btn" 
+          text="Generate a package you can use to test your app on your Windows Device before going to the Microsoft Store."
+          link="https://github.com/pwa-builder/pwabuilder-windows-chromium-docs/blob/master/next-steps.md#1-test-your-app-on-your-windows-machine">
+        </hover-tooltip>
       </div>
     `;
   }
@@ -717,8 +719,8 @@ export class AppPublish extends LitElement {
       <!-- android options modal -->
       <app-modal id="android-options-modal" heading="Android App Options" body="Customize your Android app below"
         ?open="${this.openAndroidOptions === true}" @app-modal-close="${() => this.storeOptionsCancel()}">
-        <android-form slot="modal-form" .generating=${this.generating} @init-android-gen="${(ev: CustomEvent) =>
-              this.generate('android', ev.detail.form, ev.detail.signingFile)}"></android-form>
+        <android-form slot="modal-form" .generating=${this.generating} @init-android-gen="${(e: CustomEvent) =>
+              this.generate('android', e.detail as AndroidPackageOptions)}"></android-form>
       </app-modal>
       
       <!-- ios options modal -->

--- a/src/script/pages/portals-publish.ts
+++ b/src/script/pages/portals-publish.ts
@@ -8,6 +8,7 @@ import '../components/app-button';
 import '../components/loading-button';
 import '../components/windows-form';
 import '../components/android-form';
+import '../components/info-circle-tooltip';
 
 import {
   smallBreakPoint,
@@ -28,6 +29,7 @@ import { styles as ToolTipStyles } from '../components/tooltip';
 import { localeStrings } from '../../locales';
 import { WindowsPackageOptions } from '../utils/win-validation';
 import { IOSAppPackageOptions } from '../utils/ios-validation';
+import { AndroidPackageOptions } from '../utils/android-validation';
 
 @customElement('portals-publish')
 export class PortalsPublish extends LitElement {
@@ -356,12 +358,11 @@ export class PortalsPublish extends LitElement {
     ];
   }
 
-  async generate(type: Platform, form?: HTMLFormElement | WindowsPackageOptions | IOSAppPackageOptions, signingFile?: string) {
+  async generate(type: Platform, options?: AndroidPackageOptions | WindowsPackageOptions | IOSAppPackageOptions) {
     try {
       this.generating = true;
 
-      const packageData = await generatePackage(type, form, signingFile);
-
+      const packageData = await generatePackage(type, options);
       if (packageData) {
         if (packageData.type === 'test') {
           this.testBlob = packageData.blob;
@@ -438,17 +439,12 @@ export class PortalsPublish extends LitElement {
                       class="navigation secondary"
                       ?loading=${this.generating}
                       id="test-package-button"
-                      @click="${() => this.generate('windows')}"
-                      >Test Package
-
-                      <!-- todo after release: refactor this into a <hover-tooltip /> component -->
-                      <a
-                        id="hover-tooltip"
-                        target="_blank"
-                        href="https://github.com/pwa-builder/pwabuilder-windows-chromium-docs/blob/master/next-steps.md#1-test-your-app-on-your-windows-machine"
-                        >Generate a package you can use to test your app on your
-                        Windows Device before going to the Microsoft Store.</a
-                      >
+                      @click="${() => this.generate('windows')}">
+                      Test Package
+                      <info-circle-tooltip 
+                        text="Generate a package you can use to test your app on your Windows Device before going to the Microsoft Store."
+                        link="https://github.com/pwa-builder/pwabuilder-windows-chromium-docs/blob/master/next-steps.md#1-test-your-app-on-your-windows-machine">
+                      </info-circle-tooltip>
                     </loading-button>
                   </div>
                 `
@@ -493,7 +489,7 @@ export class PortalsPublish extends LitElement {
     return html`
       <!-- error modal -->
       <app-modal
-        title="Wait a minute!"
+        heading="Wait a minute!"
         .body="${this.errorMessage || ''}"
         ?open="${this.errored}"
         id="error-modal"
@@ -520,7 +516,7 @@ export class PortalsPublish extends LitElement {
       <!-- download modal -->
       <app-modal
         ?open="${this.blob ? true : false}"
-        title="Download your package"
+        heading="Download your package"
         body="Your app package is ready for download."
         id="download-modal"
         @app-modal-close="${() => this.downloadCancel()}"
@@ -540,7 +536,7 @@ export class PortalsPublish extends LitElement {
       <!-- test package download modal -->
       <app-modal
         ?open="${this.testBlob ? true : false}"
-        title="Test Package Download"
+        heading="Test Package Download"
         body="${localeStrings.input.publish.windows.test_package}"
         id="test-download-modal"
         @app-modal-close="${() => this.downloadTestCancel()}"
@@ -585,8 +581,8 @@ export class PortalsPublish extends LitElement {
         <android-form
           slot="modal-form"
           .generating=${this.generating}
-          @init-android-gen="${(ev: CustomEvent) =>
-            this.generate('android', ev.detail.form, ev.detail.signingFile)}"
+          @init-android-gen="${(e: CustomEvent) =>
+            this.generate('android', e.detail as AndroidPackageOptions)}"
         ></android-form>
       </app-modal>
 

--- a/src/script/services/publish/android-publish.ts
+++ b/src/script/services/publish/android-publish.ts
@@ -1,20 +1,15 @@
 import {
   validateAndroidOptions,
-  AndroidApkOptions,
-  generatePackageId,
+  AndroidPackageOptions,
+  generatePackageId
 } from '../../utils/android-validation';
 import { env } from '../../utils/environment';
 import { findSuitableIcon, findBestAppIcon } from '../../utils/icons';
-import { Manifest } from '../../utils/interfaces';
-import { getURL, getManifestUrl } from '../app-info';
-import { fetchOrCreateManifest } from '../manifest';
+import { ManifestContext } from '../../utils/interfaces';
 
 export let hasGeneratedAndroidPackage = false;
 
-export async function generateAndroidPackage(
-  androidOptions: AndroidApkOptions,
-  form?: HTMLFormElement
-): Promise<Blob | undefined> {
+export async function generateAndroidPackage(androidOptions: AndroidPackageOptions): Promise<Blob | undefined> {
   const validationErrors = validateAndroidOptions(androidOptions);
   if (validationErrors.length > 0 || !androidOptions) {
     throw new Error(
@@ -22,8 +17,7 @@ export async function generateAndroidPackage(
     );
   }
 
-  const generateAppUrl = `${env.androidPackageGeneratorUrl}/generateApkZip`;
-
+  const generateAppUrl = `${env.androidPackageGeneratorUrl}/generateAppPackage`;
   const response = await fetch(generateAppUrl, {
     method: 'POST',
     body: JSON.stringify(androidOptions),
@@ -31,9 +25,7 @@ export async function generateAndroidPackage(
   });
 
   if (response.status === 200) {
-    //set generated flag
     hasGeneratedAndroidPackage = true;
-
     return await response.blob();
   } else {
     const responseText = await response.text();
@@ -55,8 +47,7 @@ export async function generateAndroidPackage(
         responseText
       );
       const updatedOptions = updateAndroidOptionsWithSafeUrls(androidOptions);
-
-      await generateAndroidPackage(updatedOptions, form);
+      await generateAndroidPackage(updatedOptions);
     } else {
       throw new Error(
         `Error generating Android package.\nStatus code: ${response.status}\nError: ${response.statusText}\nDetails: ${responseText}`
@@ -67,122 +58,7 @@ export async function generateAndroidPackage(
   return undefined;
 }
 
-export async function createAndroidPackageOptionsFromForm(
-  form: HTMLFormElement,
-  signingFile?: string
-): Promise<AndroidApkOptions> {
-  const manifestContext = await fetchOrCreateManifest();
-  const manifest = manifestContext.manifest;
-  if (!manifest) {
-    throw new Error('Could not find the web manifest');
-  }
-
-  const maniUrl = manifestContext.manifestUrl;
-  const pwaUrl = manifestContext.siteUrl;
-
-  if (!pwaUrl) {
-    throw new Error("Can't find the current URL");
-  }
-
-  if (!maniUrl) {
-    throw new Error('Cant find the manifest URL');
-  }
-
-  const manifestUrlOrRoot = maniUrl.startsWith(
-    'data:application/manifest+json,'
-  )
-    ? pwaUrl
-    : maniUrl;
-
-  const appName =
-    form.appName.value || manifest.short_name || manifest.name || 'My PWA';
-  const packageName = generatePackageId(
-    form.packageId.value || new URL(pwaUrl).hostname
-  );
-  // Use standalone display mode unless the manifest has fullscreen specified.
-  const display =
-    manifest.display === 'fullscreen' ? 'fullscreen' : 'standalone';
-  const navColorOrFallback =
-    manifest.theme_color || manifest.background_color || '#000000';
-  /*
-const manifestUrlOrRoot = maniUrl.startsWith(
-  'data:application/manifest+json,'
-)
-  ? pwaUrl
-  : maniUrl;
-  */
-  return {
-    appVersion: form.appVersion.value || '1.0.0.0',
-    appVersionCode: form.appVersionCode.value || 1,
-    backgroundColor:
-      form.backgroundColor.value ||
-      manifest.background_color ||
-      manifest.theme_color ||
-      '#FFFFFF',
-    display: form.displayMode.value || display,
-    enableNotifications: form.enableNotifications.checked,
-    enableSiteSettingsShortcut: form.enableSiteSettingsShortcut.checked,
-    fallbackType: form.fallbackType.value || 'customtabs',
-    features: {
-      locationDelegation: {
-        enabled: form.locationDelegation.checked,
-      },
-      playBilling: {
-        enabled: form.playBilling.checked,
-      },
-    },
-    host: form.host.value || pwaUrl,
-    iconUrl: getAbsoluteUrl(form.iconUrl.value, manifestUrlOrRoot),
-    includeSourceCode: form.includeSourceCode.checked,
-    isChromeOSOnly: form.isChromeOSOnly.checked,
-    launcherName: form.launcherName.value || manifest.short_name || appName, // launcher name should be the short name. If none is available, fallback to the full app name.
-    maskableIconUrl: getAbsoluteUrl(
-      form.maskableIconUrl.value,
-      manifestUrlOrRoot
-    ),
-    monochromeIconUrl: getAbsoluteUrl(
-      form.monochromeIconUrl.value,
-      manifestUrlOrRoot
-    ),
-    name: form.appName.value || manifest.name || 'My Awesome PWA',
-    navigationColor: form.navigationColor.value || navColorOrFallback,
-    navigationColorDark: form.navigationColorDark.value || navColorOrFallback,
-    navigationDividerColor:
-      form.navigationDividerColor.value || navColorOrFallback,
-    navigationDividerColorDark:
-      form.navigationDividerColorDark.value || navColorOrFallback,
-    orientation: manifest.orientation || 'default',
-    packageId: form.packageId.value || packageName,
-    shortcuts: manifest.shortcuts || [],
-    signing: {
-      file: signingFile ? signingFile : null,
-      alias: form.alias ? form.alias.value : 'my-key-alias',
-      fullName: form.fullName
-        ? form.fullName.value
-        : `${manifest.short_name || manifest.name || 'App'} Admin`,
-      organization: form.organization
-        ? form.organization.value
-        : manifest.name || 'PWABuilder',
-      organizationalUnit: form.organizationalUnit
-        ? form.organizationalUnit.value
-        : 'Engineering',
-      countryCode: form.countryCode ? form.countryCode.value : 'US',
-      keyPassword: form.keyPassword ? form.keyPassword.value : '', // If empty, one will be generated by CloudAPK service
-      storePassword: form.keyPassword ? form.storePassword.value : '',
-    },
-    signingMode: form.signingMode.value ? form.signingMode.value : 'new',
-    splashScreenFadeOutDuration: form.splashScreenFadeOutDuration.value || 300,
-    startUrl: getStartUrlRelativeToHost(
-      form.startUrl.value || manifest.start_url || '/',
-      manifestUrlOrRoot
-    ),
-    themeColor: form.themeColor.value || manifest.theme_color || '#FFFFFF',
-    shareTarget: manifest.share_target,
-    webManifestUrl: form.webManifestUrl.value || maniUrl,
-  };
-}
-
-export function emptyAndroidPackageOptions(): AndroidApkOptions {
+export function emptyAndroidPackageOptions(): AndroidPackageOptions {
   return {
     appVersion: '1.0.0.0',
     appVersionCode: 1,
@@ -214,7 +90,16 @@ export function emptyAndroidPackageOptions(): AndroidApkOptions {
     orientation: 'default',
     packageId: '',
     shortcuts: [],
-    signing: null,
+    signing: {
+      file: null,
+      alias: '',
+      fullName: '',
+      organization: '',
+      organizationalUnit: '',
+      countryCode: '',
+      keyPassword: '',
+      storePassword: ''
+    },
     signingMode: 'none',
     splashScreenFadeOutDuration: 300,
     startUrl: '',
@@ -223,24 +108,10 @@ export function emptyAndroidPackageOptions(): AndroidApkOptions {
   };
 }
 
-export async function createAndroidPackageOptionsFromManifest(
-  localManifest?: Manifest
-): Promise<AndroidApkOptions> {
-  let manifest: Manifest | undefined;
-
-  if (localManifest) {
-    manifest = localManifest;
-  } else {
-    const manifestContext = await fetchOrCreateManifest();
-    manifest = manifestContext.manifest;
-  }
-
-  if (!manifest) {
-    throw new Error('Could not find the web manifest');
-  }
-
-  const maniUrl = getManifestUrl();
-  const pwaUrl = getURL();
+export function createAndroidPackageOptionsFromManifest(manifestContext: ManifestContext): AndroidPackageOptions {
+  const maniUrl = manifestContext.manifestUrl;
+  const pwaUrl = manifestContext.siteUrl;
+  const manifest = manifestContext.manifest;
 
   if (!pwaUrl) {
     throw new Error("Can't find the current URL");
@@ -292,8 +163,8 @@ export async function createAndroidPackageOptionsFromManifest(
     appVersion: '1.0.0.0',
     appVersionCode: 1,
     backgroundColor:
-      (manifest.background_color as string) ||
-      (manifest.theme_color as string) ||
+      manifest.background_color ||
+      manifest.theme_color ||
       '#FFFFFF',
     display: display,
     enableNotifications: true,
@@ -307,18 +178,18 @@ export async function createAndroidPackageOptionsFromManifest(
         enabled: false,
       },
     },
-    host: new URL(pwaUrl).origin,
+    host: new URL(pwaUrl).host,
     iconUrl: getAbsoluteUrl(icon.src, manifestUrlOrRoot),
     includeSourceCode: false,
     isChromeOSOnly: false,
-    launcherName: (manifest.short_name as string) || (appName as string), // launcher name should be the short name. If none is available, fallback to the full app name.
+    launcherName: (manifest.short_name || appName || 'My PWA').substring(0, 30), // launcher name should be the short name. If none is available, fallback to the full app name.
     maskableIconUrl: getAbsoluteUrl(maskableIcon?.src, manifestUrlOrRoot),
     monochromeIconUrl: getAbsoluteUrl(monochromeIcon?.src, manifestUrlOrRoot),
     name: appName,
-    navigationColor: navColorOrFallback as string,
-    navigationColorDark: navColorOrFallback as string,
-    navigationDividerColor: navColorOrFallback as string,
-    navigationDividerColorDark: navColorOrFallback as string,
+    navigationColor: navColorOrFallback,
+    navigationColorDark: navColorOrFallback,
+    navigationDividerColor: navColorOrFallback,
+    navigationDividerColorDark: navColorOrFallback,
     orientation: manifest.orientation || 'default',
     packageId: packageName,
     shortcuts: manifest.shortcuts || [],
@@ -338,7 +209,7 @@ export async function createAndroidPackageOptionsFromManifest(
       manifest.start_url,
       new URL(manifestUrlOrRoot)
     ),
-    themeColor: (manifest.theme_color as string) || '#FFFFFF',
+    themeColor: manifest.theme_color || '#FFFFFF',
     shareTarget: manifest.share_target,
     webManifestUrl: maniUrl,
   };
@@ -395,9 +266,9 @@ function getStartUrlRelativeToHost(
 }
 
 function updateAndroidOptionsWithSafeUrls(
-  options: AndroidApkOptions
-): AndroidApkOptions {
-  const absoluteUrlProps: Array<keyof AndroidApkOptions> = [
+  options: AndroidPackageOptions
+): AndroidPackageOptions {
+  const absoluteUrlProps: Array<keyof AndroidPackageOptions> = [
     'maskableIconUrl',
     'monochromeIconUrl',
     'iconUrl',

--- a/src/script/services/publish/index.ts
+++ b/src/script/services/publish/index.ts
@@ -1,10 +1,7 @@
-import { Manifest } from '../../utils/interfaces';
+import { AndroidPackageOptions } from '../../utils/android-validation';
 import { IOSAppPackageOptions } from '../../utils/ios-validation';
 import { WindowsPackageOptions } from '../../utils/win-validation';
-import { fetchOrCreateManifest } from '../manifest';
 import {
-  createAndroidPackageOptionsFromForm,
-  createAndroidPackageOptionsFromManifest,
   generateAndroidPackage,
 } from './android-publish';
 import { generateIOSPackage } from './ios-publish';
@@ -22,16 +19,15 @@ type PackageInfo = {
 
 export async function generatePackage(
   type: Platform,
-  form?: HTMLFormElement | IOSAppPackageOptions | WindowsPackageOptions,
-  signingFile?: string
+  packageOptions?: AndroidPackageOptions | IOSAppPackageOptions | WindowsPackageOptions
 ): Promise<PackageInfo | null> {
   switch (type) {
     case 'windows':
-      return await tryGenerateWindowsPackage(form as WindowsPackageOptions);
+      return await tryGenerateWindowsPackage(packageOptions as WindowsPackageOptions);
     case 'android':
-      return await tryGenerateAndroidPackage(form as HTMLFormElement, signingFile);
+      return await tryGenerateAndroidPackage(packageOptions as AndroidPackageOptions);
     case 'ios':
-      return await tryGenerateIOSPackage(form as IOSAppPackageOptions);
+      return await tryGenerateIOSPackage(packageOptions as IOSAppPackageOptions);
     default:
       throw new Error(
         `A platform type must be passed, ${type} is not a valid platform.`
@@ -39,29 +35,29 @@ export async function generatePackage(
   }
 }
 
-async function grabBackupManifest() {
-  console.error(
-    'Error generating package because manifest information is missing, trying fallback'
-  );
-  const search = new URLSearchParams(location.search);
-  let site: string | null = null;
-  if (search) {
-    site = search.get('site');
-  }
+// async function grabBackupManifest() {
+//   console.error(
+//     'Error generating package because manifest information is missing, trying fallback'
+//   );
+//   const search = new URLSearchParams(location.search);
+//   let site: string | null = null;
+//   if (search) {
+//     site = search.get('site');
+//   }
 
-  let localManifest: Manifest | null = null;
+//   let localManifest: Manifest | null = null;
 
-  if (site) {
-    try {
-      const context = await fetchOrCreateManifest(site);
-      localManifest = context.manifest;
-    } catch (error) {
+//   if (site) {
+//     try {
+//       const context = await fetchOrCreateManifest(site);
+//       localManifest = context.manifest;
+//     } catch (error) {
 
-    }
-  }
+//     }
+//   }
 
-  return localManifest;
-}
+//   return localManifest;
+// }
 
 async function tryGenerateIOSPackage(options: IOSAppPackageOptions): Promise<PackageInfo | null> {
   const result = await generateIOSPackage(options);
@@ -81,55 +77,11 @@ async function tryGenerateWindowsPackage(packageOptions: WindowsPackageOptions):
   };
 }
 
-async function tryGenerateAndroidPackage(
-  form?: HTMLFormElement,
-  signingFile?: string
-): Promise<PackageInfo | null> {
-  if (form) {
-    const androidOptions = await createAndroidPackageOptionsFromForm(
-      form,
-      signingFile
-    );
-
-    if (!androidOptions) {
-      return null;
-    }
-
-    const blob = await generateAndroidPackage(androidOptions, form);
-    return {
-      appName: androidOptions.name,
-      blob: blob || null,
-      type: 'store',
-    };
-  } else {
-    // No form. Try creating from manifest.
-    try {
-      const androidOptions = await createAndroidPackageOptionsFromManifest();
-      const testBlob = await generateAndroidPackage(androidOptions);
-
-      return {
-        appName: androidOptions.name,
-        blob: testBlob || null,
-        type: 'test',
-      };
-    } catch (err) {
-      // Oh no, looks like we dont have the manifest in memory
-      // Lets try to grab it
-      const localManifest = await grabBackupManifest();
-      if (!localManifest) {
-        return null;
-      }
-
-      const androidOptions = await createAndroidPackageOptionsFromManifest(
-        localManifest
-      );
-
-      const testBlob = await generateAndroidPackage(androidOptions);
-      return {
-        appName: androidOptions.name,
-        blob: testBlob || null,
-        type: 'test',
-      };
-    }
-  }
+async function tryGenerateAndroidPackage(options: AndroidPackageOptions): Promise<PackageInfo | null> {
+  const blob = await generateAndroidPackage(options);
+  return {
+    appName: options.name,
+    blob: blob || null,
+    type: 'store',
+  };
 }

--- a/src/script/utils/analytics.ts
+++ b/src/script/utils/analytics.ts
@@ -11,6 +11,8 @@
  *    -   Instead, we append a global script and use the global 
  */
 
+import { env } from "./environment";
+
 // import { AppInsightsCore, IExtendedConfiguration } from '@microsoft/1ds-core-js';
 // import { ApplicationInsights, IPageViewTelemetry, IWebAnalyticsConfiguration } from '@microsoft/1ds-wa-js';
 
@@ -22,9 +24,11 @@ export function recordPageView(uri: string, name?: string, properties?: any) {
     uri: uri,
     properties: properties
   };
-  lazyLoadAnalytics()
-    .then(oneDS => oneDS.trackPageView(pageViewOptions))
-    .catch(err => console.warn('OneDS record page view error', err));
+  if (env.isProduction) {
+    lazyLoadAnalytics()
+      .then(oneDS => oneDS.trackPageView(pageViewOptions))
+      .catch(err => console.warn('OneDS record page view error', err));
+  }
 }
 
 // See https://martech.azurewebsites.net/website-tools/oneds/guided-learning/scenario-process
@@ -33,16 +37,19 @@ export function recordProcessStep(
   processStep: string,
   stepType: AnalyticsBehavior.ProcessCheckpoint | AnalyticsBehavior.StartProcess | AnalyticsBehavior.ProcessCheckpoint | AnalyticsBehavior.CancelProcess | AnalyticsBehavior.CompleteProcess,
   additionalInfo?: {}) {
-  lazyLoadAnalytics()
-    .then(oneDS => oneDS.capturePageAction(null, {
-      actionType: AnalyticsActionType.Other,
-      behavior: stepType,
-      contentTags: {
-        scn: processName,
-        scnstp: processStep
-      },
-      content: additionalInfo
-    }));
+
+  if (env.isProduction) {
+    lazyLoadAnalytics()
+      .then(oneDS => oneDS.capturePageAction(null, {
+        actionType: AnalyticsActionType.Other,
+        behavior: stepType,
+        contentTags: {
+          scn: processName,
+          scnstp: processStep
+        },
+        content: additionalInfo
+      }));
+  }
 }
 
 export function recordPageAction(actionName: string, type: AnalyticsActionType, behavior: AnalyticsBehavior, properties?: { [key: string]: string | number | boolean | string[] | number[] | boolean[] | object }) {

--- a/src/script/utils/environment.ts
+++ b/src/script/utils/environment.ts
@@ -1,4 +1,5 @@
 export const env = {
+  isProduction: false,
   manifestFinderUrl: '',
   manifestCreatorUrl: '',
   serviceWorkerUrl: '',
@@ -14,6 +15,7 @@ export const env = {
 }
 
 if ((window as any).ENV == "production") {
+  env.isProduction = true;
   env.manifestFinderUrl = 'https://pwabuilder-manifest-finder.azurewebsites.net/api/findmanifest';
   env.manifestCreatorUrl = 'https://pwabuilder-manifest-creator.azurewebsites.net/api/create'
   env.serviceWorkerUrl = 'https://pwabuilder-serviceworker-finder.centralus.cloudapp.azure.com';

--- a/styles/form-styles.css
+++ b/styles/form-styles.css
@@ -116,12 +116,6 @@ fast-accordion-item::part(icon) {
   justify-content: center;
 }
 
-.adv-settings {
-  display: grid;
-  grid-template-columns: 50% 50%;
-  gap: 10px;
-}
-
 form {
   max-height: 24em;
 }


### PR DESCRIPTION
# Fixes 
Fixes #2219, fixes #2211, fixes #2249

## PR Type
Bugfix
Refactoring (no functional changes, no api changes)

## Describe the current behavior?
- The Android form wasn't always setting the manifest URL properly. 
- The Android form had a great deal of duplicate code.
- The hover tooltip didn't work well on scrollable modals.

## Describe the new behavior?
- The Android form sets the manifest URL correctly.
- The Android form has been refactored to be more DRY, reduced by about 400 lines of code.
- The hover tooltip has been reworked to use absolute position. I tested and verified it works correctly on the manifest options page, on the packaging modals, and on the publish page. 
- Adds an additional component, `<info-circle-tooltip>`, that draws a ❓ circle + hover to get a `hover-tooltip`.
