### PR TITLE
Other Stores UI

### DIFF
--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -12,6 +12,7 @@ import { maxSigningKeySizeInBytes } from '../utils/android-validation';
 @customElement('android-form')
 export class AndroidForm extends AppPackageFormBase {
   @property({ type: Boolean }) generating = false;
+  @property({ type: Boolean }) isGooglePlayApk = false;
   @state() showAdvanced = false;
   @state() packageOptions = emptyAndroidPackageOptions();
   @state() manifestContext: ManifestContext = getManifestContext();
@@ -467,6 +468,8 @@ export class AndroidForm extends AppPackageFormBase {
                   </div>
                 </div>
 
+                ${this.isGooglePlayApk ? 
+                html`
                 <div class="form-group">
                   <label>${localeStrings.text.android.titles.notification}</label>
                   <div class="form-check">
@@ -480,8 +483,10 @@ export class AndroidForm extends AppPackageFormBase {
                       inputHandler: (_, checked) => this.packageOptions.enableNotifications = checked
                     })}
                   </div>
-                </div>
+                </div>` : html``}
 
+                ${this.isGooglePlayApk ? 
+                html`
                 <div class="form-group">
                   <label
                     >${localeStrings.text.android.titles
@@ -497,8 +502,10 @@ export class AndroidForm extends AppPackageFormBase {
                       inputHandler: (_, checked) => this.packageOptions.features.locationDelegation!.enabled = checked
                     })}
                   </div>
-                </div>
+                </div>` : html``}
 
+                ${this.isGooglePlayApk ? 
+                html`
                 <div class="form-group">
                   <label
                     >${localeStrings.text.android.titles
@@ -515,7 +522,7 @@ export class AndroidForm extends AppPackageFormBase {
                       inputHandler: (_, checked) => this.packageOptions.features.playBilling!.enabled = checked
                     })}
                   </div>
-                </div>
+                </div>` : html``}
 
                 <div class="form-group">
                   <label>
@@ -533,7 +540,9 @@ export class AndroidForm extends AppPackageFormBase {
                     })}
                   </div>
                 </div>
-
+                  
+                ${this.isGooglePlayApk ? 
+                html`
                 <div class="form-group">
                   <label>
                     ${localeStrings.text.android.titles.chromeos_only}
@@ -548,7 +557,7 @@ export class AndroidForm extends AppPackageFormBase {
                       inputHandler: (_, checked) => this.packageOptions.isChromeOSOnly = checked
                     })}
                   </div>
-                </div>
+                </div>` : html``}
 
                 <div class="form-group">
                   <label>${localeStrings.text.android.titles.source_code}</label>
@@ -564,6 +573,8 @@ export class AndroidForm extends AppPackageFormBase {
                   </div>
                 </div>
 
+                ${this.isGooglePlayApk ? 
+                html`
                 <div class="form-group">
                   <label>${localeStrings.text.android.titles.signing_key}</label>
                   <div class="form-check">
@@ -604,7 +615,8 @@ export class AndroidForm extends AppPackageFormBase {
                   </div>
                 </div>
 
-                ${this.renderSigningKeyFields()}
+                ${this.renderSigningKeyFields()}` :
+                html``}
                 
               </div>
 

--- a/src/script/components/android-form.ts
+++ b/src/script/components/android-form.ts
@@ -43,6 +43,23 @@ export class AndroidForm extends AppPackageFormBase {
     }
 
     this.packageOptions = createAndroidPackageOptionsFromManifest(this.manifestContext);
+    if(!this.isGooglePlayApk){
+      this.packageOptions.features.locationDelegation!.enabled = false;
+      this.packageOptions.features.playBilling!.enabled = false;
+      this.packageOptions.isChromeOSOnly = false;
+      this.packageOptions.enableNotifications = false;
+      this.packageOptions.signingMode = "none";
+      this.packageOptions.signing = {
+                                      file: null,
+                                      alias: '',
+                                      fullName: '',
+                                      organization: '',
+                                      organizationalUnit: '',
+                                      countryCode: '',
+                                      keyPassword: '',
+                                      storePassword: ''
+                                    };
+    }
   }
 
   initGenerate(ev: InputEvent) {

--- a/src/script/components/app-modal.ts
+++ b/src/script/components/app-modal.ts
@@ -16,6 +16,7 @@ export class AppModal extends LitElement implements AppModalElement {
   @property({ type: String }) heading = '';
   @property({ type: String }) body = '';
   @property({ type: String }) modalId = '';
+  @property() nav: any;
 
   modalAni: Animation | undefined = undefined;
   backgroundAni: Animation | undefined = undefined;
@@ -114,6 +115,35 @@ export class AppModal extends LitElement implements AppModalElement {
           font-weight: 300;
           font-size: var(--small-font-size);
           color: var(--secondary-font-color);
+        }
+
+        #modal-nav {
+          width: 100%;
+        }
+
+        #apk-type {
+          display: flex;
+          width: 100%;
+          border-bottom: 2px solid #5D5DB9;
+        }
+
+        #apk-type p {
+          font-size: 20px;
+          font-weight: 700;
+          line-height: 20px;
+          letter-spacing: 0px;
+          text-align: center;
+          width: 100%;
+          height: 100%;
+          margin: 0;
+          padding: 3px 0;
+          border-bottom: 5px solid transparent;
+        }
+
+        #apk-type p:hover {
+          cursor: pointer;
+          border-bottom: 5px solid #5D5DB9;
+          color: #5D5DB9;
         }
       `,
       smallBreakPoint(css`
@@ -233,6 +263,17 @@ export class AppModal extends LitElement implements AppModalElement {
             <section id="modal-body" part="modal-body">
               <p part="modal-body-contents">${this.body}</p>
             </section>
+
+            ${this.nav ? html`
+            <section id="modal-nav" part="modal-nav">
+              <div part="modal-nav-contents">
+                <div id="apk-type">
+                  <p>Google Play</p>
+                  <p>Other Android</p>
+                </div>
+              </div>
+            </section>` : 
+            html``}
         
             <slot id="modal-form" name="modal-form"></slot>
         

--- a/src/script/components/app-modal.ts
+++ b/src/script/components/app-modal.ts
@@ -116,34 +116,9 @@ export class AppModal extends LitElement implements AppModalElement {
           font-size: var(--small-font-size);
           color: var(--secondary-font-color);
         }
-
+        
         #modal-nav {
           width: 100%;
-        }
-
-        #apk-type {
-          display: flex;
-          width: 100%;
-          border-bottom: 2px solid #5D5DB9;
-        }
-
-        #apk-type p {
-          font-size: 20px;
-          font-weight: 700;
-          line-height: 20px;
-          letter-spacing: 0px;
-          text-align: center;
-          width: 100%;
-          height: 100%;
-          margin: 0;
-          padding: 3px 0;
-          border-bottom: 5px solid transparent;
-        }
-
-        #apk-type p:hover {
-          cursor: pointer;
-          border-bottom: 5px solid #5D5DB9;
-          color: #5D5DB9;
         }
       `,
       smallBreakPoint(css`
@@ -264,16 +239,7 @@ export class AppModal extends LitElement implements AppModalElement {
               <p part="modal-body-contents">${this.body}</p>
             </section>
 
-            ${this.nav ? html`
-            <section id="modal-nav" part="modal-nav">
-              <div part="modal-nav-contents">
-                <div id="apk-type">
-                  <p>Google Play</p>
-                  <p>Other Android</p>
-                </div>
-              </div>
-            </section>` : 
-            html``}
+            <slot id="modal-nav" name="modal-nav"></slot>
         
             <slot id="modal-form" name="modal-form"></slot>
         

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -728,8 +728,6 @@ export class AppPublish extends LitElement {
     } else {
       this.isGooglePlay = false;
     }
-
-    console.log(this.isGooglePlay);
   }
 
   render() {

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -60,6 +60,7 @@ export class AppPublish extends LitElement {
   @state() openiOSOptions = false;
 
   @state() generating = false;
+  @state() isGooglePlay = true;
 
   @state() finalChecks: checkResults | undefined;
 
@@ -722,7 +723,13 @@ export class AppPublish extends LitElement {
     let next = event.target;
     next.classList.replace("unselected-apk", "selected-apk");
 
-    // change android form.
+    if(event.target.innerHTML === "Google Play"){
+      this.isGooglePlay = true;
+    } else {
+      this.isGooglePlay = false;
+    }
+
+    console.log(this.isGooglePlay);
   }
 
   render() {
@@ -774,9 +781,13 @@ export class AppPublish extends LitElement {
             <p class="selected-apk apk-type" @click=${(e: any) => this.toggleApkType(e)}>Google Play</p>
             <p class="unselected-apk apk-type" @click=${(e: any) => this.toggleApkType(e)}>Other Android</p>
           </div>
-        <android-form slot="modal-form" .generating=${this.generating} @init-android-gen="${(e: CustomEvent) =>
-              this.generate('android', e.detail as AndroidPackageOptions)}"></android-form>
-      </app-modal>
+          ${this.isGooglePlay ?
+            html`<android-form slot="modal-form" .generating=${this.generating} .isGooglePlayApk=${this.isGooglePlay} @init-android-gen="${(e: CustomEvent) =>
+              this.generate('android', e.detail as AndroidPackageOptions)}"></android-form>` :
+            html`<android-form slot="modal-form" .generating=${this.generating} .isGooglePlayApk=${this.isGooglePlay} @init-android-gen="${(e: CustomEvent) =>
+              this.generate('android', e.detail as AndroidPackageOptions)}"></android-form>`
+          }
+    </app-modal>
       
       <!-- ios options modal -->
       <app-modal id="ios-options-modal" heading="iOS App Options" body="Customize your iOS app below"

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -294,6 +294,38 @@ export class AppPublish extends LitElement {
         ios-form {
           width: 100%;
         }
+
+        #apk-type {
+          display: flex;
+          width: 100%;
+          border-bottom: 2px solid #5D5DB9;
+        }
+
+        #apk-type p {
+          font-size: 20px;
+          font-weight: 700;
+          line-height: 20px;
+          letter-spacing: 0px;
+          text-align: center;
+          width: 100%;
+          height: 100%;
+          margin: 0;
+          padding: 3px 0;
+        }
+
+        #apk-type p:hover {
+          cursor: pointer;
+          color: #5D5DB9;
+        }
+
+        .selected-apk {
+          border-bottom: 5px solid #5D5DB9;
+          color: #5D5DB9;
+        }
+        
+        .unselected-apk {
+          border-bottom: 5px solid transparent;
+        }
       `,
       xxxLargeBreakPoint(
         css`
@@ -372,6 +404,7 @@ export class AppPublish extends LitElement {
             align-items: center;
             margin-top: 2em;
           }
+          
         `
       ),
       mediumBreakPoint(
@@ -683,6 +716,15 @@ export class AppPublish extends LitElement {
     `
   }
 
+  toggleApkType(event: any){
+    let old = this.shadowRoot!.querySelector(".selected-apk");
+    old?.classList.replace("selected-apk", "unselected-apk");
+    let next = event.target;
+    next.classList.replace("unselected-apk", "selected-apk");
+
+    // change android form.
+  }
+
   render() {
     return html`
       <!-- error modal -->
@@ -728,6 +770,10 @@ export class AppPublish extends LitElement {
       <!-- android options modal -->
       <app-modal id="android-options-modal" heading="Android App Options" body="Customize your Android app below" nav=${true}
         ?open="${this.openAndroidOptions === true}" @app-modal-close="${() => this.storeOptionsCancel()}">
+          <div id="apk-type" slot="modal-nav">
+            <p class="selected-apk apk-type" @click=${(e: any) => this.toggleApkType(e)}>Google Play</p>
+            <p class="unselected-apk apk-type" @click=${(e: any) => this.toggleApkType(e)}>Other Android</p>
+          </div>
         <android-form slot="modal-form" .generating=${this.generating} @init-android-gen="${(e: CustomEvent) =>
               this.generate('android', e.detail as AndroidPackageOptions)}"></android-form>
       </app-modal>

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -674,6 +674,15 @@ export class AppPublish extends LitElement {
     this.openiOSOptions = false;
   }
 
+  fetchAndroidNav() {
+    return html`
+      <div id="apk-type">
+        <p>Google Play</p>
+        <p>Other Android</p>
+      </div>
+    `
+  }
+
   render() {
     return html`
       <!-- error modal -->
@@ -717,7 +726,7 @@ export class AppPublish extends LitElement {
       </app-modal>
       
       <!-- android options modal -->
-      <app-modal id="android-options-modal" heading="Android App Options" body="Customize your Android app below"
+      <app-modal id="android-options-modal" heading="Android App Options" body="Customize your Android app below" nav=${true}
         ?open="${this.openAndroidOptions === true}" @app-modal-close="${() => this.storeOptionsCancel()}">
         <android-form slot="modal-form" .generating=${this.generating} @init-android-gen="${(e: CustomEvent) =>
               this.generate('android', e.detail as AndroidPackageOptions)}"></android-form>

--- a/src/script/pages/app-publish.ts
+++ b/src/script/pages/app-publish.ts
@@ -300,6 +300,8 @@ export class AppPublish extends LitElement {
           display: flex;
           width: 100%;
           border-bottom: 2px solid #5D5DB9;
+          margin-top: 20px;
+          margin-bottom: 40px;
         }
 
         #apk-type p {
@@ -311,12 +313,11 @@ export class AppPublish extends LitElement {
           width: 100%;
           height: 100%;
           margin: 0;
-          padding: 3px 0;
+          padding: 10px 0;
         }
 
         #apk-type p:hover {
           cursor: pointer;
-          color: #5D5DB9;
         }
 
         .selected-apk {


### PR DESCRIPTION
# Fixes 
https://github.com/pwa-builder/PWABuilder/issues/2302

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->
Feature

## Describe the current behavior?
Other stores are forced to use the signed apk option we have by default

## Describe the new behavior?
New nav bar in android options modal (on click of generate package). Allows for unsigned apk's to be generated.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
