### PR TITLE
Added version name and additional signing key info

### DIFF
--- a/src/script/components/oculus-form.ts
+++ b/src/script/components/oculus-form.ts
@@ -104,6 +104,20 @@ export class OculusForm extends AppPackageFormBase {
             </div>
 
             <div class="form-group">
+                  ${this.renderFormInput({
+                    label: 'Version name',
+                    tooltip: `The version of your app displayed to users. This is a string, typically in the form of '1.0.0.0'. This is purely for display purposes to users, Oculus Store uses Version Code to determine the latest version of your app.`,
+                    tooltipLink: 'https://developer.android.com/guide/topics/manifest/manifest-element.html#vname',
+                    inputId: 'version-input',
+                    required: true,
+                    placeholder: '1.0.0.0',
+                    value: this.packageOptions.versionName,
+                    spellcheck: false,
+                    inputHandler: (val: string) => this.packageOptions.versionName = val
+                  })}
+                </div>
+
+            <div class="form-group">
               ${this.renderFormInput({
                 label: 'Version code',
                 tooltip: `A positive integer used as your app's version number. This number is used by the Oculus Store to determine whether one version is more recent than another, with higher numbers indicating more recent versions.`,
@@ -151,13 +165,26 @@ export class OculusForm extends AppPackageFormBase {
                   <div class="form-check">
                     ${this.renderFormInput({
                       label: 'New',
-                      tooltip: `Recommended for new Oculus apps. PWABuilder will generate a new signing key for you and sign your app package with it. Your download will contain the new signing details.`,
+                      tooltip: `Recommended for new Oculus apps. PWABuilder will generate a new signing key for you and sign your app package with it. Your download will contain the new signing key details.`,
                       inputId: 'signing-new-input',
                       name: 'signingMode',
                       value: 'new',
                       type: 'radio',
                       checked: this.packageOptions.signingMode === SigningMode.New,
                       inputHandler: () => this.signingModeChanged(SigningMode.New)
+                    })}
+                  </div>
+                  <div class="form-check">
+                    ${this.renderFormInput({
+                      label: 'None',
+                      tooltip: 'PWABuilder will generate an unsigned APK. Unsigned APKs cannot be uploaded to the Oculus Store; you will need to sign the APK manually via Java keytool before submitting to the Store.',
+                      tooltipLink: 'https://docs.oracle.com/en/java/javase/12/tools/keytool.html',
+                      inputId: 'signing-none-input',
+                      name: 'signingMode',
+                      value: 'none',
+                      type: 'radio',
+                      checked: this.packageOptions.signingMode === SigningMode.None,
+                      inputHandler: () => this.signingModeChanged(SigningMode.None)
                     })}
                   </div>
                   <div class="form-check">
@@ -170,18 +197,6 @@ export class OculusForm extends AppPackageFormBase {
                       type: 'radio',
                       checked: this.packageOptions.signingMode === SigningMode.Existing,
                       inputHandler: () => this.signingModeChanged(SigningMode.Existing)
-                    })}
-                  </div>
-                  <div class="form-check">
-                    ${this.renderFormInput({
-                      label: 'None',
-                      tooltip: 'PWABuilder will generate a raw, unsigned APK. Raw, unsigned APKs cannot be uploaded to the Oculus Store; you will need to sign the APK manually before submitting to the Store.',
-                      inputId: 'signing-none-input',
-                      name: 'signingMode',
-                      value: 'none',
-                      type: 'radio',
-                      checked: this.packageOptions.signingMode === SigningMode.None,
-                      inputHandler: () => this.signingModeChanged(SigningMode.None)
                     })}
                   </div>
 

--- a/src/script/services/publish/oculus-publish.ts
+++ b/src/script/services/publish/oculus-publish.ts
@@ -40,8 +40,10 @@ export function createOculusPackageOptionsFromManifest(manifestContext: Manifest
     manifestUrl: manifestContext.manifestUrl,
     manifest: manifestContext.manifest,
     versionCode: 1,
+    versionName: '1.0.0.0',
     existingSigningKey: null,
-    signingMode: SigningMode.New
+    signingMode: SigningMode.New,
+    url: manifestContext.siteUrl
   };
 }
 
@@ -52,8 +54,10 @@ export function emptyOculusPackageOptions(): OculusAppPackageOptions {
     manifestUrl: '',
     manifest: {},
     versionCode: 1,
+    versionName: '1.0.0.0',
     existingSigningKey: null,
-    signingMode: SigningMode.New
+    signingMode: SigningMode.New,
+    url: '',
   };
 }
 

--- a/src/script/utils/oculus-validation.ts
+++ b/src/script/utils/oculus-validation.ts
@@ -14,9 +14,17 @@ export interface OculusAppPackageOptions {
    */
   name: string;
   /**
+   * The URL analyzed in PWABuilder.
+   */
+  url: string;
+  /**
    * The Android version code of the Oculus app. Should be 1 or greater.
    */
   versionCode: number;
+  /**
+   * The version name displayed to end-users, e.g. "1.0.0.0beta2".
+   */
+  versionName: string;
   /**
    * The URL of the PWA's manifest.
    */
@@ -95,6 +103,10 @@ export function validateOculusOptions(options?: OculusAppPackageOptions | null):
     errors.push('Version code must be greater than zero');
   }
 
+  if (!options.versionName) {
+    errors.push('Version name required');
+  }
+
   if (!options.manifest) {
     errors.push("Manifest required");
   }
@@ -105,8 +117,14 @@ export function validateOculusOptions(options?: OculusAppPackageOptions | null):
 
   try {
     new URL(options.manifestUrl);
+  } catch (manifestUrlError) {
+    errors.push('Manifest URL must be a valid, absolute URL');
+  }
+
+  try {
+    new URL(options.url);
   } catch (urlError) {
-    errors.push('URL must be a valid, absolute URL');
+    errors.push('Url must be a valid, absolute URL');
   }
 
   // It's OK for signing key to be null. But if we've specified an existing signing key, then


### PR DESCRIPTION
# Fixes 
Adds `VersionName` and `Url` to Oculus package args.

## PR Type
<!-- - Feature -->

## Describe the current behavior?
Current version omits VersionName and `Url`.

## Describe the new behavior?
New version includes VersionName and gives UI for it. Adds `Url` being analyzed by PWABuilder.