### PR TITLE
theme and bg color in manifest set to #000000 rather than none

### DIFF
--- a/src/script/services/app-info.ts
+++ b/src/script/services/app-info.ts
@@ -228,8 +228,8 @@ function getManifestFromSessionOrEmpty(): ManifestContext {
     scope: '/',
     lang: 'en',
     description: 'placeholder description',
-    theme_color: 'none',
-    background_color: 'none',
+    theme_color: '#000000',
+    background_color: '#000000',
     icons: [],
     screenshots: [],
   };

--- a/src/script/services/manifest.ts
+++ b/src/script/services/manifest.ts
@@ -20,8 +20,8 @@ export let emptyManifest: Manifest = {
   scope: '/',
   lang: 'en',
   description: 'placeholder description',
-  theme_color: 'none',
-  background_color: 'none',
+  theme_color: '#000000',
+  background_color: '#000000',
   icons: [],
   screenshots: [],
 };


### PR DESCRIPTION
# Fixes 
https://github.com/pwa-builder/PWABuilder/issues/2834

## PR Type
Bugfix

## Describe the current behavior?
Theme and Background colors set to `none` in our empty manifest which causes errors down the line for users

## Describe the new behavior?
Theme and Background colors set to `#000000`

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
