### PR TITLE
added demo url flag to separate out the process where demo urls are used

### DIFF
--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -405,8 +405,8 @@ export class AppHome extends LitElement {
   }
 
   async analyzeSite() {
-    if(this.siteURL === demoURL){
-      localStorage.setItem('demoURL', JSON.stringify(false));
+    if(this.siteURL !== demoURL){
+      sessionStorage.setItem('demoURL', JSON.stringify(false));
     }
 
     if (this.siteURL) {
@@ -479,7 +479,7 @@ export class AppHome extends LitElement {
   }
 
   placeDemoURL(){
-    localStorage.setItem('demoURL', JSON.stringify(true));
+    sessionStorage.setItem('demoURL', JSON.stringify(true));
     recordPWABuilderProcessStep("home.top.DemoURL_clicked", AnalyticsBehavior.ProcessCheckpoint);
     this.siteURL = demoURL;
     let box = this.shadowRoot!.getElementById("input-box");

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -405,6 +405,10 @@ export class AppHome extends LitElement {
   }
 
   async analyzeSite() {
+    if(this.siteURL === demoURL){
+      localStorage.setItem('demoURL', JSON.stringify(false));
+    }
+
     if (this.siteURL) {
       this.gettingManifest = true;
       const isValidUrl = isValidURL(this.siteURL);
@@ -475,8 +479,9 @@ export class AppHome extends LitElement {
   }
 
   placeDemoURL(){
+    localStorage.setItem('demoURL', JSON.stringify(true));
     recordPWABuilderProcessStep("home.top.DemoURL_clicked", AnalyticsBehavior.ProcessCheckpoint);
-    this.siteURL = "https://webboard.app";
+    this.siteURL = demoURL;
     let box = this.shadowRoot!.getElementById("input-box");
     (box as HTMLInputElement)!.value = this.siteURL;
     this.analyzeSite();
@@ -549,3 +554,5 @@ export class AppHome extends LitElement {
     `;
   }
 }
+
+const demoURL: string = "https://webboard.app";

--- a/src/script/utils/analytics.ts
+++ b/src/script/utils/analytics.ts
@@ -50,6 +50,13 @@ export function recordPWABuilderProcessStep(
   stepType: AnalyticsBehavior.ProcessCheckpoint | AnalyticsBehavior.StartProcess | AnalyticsBehavior.ProcessCheckpoint | AnalyticsBehavior.CancelProcess | AnalyticsBehavior.CompleteProcess,
   additionalInfo?: {}) {
 
+    const demo_used = localStorage.getItem('demoURL')
+    let scn = 'pwa-builder';
+
+    if(demo_used){
+      scn = 'demo-process';
+    }
+
     let pageName = window.location.pathname.slice(1);
     if(pageName.length == 0) {
       pageName = "home";
@@ -63,7 +70,7 @@ export function recordPWABuilderProcessStep(
         actionType: AnalyticsActionType.Other,
         behavior: stepType,
         contentTags: {
-          scn: "pwa-builder",
+          scn: scn,
           scnstp: processLabel
         },
         content: additionalInfo

--- a/src/script/utils/analytics.ts
+++ b/src/script/utils/analytics.ts
@@ -50,7 +50,7 @@ export function recordPWABuilderProcessStep(
   stepType: AnalyticsBehavior.ProcessCheckpoint | AnalyticsBehavior.StartProcess | AnalyticsBehavior.ProcessCheckpoint | AnalyticsBehavior.CancelProcess | AnalyticsBehavior.CompleteProcess,
   additionalInfo?: {}) {
 
-    const demo_used = localStorage.getItem('demoURL')
+    const demo_used = JSON.parse(sessionStorage.getItem('demoURL')!);
     let scn = 'pwa-builder';
 
     if(demo_used){


### PR DESCRIPTION
# Fixes 
https://github.com/pwa-builder/PWABuilder/issues/2837

## PR Type
Bugfix

## Describe the current behavior?
Demo url gets tracked as a normal process and theres no way to know if this test url is inflating our numbers.

## Describe the new behavior?
Demo url gets its own process so it won't impact the normal flow numbers.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
