### PR TITLE
Fixed manifest 512x512 detection error for images with purpose = "any maskable"

### DIFF
--- a/src/script/components/manifest-options.ts
+++ b/src/script/components/manifest-options.ts
@@ -60,7 +60,7 @@ import {
   AppModalElement,
   FileInputElement,
 } from '../utils/interfaces.components';
-import { cloneIconWithoutUrlEncodedSrc, getProbableFileExtension } from '../utils/icons';
+import { IconInfo } from '../utils/icons';
 import { debounce } from '../utils/debounce';
 
 type ColorRadioValues = 'none' | 'custom';
@@ -1068,7 +1068,7 @@ export class AppManifest extends LitElement {
     this.uploadSelectedImageFile = files?.item(0) ?? undefined;
     this.generateIconButtonDisabled = !this.validIconInput();
 
-    if (!this.generateIconButtonDisabled) {
+    if (!this.generateIconButtonDisabled && this.uploadSelectedImageFile) {
       this.uploadImageObjectUrl = URL.createObjectURL(
         this.uploadSelectedImageFile
       );
@@ -1189,13 +1189,15 @@ export class AppManifest extends LitElement {
     // See https://github.com/pwa-builder/PWABuilder/issues/2038
     const clone = { ...this.manifest };
     if (clone.icons) {
-      clone.icons = clone.icons.map((icon, index) =>
-        cloneIconWithoutUrlEncodedSrc(icon, `/images/icon-${index + 1}.${getProbableFileExtension(icon)}`)
+      clone.icons = clone.icons
+        .map(i => new IconInfo(i))
+        .map((i, index) => i.createIconWithoutUrlEncodedSrc(`/images/icon-${index + 1}.${i.getProbableFileExtension()}`)
       );
     }
     if (clone.screenshots) {
-      clone.screenshots = clone.screenshots.map((icon, index) =>
-        cloneIconWithoutUrlEncodedSrc(icon, `/images/screenshot-${index + 1}.${getProbableFileExtension(icon)}`)
+      clone.screenshots = clone.screenshots
+        .map(i => new IconInfo(i))
+        .map((i, index) => i.createIconWithoutUrlEncodedSrc(`/images/screenshot-${index + 1}.${i.getProbableFileExtension()}`)
       );
     }
        

--- a/src/script/services/app-info.ts
+++ b/src/script/services/app-info.ts
@@ -8,7 +8,7 @@ import {
   Status,
 } from '../utils/interfaces';
 import { getChosenServiceWorker } from './service_worker';
-import { doTest } from './tests/manifest'; // TODO: this creates a cyclical reference between app-info and manifest.ts. We should remove this.
+import { runManifestChecks } from './tests/manifest'; // TODO: this creates a cyclical reference between app-info and manifest.ts. We should remove this.
 
 let site_url: string | undefined;
 let results: RawTestResult | undefined;
@@ -276,7 +276,7 @@ export async function doubleCheckManifest(maniContext: ManifestContext): Promise
   icon: boolean;
 }> {
   // manifest double checks
-  const test_results = await doTest(maniContext);
+  const test_results = await runManifestChecks(maniContext);
 
   let startURL = false;
   let name = false;

--- a/src/script/utils/icons.ts
+++ b/src/script/utils/icons.ts
@@ -1,13 +1,27 @@
+import { env } from './environment';
 import { Icon } from './interfaces';
 
-type IconDimension = { width: number; height: number };
+type IconDimension = { 
+  width: number; 
+  height: number 
+}
+
+type ImageFormat = {
+  exts: [string, string?];
+  mime: string;
+}
 
 /**
- * Finds an icon matching the specified purpose and desired dimensions.
- * @param mimeType Should be an image mime type, e.g. "image/png", or null or empty to ignore format.
+ * Finds an icon matching the specified purpose, dimensions, and mime type.
+ * If no exact match can be found, it will consider icons larger than the specified dimensions.
+ * @param icons The icons to search.
+ * @param purpose The desired purpose of the icon, e.g. 'any', 'maskable', etc, or null to ignore purpose.
+ * @param mimeType Should be an image mime type, e.g. 'image/png', or null or empty to ignore format.
+ * @param desiredHeight The desired height of a match.
+ * @param desiredWidth The desired width of a match.
  */
 export function findSuitableIcon(
-  icons: Icon[] | null | undefined,
+  icons: Icon[] | IconInfo[] | null | undefined,
   purpose: 'any' | 'maskable' | 'monochrome' | null,
   desiredWidth: number,
   desiredHeight: number,
@@ -17,42 +31,14 @@ export function findSuitableIcon(
     return null;
   }
 
-  // See if we have an exact match for size and purpose.
-  const desiredSize = `${desiredWidth}x${desiredHeight}`;
-  const exactMatch = icons.find(
-    i =>
-      hasPurpose(i, purpose) &&
-      hasSize(i, desiredSize) &&
-      !isEmbedded(i) &&
-      hasMimeType(i, mimeType)
-  );
+  const iconInfos = isIconInfos(icons) ? icons : icons.map(i => new IconInfo(i));
+  const exactMatch = iconInfos.find(i => i.isExactMatch(purpose, desiredWidth, desiredHeight, mimeType));
   if (exactMatch) {
-    return exactMatch;
+    return exactMatch.getIcon();
   }
 
-  if (!purpose) {
-    const withoutPurpose = icons.find(
-      i => hasSize(i, desiredSize) && !isEmbedded(i) && hasMimeType(i, mimeType)
-    );
-
-    if (withoutPurpose) {
-      return withoutPurpose;
-    }
-  }
-
-  // Find a larger one if we're able.
-  const isExpectingSquare = desiredWidth === desiredHeight;
-  const matchesSquareRequirement = (i: Icon) =>
-    !isExpectingSquare || isSquare(i);
-  const largerIcon = icons.find(
-    i =>
-      hasPurpose(i, purpose) &&
-      isLarger(i, desiredWidth, desiredHeight) &&
-      !isEmbedded(i) &&
-      hasMimeType(i, mimeType) &&
-      matchesSquareRequirement(i)
-  );
-  return largerIcon || null;
+  var largerMatch = iconInfos.find(i => i.isSuitableIcon(purpose, desiredWidth, desiredHeight, mimeType));
+  return largerMatch?.getIcon() || null;
 }
 
 /**
@@ -61,116 +47,261 @@ export function findSuitableIcon(
  * @returns An icon suitable to use as a general purpose app icon.
  */
 export function findBestAppIcon(icons: Icon[] | null | undefined): Icon | null {
-  return (
-    findSuitableIcon(icons, 'any', 512, 512, 'image/png') ||
-    findSuitableIcon(icons, 'maskable', 512, 512, 'image/png') ||
-    findSuitableIcon(icons, 'any', 192, 192, 'image/png') ||
-    findSuitableIcon(icons, 'maskable', 192, 192, 'image/png') ||
-    findSuitableIcon(icons, 'any', 512, 512, 'image/jpeg') ||
-    findSuitableIcon(icons, 'maskable', 512, 512, 'image/jpeg') ||
-    findSuitableIcon(icons, 'any', 192, 192, 'image/jpeg') ||
-    findSuitableIcon(icons, 'maskable', 192, 192, 'image/jpeg') ||
-    findSuitableIcon(icons, 'any', 512, 512, undefined) ||
-    findSuitableIcon(icons, 'maskable', 512, 512, undefined) ||
-    findSuitableIcon(icons, 'any', 192, 192, undefined) ||
-    findSuitableIcon(icons, 'maskable', 192, 192, undefined) ||
-    findSuitableIcon(icons, 'any', 0, 0, 'image/png') ||
-    findSuitableIcon(icons, 'maskable', 0, 0, 'image/png') ||
-    findSuitableIcon(icons, 'any', 0, 0, 'image/jpeg') ||
-    findSuitableIcon(icons, 'maskable', 0, 0, 'image/jpeg') ||
-    findSuitableIcon(icons, 'any', 0, 0, undefined) ||
-    findSuitableIcon(icons, 'maskable', 0, 0, undefined)
-  );
+  const iconInfos = (icons || []).map(i => new IconInfo(i));
+  return findSuitableIcon(iconInfos, 'any', 512, 512, 'image/png') ||
+    findSuitableIcon(iconInfos, 'maskable', 512, 512, 'image/png') ||
+    findSuitableIcon(iconInfos, 'any', 192, 192, 'image/png') ||
+    findSuitableIcon(iconInfos, 'maskable', 192, 192, 'image/png') ||
+    findSuitableIcon(iconInfos, 'any', 512, 512, 'image/jpeg') ||
+    findSuitableIcon(iconInfos, 'maskable', 512, 512, 'image/jpeg') ||
+    findSuitableIcon(iconInfos, 'any', 192, 192, 'image/jpeg') ||
+    findSuitableIcon(iconInfos, 'maskable', 192, 192, 'image/jpeg') ||
+    findSuitableIcon(iconInfos, 'any', 512, 512, undefined) ||
+    findSuitableIcon(iconInfos, 'maskable', 512, 512, undefined) ||
+    findSuitableIcon(iconInfos, 'any', 192, 192, undefined) ||
+    findSuitableIcon(iconInfos, 'maskable', 192, 192, undefined) ||
+    findSuitableIcon(iconInfos, 'any', 0, 0, 'image/png') ||
+    findSuitableIcon(iconInfos, 'maskable', 0, 0, 'image/png') ||
+    findSuitableIcon(iconInfos, 'any', 0, 0, 'image/jpeg') ||
+    findSuitableIcon(iconInfos, 'maskable', 0, 0, 'image/jpeg') ||
+    findSuitableIcon(iconInfos, 'any', 0, 0, undefined) ||
+    findSuitableIcon(iconInfos, 'maskable', 0, 0, undefined);
 }
 
-function hasPurpose(icon: Icon, purpose: string | null | undefined): boolean {
-  if (!purpose) {
+function isIconInfos(icons: Icon[] | IconInfo[]): icons is IconInfo[] {
+  const firstIcon = icons[0];
+  if (firstIcon instanceof IconInfo) {
     return true;
   }
 
-  return (icon.purpose || 'any').split(' ').some(p => p === purpose);
-}
-
-function hasSize(icon: Icon, size: string): boolean {
-  return (icon.sizes || '0x0').split(' ').some(s => s === size);
-}
-
-function isEmbedded(icon: Icon): boolean {
-  return icon.src.includes('data:image');
-}
-
-function hasMimeType(icon: Icon, mimeType: string | null | undefined): boolean {
-  if (mimeType === undefined) {
-    return true;
-  }
-
-  return (
-    icon.type === mimeType ||
-    (!icon.type && mimeType === 'image/png' && icon.src?.endsWith('.png')) || // best guess when the manifest doesn't specify the type of image
-    (!icon.type && mimeType === 'image/jpeg' && icon.src?.endsWith('.jpg'))
-  ); // best guess when the manifest doesn't specify the type of image
-}
-
-function getDimensions(icon: Icon): IconDimension[] {
-  return (icon.sizes || '0x0').split(' ').map(size => {
-    const dimensions = size.split('x');
-    return {
-      width: Number.parseInt(dimensions[0] || '0'),
-      height: Number.parseInt(dimensions[1] || '0'),
-    };
-  });
-}
-
-function isLarger(icon: Icon, width: number, height: number): boolean {
-  const dimensions = getDimensions(icon);
-  return dimensions.some(i => i.width > width && i.height > height);
-}
-
-function isSquare(icon: Icon): boolean {
-  const dimensions = getDimensions(icon);
-  return dimensions.some(d => d.width === d.height);
+  return false;
 }
 
 /**
- * Clones the icon and if the src is a URL-encoded image, swaps out the src with a replacement.
- * @param icon The icon to clone.
- * @param newSrc The new desired src of the resulting clone.
- * @returns A clone of the icon with its src changed.
+ * Wraps a manifest icon and provides information about it.
  */
-export function cloneIconWithoutUrlEncodedSrc(icon: Icon, newSrc: string): Icon {
-  const clone = { ...icon };
-  if (clone.src?.startsWith('data:image')) {
-    clone.src = newSrc;
-  }
-  return clone;
-}
+export class IconInfo {
 
-/**
- * Guesses the file extension from the icon's mime type.
- * @param icon The icon from whose mime type the file extension will be guessed.
- * @returns A best guess of the file extesion, or empty if no extension could be guessed.
- */
-export function getProbableFileExtension(icon: Icon): string {
-  if (!icon.type) {
-    return '';
+  static readonly pngFormat: ImageFormat = { exts: ['png'], mime: 'image/png' };
+  static readonly jpgFormat: ImageFormat = { exts: ['jpg', 'jpeg'], mime: 'image/jpeg' };
+  static readonly formats: ImageFormat[] = [
+    IconInfo.pngFormat,
+    IconInfo.jpgFormat,
+    { exts: ['webp'], mime: 'image/webp' },
+    { exts: ['gif'], mime: 'image/gif' },
+    { exts: ['ico'], mime: 'image/x-icon' },
+    { exts: ['tiff'], mime: 'image/tiff' },
+    { exts: ['bmp'], mime: 'image/bmp' },
+    { exts: ['svg'], mime: 'image/svg+xml' },
+  ]
+
+  constructor(private readonly icon: Icon) {
   }
 
-  switch (icon.type) {
-    case "image/png": return "png";
-    case "image/jpeg": return "jpg";
-    case "image/jpg": return "jpg";
-    case "image/webp": return "webp";
-    case "image/gif": return "gif";
-    case "image/x-icon": return "ico";
-    case "image/tiff": return "tiff";
-    case "image/bmp": return "bmp";
-    case "image/svg+xml": return "svg";
-    default:
-      const lastSlashIndex = icon.type.lastIndexOf('/');
-      if (lastSlashIndex != -1) {
-        return icon.type.substr(lastSlashIndex + 1);
+  getProbableFileExtension(): string | null {
+    if (!this.icon.type) {
+      // No mime type? See if we can guess it from the src.
+      return this.getFileExtensionFromSrc();
+    }
+
+    const format = this.getFormat();
+    if (format) {
+      return format.exts[0];
+    }
+
+    // Couldn't find a matching format? See if we can guess it from the last half of the mime type.
+    const lastSlashIndex = this.icon.type.lastIndexOf('/');
+    if (lastSlashIndex != -1) {
+      return this.icon.type.substring(lastSlashIndex + 1);
+    }
+
+    return null;
+  }
+
+  isAtLeast(width: number, height: number): boolean {
+    const dimensions = this.getDimensions();
+    return dimensions.some(i => i.width >= width && i.height >= height);
+  }
+
+  get isPng(): boolean {
+    return this.getMimeTypeOrGuessFromSrc() === IconInfo.pngFormat.mime;
+  }
+
+  get isJpg(): boolean {
+    return this.getMimeTypeOrGuessFromSrc() === IconInfo.jpgFormat.mime;
+  }
+  
+  get isSquare(): boolean {
+    const dimensions = this.getDimensions();
+    return dimensions.some(d => d.width === d.height);
+  }
+
+  get isEmbedded(): boolean {
+    return this.icon.src.includes('data:image');
+  }
+
+  hasPurpose(purpose: string | null | undefined): boolean {
+    if (!purpose) {
+      return true;
+    }
+  
+    return (this.icon.purpose || 'any')
+      .split(' ')
+      .some(p => p.toLowerCase() === purpose.toLowerCase());
+  }
+  
+  hasSize(size: `${number}x${number}`): boolean {
+    return (this.icon.sizes || '0x0')
+      .split(' ')
+      .some(s => s === size);
+  }
+
+  /**
+   * Creates a clone of the this and if the src is a URL-encoded image, swaps out the src with a replacement.
+   * @param icon The icon to clone.
+   * @param newSrc The new desired src of the resulting clone.
+   * @returns A clone of the icon with its src changed.
+   */
+  createIconWithoutUrlEncodedSrc(newSrc: string): Icon {
+    const clone = { ...this.icon };
+    if (clone.src?.startsWith('data:image')) {
+      clone.src = newSrc;
+    }
+    return clone;
+  }
+
+  getIcon(): Icon {
+    return this.icon;
+  }
+
+  getDimensions(): IconDimension[] {
+    return (this.icon.sizes || '0x0')
+      .split(' ')
+      .map(size => {
+        const dimensions = size.split('x');
+        return {
+          width: Number.parseInt(dimensions[0] || '0', 10),
+          height: Number.parseInt(dimensions[1] || '0', 10),
+        };
+      });
+  }
+
+  hasMimeType(mimeType?: string | null): boolean {
+    if (!mimeType) {
+      return true;
+    }
+  
+    return this.getMimeTypeOrGuessFromSrc() === mimeType.toLowerCase();
+  }
+
+  isExactMatch(
+    purpose: 'any' | 'maskable' | 'monochrome' | null,
+    desiredWidth: number,
+    desiredHeight: number,
+    mimeType: string | undefined): boolean {
+
+    // See if we're an exact match.
+    const desiredSize: `${number}x${number}` = `${desiredWidth}x${desiredHeight}`;
+    return this.hasPurpose(purpose) && 
+      this.hasSize(desiredSize) && 
+      !this.isEmbedded && 
+      this.hasMimeType(mimeType);
+  }
+
+  /**
+   * Checks if this icon is suitable: matches the specified purpose,
+   * is the desired dimensions or larger,
+   * and has the desired mime type.
+   * @param purpose 
+   * @param desiredWidth 
+   * @param desiredHeight 
+   * @param mimeType 
+   */
+  isSuitableIcon(
+    purpose: 'any' | 'maskable' | 'monochrome' | null,
+    desiredWidth: number,
+    desiredHeight: number,
+    mimeType: string | undefined) {
+
+      const exactMatch = this.isExactMatch(purpose, desiredWidth, desiredHeight, mimeType);
+      if (exactMatch) {
+        return true;
+      }
+      
+      // See if everything matches but purpose is left empty.
+      if (!purpose) {
+        const withoutPurpose = this.isExactMatch(this.icon.purpose || null, desiredWidth, desiredHeight, mimeType);
+        if (withoutPurpose) {
+          return true;
+        }
       }
 
-      return '';
+      // Find a larger one if we're able.
+      const isExpectingSquare = desiredWidth === desiredHeight;
+      const matchesSquareRequirement = !isExpectingSquare || this.isSquare;
+      const largerIcon = 
+          this.hasPurpose(purpose) &&
+          this.isAtLeast(desiredWidth, desiredHeight) &&
+          !this.isEmbedded &&
+          this.hasMimeType(mimeType) &&
+          matchesSquareRequirement;
+      return !!largerIcon;
+  }
+
+  /**
+   * Attempts to load the icon and returns whether it loaded successfully.
+   * @param manifestUrl The manifest URL from which to resolve the icon's URL.
+   * @returns A promise that results in true if the image loaded successfully, false if it didn't.
+   */
+  async resolvesSuccessfully(manifestUrl: string): Promise<boolean> {
+    if (!this.icon.src) {
+      return Promise.resolve(false);
+    }
+    
+    return new Promise(resolve => {
+      const imageEl = new Image();
+      const imgUrl = new URL(
+        this.icon.src,
+        manifestUrl
+      );
+      imageEl.src = `${env.safeUrlFetcher}?checkExistsOnly=false&url=${encodeURIComponent(imgUrl.toString())}`;
+      imageEl.onload = () => {
+        if (imageEl.complete && imageEl.naturalHeight > 0) {
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      };
+      imageEl.onerror = () => {
+        resolve(false);
+      };
+    });
+  }
+
+  private getFileExtensionFromSrc(): string | null {
+    const format = this.getFormat();
+    return format?.exts[0] || null;
+  }
+
+  private getFormat(): ImageFormat | null {
+    const formatByMimeType = IconInfo.formats.find(f => f.mime === this.icon.type);
+    if (formatByMimeType) {
+      return formatByMimeType;
+    }
+
+    // Couldn't find it by mime type. See if we can guess it by looking at src.
+    const srcLower = this.icon.src?.toLowerCase() || '';
+    const guessedFormat = IconInfo.formats
+      .find(f => f.exts.some(ext => srcLower.endsWith(`.${ext}`)));
+    return guessedFormat ?? null;
+  }
+
+  private getMimeTypeOrGuessFromSrc(): string | null {
+    if (this.icon.type) {
+      return this.icon.type;
+    }
+
+    const guessFormat = this.getFormat();
+    return guessFormat?.mime || null;
   }
 }


### PR DESCRIPTION
# Fixes 
Addresses an issue in #2231 where images set to "any maskable" would not be picked up by our 512x512 image check. 

Additionally, I implemented 2 more manifest checks (#1575): all icons specify their size, and all icons specify their type. These are needed to prevent PWABuilder choosing the wrong icon for packaging.

Finally, I refactored the various icon utilities into `IconInfo` class in `icons.ts`.

## PR Type
Bugfix
Feature
Refactor

## Describe the current behavior?
If a manifest's 512x512 image had its `purpose` set to `any maskable`, PWABuilder would erroneously show an error saying you can't package because you're missing a 512x512 image.

## Describe the new behavior?
- Manifest checks detect 512x512 image even if the type is set to `any maskable`.
- Manifest checks now add points if all your icons have `type` specified, and add points if all your icons have `size` specified.