### PR TITLE
Adds pwaUrl to Android platform

### DIFF
--- a/src/script/services/publish/android-publish.ts
+++ b/src/script/services/publish/android-publish.ts
@@ -89,6 +89,7 @@ export function emptyAndroidPackageOptions(): AndroidPackageOptions {
     navigationDividerColorDark: '#000000',
     orientation: 'default',
     packageId: '',
+    pwaUrl: '',
     shortcuts: [],
     signing: {
       file: null,
@@ -212,6 +213,7 @@ export function createAndroidPackageOptionsFromManifest(manifestContext: Manifes
     themeColor: manifest.theme_color || '#FFFFFF',
     shareTarget: manifest.share_target,
     webManifestUrl: maniUrl,
+    pwaUrl: manifestContext.siteUrl
   };
 }
 

--- a/src/script/utils/android-validation.ts
+++ b/src/script/utils/android-validation.ts
@@ -51,6 +51,7 @@ export interface AndroidPackageOptions {
   | 'landscape-primary'
   | 'landscape-secondary';
   packageId: string;
+  pwaUrl: string;
   shareTarget?: ShareTarget;
   shortcuts: ShortcutItem[];
   signing: AndroidSigningOptions;


### PR DESCRIPTION
# Fixes 
Adds more URL precision to Android platform backend analytics.

## PR Type
Feature

## Describe the current behavior?
We send to Android platform the host URL for analytics purposes.


## Describe the new behavior?
We send in the URL given by the user to PWABuilder.