### PR TITLE
added aka link to home page

### DIFF
--- a/src/script/components/code-editor.ts
+++ b/src/script/components/code-editor.ts
@@ -14,7 +14,7 @@ import {
 import { increment } from '../utils/id';
 
 import './app-button';
-import { recordProcessStep, AnalyticsBehavior, recordPWABuilderProcessStep } from '../utils/analytics';
+import { AnalyticsBehavior, recordPWABuilderProcessStep } from '../utils/analytics';
 
 @customElement('code-editor')
 export class CodeEditor extends LitElement {

--- a/src/script/pages/app-home.ts
+++ b/src/script/pages/app-home.ts
@@ -511,7 +511,7 @@ export class AppHome extends LitElement {
           
               <div class="intro-grid-item">
                 <div class="grid-item-header">  
-                  <h2><a @click=${() => recordPWABuilderProcessStep("home.top.PWAStudio_clicked", AnalyticsBehavior.ProcessCheckpoint)} href="https://marketplace.visualstudio.com/items?itemName=PWABuilder.pwa-studio" target="_blank" rel="noopener">Use dev tools</a></h2>
+                  <h2><a @click=${() => recordPWABuilderProcessStep("home.top.PWAStudio_clicked", AnalyticsBehavior.ProcessCheckpoint)} href="https://aka.ms/install-pwa-studio" target="_blank" rel="noopener">Use dev tools</a></h2>
                   <img src="/assets/new/arrow.svg" alt="arrow" />
                 </div>
                 <p>

--- a/src/script/pages/app-report.ts
+++ b/src/script/pages/app-report.ts
@@ -23,7 +23,7 @@ import '../components/app-modal';
 import style from '../../../styles/layout-defaults.css';
 import { RawTestResult, ScoreEvent } from '../utils/interfaces';
 import { giveOutBadges } from '../services/badges';
-import { recordProcessStep, AnalyticsBehavior, recordPWABuilderProcessStep } from '../utils/analytics';
+import {  AnalyticsBehavior, recordPWABuilderProcessStep } from '../utils/analytics';
 
 const possible_messages = {
   overview: {


### PR DESCRIPTION
# Fixes 
https://github.com/pwa-builder/PWABuilder/issues/2883

## PR Type
Bugfix

## Describe the current behavior?
The direct link to the PWA Studio Marketplace page is in the site.

## Describe the new behavior?
The aka.ms link replaces the direct link.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information