### PR TITLE
package id limited to 50 chars in the test windows package process.

### DIFF
--- a/src/script/services/publish/windows-publish.ts
+++ b/src/script/services/publish/windows-publish.ts
@@ -82,7 +82,6 @@ export function createWindowsPackageOptionsFromManifest(
 
   const name = manifest.short_name || manifest.name || 'My PWA';
   const packageID = generateWindowsPackageId(new URL(pwaURL).hostname);
-  
   const manifestIcons = manifest.icons || [];
 
   const icon = findBestAppIcon(manifestIcons);


### PR DESCRIPTION
# Fixes 
https://github.com/pwa-builder/PWABuilder/issues/2744

## PR Type
 Bugfix

## Describe the current behavior?
The windows test package generates a package id based on the users origin + some additional info. This string must be <= 50 chars but we don't actually limit it to 50 which for some people, causes errors.

## Describe the new behavior?
The string doesn't actually have to be perfectly accurate for the test package so we create the id the same way but on return I only return up to the 50th char. If there are less than or equal to 50 chars, they'll all be returned.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
