### PR TITLE
Faster builds, faster loads from watch file change

### DIFF
--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -23,7 +23,7 @@ export default {
     }),
     litcss(),
     replace({
-        "window.ENV": JSON.stringify(process.env.NODE_ENV || "development")
+      "window.ENV": JSON.stringify(process.env.NODE_ENV || "development")
     }),
     copy({
       targets: [
@@ -33,6 +33,7 @@ export default {
         { src: "workers/**/*", dest: "build/workers/" },
         { src: "fast-components.min.js", dest: "build/" }
       ],
+      copyOnce: true
     }),
   ],
 };

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -4,6 +4,7 @@
     "module": "es2020",
     "moduleResolution": "node",
     "lib": ["esnext.array", "esnext", "es2017", "dom"],
+    "incremental": true,
     "forceConsistentCasingInFileNames": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/web-dev-server.config.mjs
+++ b/web-dev-server.config.mjs
@@ -1,9 +1,11 @@
 // This is the configuration for `npm dev` and `npm start`.
 
 export default {
-    appIndex: "build/index.html",
-    rootDir: "build/",
-    compatibility: "none",
-    watch: true,
-    open: "/"
-  };
+  appIndex: "build/index.html",
+  rootDir: "build/",
+  compatibility: "none",
+  watch: true,
+  watchExcludes: "*.js.map", // ignore js map changes
+  watchDebounce: 250,
+  open: "/"
+};


### PR DESCRIPTION
# Fixes 
The problem where the page would reload 3x when a watched file changed.

## PR Type
Build or CI related changes

## Describe the current behavior?
When running npm dev and you made a single change to a TS file, the app would reload 3x in browser.

## Describe the new behavior?
The app reloads just once after a change has been made.