### PR TITLE
"PWA Builder" to "PWABuilder"

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest an idea for PWA Builder
+description: Suggest an idea for PWABuilder
 labels: ["feature request :mailbox_with_mail:", "needs triage :mag:"]
 body:
   - type: textarea

--- a/src/script/components/app-footer.ts
+++ b/src/script/components/app-footer.ts
@@ -150,7 +150,7 @@ export class AppFooter extends LitElement {
       <footer>
         <div id="footer-top">
           <span
-            >PWA Builder was founded by Microsoft as a community guided, open
+            >PWABuilder was founded by Microsoft as a community guided, open
             source project to help move PWA adoption forward.</span
           >
 

--- a/src/script/components/app-header.ts
+++ b/src/script/components/app-header.ts
@@ -172,7 +172,7 @@ export class AppHeader extends LitElement {
     return html`
       <header part="header">
         <img @click="${this.goBack}" tabindex="0" id="header-icon" src="/assets/images/header_logo.svg"
-          alt="PWA Builder logo" />
+          alt="PWABuilder logo" />
       
         <nav id="desktop-nav">
           <fast-anchor

--- a/src/script/components/rating-dial.ts
+++ b/src/script/components/rating-dial.ts
@@ -152,16 +152,16 @@ export class RatingDial extends LitElement {
   decideComment(): TemplateResult {
     const topHTML = html`<span id="rating-comment"
       >Your PWA ranks in the <span id="top">Top 100</span> of all developers
-      using PWA Builder</span
+      using PWABuilder</span
     > `;
     const middleHTML = html`<span id="rating-comment"
       >Your PWA ranks in the <span id="middle">middle</span> of all developers
-      using PWA Builder</span
+      using PWABuilder</span
     > `;
 
     const lowerHTML = html`<span id="rating-comment"
       >Your PWA ranks <span id="lower">below the average</span> of all
-      developers using PWA Builder</span
+      developers using PWABuilder</span
     > `;
 
     if (this.rating === 'middle') {


### PR DESCRIPTION
We discussed the importance of being consistent with how we spell and space PWABuilder. It seems like PWABuilder (with no space) seems to be used more widely so we decided to move forwards with that one.