### PR TITLE
Link to report card displays correct total score

### DIFF
--- a/src/script/pages/app-report.ts
+++ b/src/script/pages/app-report.ts
@@ -257,6 +257,7 @@ export class AppReport extends LitElement {
     const search = new URLSearchParams(location.search);
     const results = search.get('results');
     const url = search.get('site');
+    const hasBadges = sessionStorage.getItem('current_badges');
     setURL(url!);
     
     if (results) {
@@ -274,8 +275,9 @@ export class AppReport extends LitElement {
 
       this.resultOfTest = JSON.parse(results);
 
-      giveOutBadges();
-
+      if(!hasBadges) {
+        giveOutBadges();
+      }
     }
 
     await this.handleDoubleChecks();

--- a/src/script/pages/app-report.ts
+++ b/src/script/pages/app-report.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { doubleCheckManifest, getManifestContext } from '../services/app-info';
+import { doubleCheckManifest, getManifestContext, setResults, setURL } from '../services/app-info';
 
 import {
   BreakpointValues,
@@ -22,6 +22,7 @@ import '../components/app-modal';
 //@ts-ignore
 import style from '../../../styles/layout-defaults.css';
 import { RawTestResult, ScoreEvent } from '../utils/interfaces';
+import { giveOutBadges } from '../services/badges';
 
 const possible_messages = {
   overview: {
@@ -255,7 +256,9 @@ export class AppReport extends LitElement {
   async firstUpdated() {
     const search = new URLSearchParams(location.search);
     const results = search.get('results');
-
+    const url = search.get('site');
+    setURL(url!);
+    
     if (results) {
       /*
         cache results string as we may need this farther in the flow
@@ -266,6 +269,13 @@ export class AppReport extends LitElement {
       sessionStorage.setItem('results-string', results);
 
       this.resultOfTest = JSON.parse(results);
+
+      setResults((this.resultOfTest as RawTestResult));
+
+      this.resultOfTest = JSON.parse(results);
+
+      giveOutBadges();
+
     }
 
     await this.handleDoubleChecks();

--- a/src/script/services/app-info.ts
+++ b/src/script/services/app-info.ts
@@ -9,6 +9,7 @@ import {
 } from '../utils/interfaces';
 import { runManifestChecks } from '../utils/manifest-validation';
 import { getChosenServiceWorker, getSetSWCounter } from './service_worker';
+import { Router } from '@vaadin/router';
 
 let site_url: string | undefined;
 let results: RawTestResult | undefined;
@@ -106,6 +107,13 @@ export function getURL(): string {
 
   if (site_url) {
     return site_url;
+  }
+
+  //if report card link is opened in a new tab
+  if(!site_url && window.location.href.includes('site=')) {
+    let windowUrl = window.location.href;
+    let currentUrl = windowUrl.substring(windowUrl.indexOf('=') + 1, windowUrl.indexOf('&'));
+    Router.go(`/testing?site=${currentUrl}`);
   }
 
   if (url) {

--- a/src/script/services/app-info.ts
+++ b/src/script/services/app-info.ts
@@ -9,7 +9,7 @@ import {
 } from '../utils/interfaces';
 import { runManifestChecks } from '../utils/manifest-validation';
 import { getChosenServiceWorker, getSetSWCounter } from './service_worker';
-import { Router } from '@vaadin/router';
+
 
 let site_url: string | undefined;
 let results: RawTestResult | undefined;
@@ -107,13 +107,6 @@ export function getURL(): string {
 
   if (site_url) {
     return site_url;
-  }
-
-  //if report card link is opened in a new tab
-  if(!site_url && window.location.href.includes('site=')) {
-    let windowUrl = window.location.href;
-    let currentUrl = windowUrl.substring(windowUrl.indexOf('=') + 1, windowUrl.indexOf('&'));
-    Router.go(`/testing?site=${currentUrl}`);
   }
 
   if (url) {


### PR DESCRIPTION
# Fixes 
#2580 

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
When using the link to the report card is displays the incorrect total score.


## Describe the new behavior?
Report card now displays correct total score when opening the report card in a new tab. If someone needed to share their report card link for a group project, etc, the link will display the correct info.


## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
