### PR TITLE
Category in report card specifies if it is non standard or non existent

### DIFF
--- a/src/script/utils/manifest-validation.ts
+++ b/src/script/utils/manifest-validation.ts
@@ -317,12 +317,11 @@ function containsStandardCategory(categories: string[]): boolean {
 function categoryReport(categories: string[] | undefined) {
   if(categories &&
     categories.length > 0 &&
-      containsStandardCategory(categories)) {
-      return 'Contains categories to classify the app'
-  } else if ((categories &&
-          categories.length > 0 &&
-          !containsStandardCategory(categories))){
-      return 'You have non-standard categories'
+      !containsStandardCategory(categories)) {
+      return 'You have non-standard categories';
+      
+  } else {
+        return 'Contains categories to classify the app';
   }
-  return;
+
 } 

--- a/src/script/utils/manifest-validation.ts
+++ b/src/script/utils/manifest-validation.ts
@@ -318,7 +318,7 @@ function categoryReport(categories: string[] | undefined) {
   if(categories &&
     categories.length > 0 &&
       !containsStandardCategory(categories)) {
-      return 'You have non-standard categories';
+      return 'Contains non-standard categories';
       
   } else {
         return 'Contains categories to classify the app';

--- a/src/script/utils/manifest-validation.ts
+++ b/src/script/utils/manifest-validation.ts
@@ -228,7 +228,7 @@ export async function runManifestChecks(context: ManifestContext): Promise<Array
         category: 'recommended',
       },
       {
-        infoString: 'Contains categories to classify the app',
+        infoString: categoryReport(context.manifest.categories) as any,
         result:
           context.manifest.categories &&
             context.manifest.categories.length > 0 &&
@@ -313,3 +313,16 @@ function containsStandardCategory(categories: string[]): boolean {
   ];
   return categories.some(c => standardCategories.includes(c));
 }
+
+function categoryReport(categories: string[] | undefined) {
+  if(categories &&
+    categories.length > 0 &&
+      containsStandardCategory(categories)) {
+      return 'Contains categories to classify the app'
+  } else if ((categories &&
+          categories.length > 0 &&
+          !containsStandardCategory(categories))){
+      return 'You have non-standard categories'
+  }
+  return;
+} 


### PR DESCRIPTION


# Fixes 
#2650

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
User has categories in their manifest, but it is not in the standard list here https://github.com/pwa-builder/PWABuilder/blob/e5764f13d21846a5c97d3239c337be3eb81db494/src/script/utils/manifest-validation.ts . The user is told in the report-card page that they don't have categories even though they do, they are just non-standard.


## Describe the new behavior?
Specifies if the category is non standard

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
