### PR TITLE
fix: attempt to make the content fit in the container

### DIFF
--- a/src/script/components/sw-picker.ts
+++ b/src/script/components/sw-picker.ts
@@ -39,7 +39,7 @@ export class SWPicker extends LitElement {
       css`
         :host {
           display: block;
-          width: 100%;
+          width: 95%;
 
           padding: 32px;
         }


### PR DESCRIPTION
ref #2228

# Fixes 

 #2228

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->

This is an attempt to fix the content in the service worker options, which is breaking the layout as related in the issue, this is the current behavior:

![image](https://user-images.githubusercontent.com/2129872/144563184-e5bfcac2-3a5b-4406-ba79-30cd9c755eb1.png)



## Describe the new behavior?

This is how the page looks with this change:

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [ x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
