### PR TITLE
Keyboard focus added to close button on discord modal

### DIFF
--- a/apps/pwabuilder/src/script/components/discord-box.ts
+++ b/apps/pwabuilder/src/script/components/discord-box.ts
@@ -52,6 +52,10 @@ export class DiscordBox extends LitElement {
       #discord-box a:visited{
         color: black;
       }
+      #close-wrapper {
+        border: none;
+        background-color: transparent;
+      }
       #close:hover {
         cursor: pointer;
       }
@@ -76,7 +80,7 @@ export class DiscordBox extends LitElement {
         <div id="discord-box">
           <img id="logo" src="/assets/images/discord_logo.svg" alt="discord logo"/>
           <p>Want to chat? Join us on <a @click=${() => recordPWABuilderProcessStep("discord_box_link_clicked", AnalyticsBehavior.ProcessCheckpoint)} href="https://aka.ms/pwabuilderdiscord" target="_blank" rel="noopener">Discord</a></p>
-          <img id="close" src="/assets/images/Close_desk.png" @click=${() => this.close()} alt="close button"/>
+          <button id="close-wrapper" @click=${() => this.close()} aria-label="discord modal close" type="button"><img id="close" src="/assets/images/Close_desk.png" role="presentation"/></button>
         </div>`
         : null}
     `;


### PR DESCRIPTION
fixes #[issue number] 
#2888 

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
apps/pwabuilder


## Describe the current behavior?
The close button was not accessible by keyboard (tab).


## Describe the new behavior?
Close button should now be focusable when tabbing through the page.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
