### PR TITLE
Rating Dial Complete fix

### DIFF
--- a/src/script/components/app-sidebar.ts
+++ b/src/script/components/app-sidebar.ts
@@ -667,7 +667,7 @@ export class AppSidebar extends LitElement {
               <span class="rating-header" id="score-header"
                 >Your PWA Score compared with other developers</span
               >
-              <rating-dial .overallScore=${this.overallScore}></rating-dial>
+              <rating-dial></rating-dial>
             </div>
           </sidebar-card>
 

--- a/src/script/components/rating-dial.ts
+++ b/src/script/components/rating-dial.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css, TemplateResult } from 'lit';
-import { customElement, state, property } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import { getOverallScore } from '../services/tests';
 import { env } from '../utils/environment';
 
@@ -8,7 +8,7 @@ type Rating = 'top' | 'middle' | 'bottom';
 @customElement('rating-dial')
 export class RatingDial extends LitElement {
   @state() rating: Rating = 'bottom';
-  @property({type: Number}) overallScore = 0;
+  @state() overallScore = 0;
   @state() ratingComment = '';
 
   static get styles() {
@@ -125,14 +125,10 @@ export class RatingDial extends LitElement {
   }
 
   async calcRating(): Promise<void> {
-    const response = await fetch(env.ratingUrl);
-    const scoreData = await response.json();
-
-    // Adding 94 here to "shim" the data so that we can
-    // fairly average it with our new scoring system
-    // which ends up with much higher scores overall.
-    // We wont need this once we start getting alot of data from v3 in prod
-    const averageScore = scoreData.overallAverageScore + 94;
+  
+    // Instead of doing a network request just going to set average at 150.
+    // Network call was hand wavy anyway, so 150 will do for now.
+    const averageScore = 150;
     this.overallScore = getOverallScore();
 
     if (


### PR DESCRIPTION
# Fixes 
https://github.com/pwa-builder/PWABuilder/issues/2483

## PR Type
Bugfix

## Describe the current behavior?
The rating dial in the side bar was not correctly displaying the score of the PWA. This was due to a network call that was failing.

## Describe the new behavior?
Eliminated the network call and now we handle the averageScore on client side.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information