### PR TITLE
New cookies banner that allows users to accept/reject

### DIFF
--- a/src/script/components/cookie-banner.ts
+++ b/src/script/components/cookie-banner.ts
@@ -22,14 +22,24 @@ export class CookieBanner extends LitElement {
 
       #cookie-info {
         display: flex;
-        align-items: center;
-        justify-content: space-between;
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: flex-start;
       }
 
-      #cookie-banner #close-button {
+      #cookie-info p {
+        margin: 0;
+      }
+
+      #cookie-actions {
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+
+      #cookie-actions button {
         border-radius: var(--button-radius);
         border: none;
-        background: white;
         padding: 8px;
         font-weight: bold;
         padding-left: 10px;
@@ -38,12 +48,32 @@ export class CookieBanner extends LitElement {
         width: 6em;
       }
 
+      #cookie-actions button:hover {
+        cursor: pointer;
+      }
+
+      #cookie-actions #reject-button {
+        background: black;
+        color: white;
+      }
+
+      #cookie-actions #accept-button {
+        background: white;
+      }
+
+
+
       ${smallBreakPoint(css`
         #cookie-banner {
-          align-items: center;
-          display: flex;
           flex-direction: column;
           text-align: center;
+        }
+
+        #cookie-info{
+          align-items: center;
+          justify-content: center;
+          text-align: center;
+          margin-bottom: 10px;
         }
       `)}
     `;
@@ -54,40 +84,54 @@ export class CookieBanner extends LitElement {
   }
 
   firstUpdated() {
+    // by default, non essential cookies are denied.
     const savedValue = localStorage.getItem('PWABuilderGDPR');
 
     if (JSON.parse(savedValue as string) !== true) {
       this.show = true;
-      localStorage.setItem('PWABuilderGDPR', JSON.stringify(true));
+      localStorage.setItem('PWABuilderGDPR', JSON.stringify(false));
     }
   }
 
-  close() {
+  close(accepted: boolean) {
     this.show = false;
-    localStorage.setItem('PWABuilderGDPR', JSON.stringify(true));
+
+    // setting the PWABuilderGDPR var to what the user chose.
+    localStorage.setItem('PWABuilderGDPR', JSON.stringify(accepted));
   }
 
   render() {
     return html`
       ${this.show
         ? html`<div id="cookie-banner">
-            <p>
-              This site uses cookies for analytics and personalized content. By
-              continuing to browse this site, you agree to this use.
-            </p>
+            
 
             <div id="cookie-info">
+              <p>
+              This site uses cookies for analytics and personalized content. By
+              continuing to browse this site, you agree to this use.
+              </p>
               <a
                 href="https://privacy.microsoft.com/en-us/privacystatement#maincookiessimilartechnologiesmodule"
-                >Learn More</a
-              >
+                >Learn More
+              </a>
+            </div>
+
+            <div id="cookie-actions">
+              <button
+                id="reject-button"
+                aria-label="Reject Button"
+                @click="${() => this.close(false)}"
+              > 
+                Reject
+              </button>
 
               <button
-                id="close-button"
-                aria-label="Close Button"
-                @click="${() => this.close()}"
+                id="accept-button"
+                aria-label="Accept Button"
+                @click="${() => this.close(true)}"
               >
-                Close
+                Accept
               </button>
             </div>
           </div>`

--- a/src/script/components/cookie-banner.ts
+++ b/src/script/components/cookie-banner.ts
@@ -75,6 +75,13 @@ export class CookieBanner extends LitElement {
           text-align: center;
           margin-bottom: 10px;
         }
+
+        #cookie-actions {
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          row-gap: 5px;
+        }
       `)}
     `;
   }
@@ -122,7 +129,7 @@ export class CookieBanner extends LitElement {
                 aria-label="Reject Button"
                 @click="${() => this.close(false)}"
               > 
-                Reject
+                Reject all non-essential cookies
               </button>
 
               <button
@@ -130,7 +137,7 @@ export class CookieBanner extends LitElement {
                 aria-label="Accept Button"
                 @click="${() => this.close(true)}"
               >
-                Accept
+                Accept all cookies
               </button>
             </div>
           </div>`

--- a/src/script/components/cookie-banner.ts
+++ b/src/script/components/cookie-banner.ts
@@ -45,7 +45,7 @@ export class CookieBanner extends LitElement {
         padding-left: 10px;
         padding-right: 10px;
         margin-left: 10px;
-        width: 6em;
+        width: fit-content;
       }
 
       #cookie-actions button:hover {
@@ -87,7 +87,7 @@ export class CookieBanner extends LitElement {
     // by default, non essential cookies are denied.
     const savedValue = localStorage.getItem('PWABuilderGDPR');
 
-    if (JSON.parse(savedValue as string) !== true) {
+    if (!savedValue) {
       this.show = true;
       localStorage.setItem('PWABuilderGDPR', JSON.stringify(false));
     }
@@ -108,8 +108,7 @@ export class CookieBanner extends LitElement {
 
             <div id="cookie-info">
               <p>
-              This site uses cookies for analytics and personalized content. By
-              continuing to browse this site, you agree to this use.
+              This site uses cookies to offer you a better browsing experience. Click below to learn more.
               </p>
               <a
                 href="https://privacy.microsoft.com/en-us/privacystatement#maincookiessimilartechnologiesmodule"

--- a/src/script/components/cookie-banner.ts
+++ b/src/script/components/cookie-banner.ts
@@ -53,12 +53,12 @@ export class CookieBanner extends LitElement {
       }
 
       #cookie-actions #reject-button {
-        background: black;
-        color: white;
+        background: white;
       }
 
       #cookie-actions #accept-button {
-        background: white;
+        background: black;
+        color: white;
       }
 
 

--- a/src/script/utils/analytics.ts
+++ b/src/script/utils/analytics.ts
@@ -25,6 +25,10 @@ the below three functions will all being firing. However, if the user
 chooses to deny or ignore the cookies banner, only recordPageView will
 record data as it is the only aggregated analytics tracker (The other two 
 track individual user pathing).
+
+In order to check if the cookies have been accepted check: 
+const acceptedCookies = localStorage.getItem('PWABuilderGDPR'); 
+and add acceptedCookies to the if(env.isProduction && acceptedCookies) 
 */
 
 export function recordPageView(uri: string, name?: string, properties?: any) {
@@ -47,9 +51,7 @@ export function recordProcessStep(
   stepType: AnalyticsBehavior.ProcessCheckpoint | AnalyticsBehavior.StartProcess | AnalyticsBehavior.ProcessCheckpoint | AnalyticsBehavior.CancelProcess | AnalyticsBehavior.CompleteProcess,
   additionalInfo?: {}) {
 
-  const acceptedCookies = localStorage.getItem('PWABuilderGDPR');
-
-  if (env.isProduction && acceptedCookies) {
+  if (env.isProduction) {
     lazyLoadAnalytics()
       .then(oneDS => oneDS.capturePageAction(null, {
         actionType: AnalyticsActionType.Other,
@@ -71,9 +73,7 @@ export function recordPageAction(actionName: string, type: AnalyticsActionType, 
     properties: properties
   };
   
-  const acceptedCookies = localStorage.getItem('PWABuilderGDPR');
-  
-  if (env.isProduction && acceptedCookies) {
+  if (env.isProduction) {
     lazyLoadAnalytics()
       .then(oneDS => oneDS.trackPageAction(action))
       .catch(err => console.warn('OneDS record page action error', err));


### PR DESCRIPTION
# Fixes 
https://github.com/pwa-builder/PWABuilder/issues/2516

## PR Type
Feature

## Describe the current behavior?
Banner does not give the option to reject non-essential cookies.

## Describe the new behavior?
Banner now gives the option to reject non-essential cookies. If the ignore the banner, it works the same as rejecting.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
@joshsach, this will probably cause a drop of in our analytics since the only essential analytic cookie is tracking page views.