### PR TITLE
Start button is disabled until input is true for isValidUrl()

### DIFF
--- a/apps/pwabuilder/src/script/pages/app-home.ts
+++ b/apps/pwabuilder/src/script/pages/app-home.ts
@@ -41,6 +41,8 @@ export class AppHome extends LitElement {
   @state() errorGettingURL = false;
   @state() errorMessage: string | undefined;
 
+  @state() disableStart = true;
+
   static get styles() {
     return [
       style,
@@ -400,6 +402,10 @@ export class AppHome extends LitElement {
     if (inputEvent) {
       this.siteURL = (inputEvent.target as HTMLInputElement).value.trim();
     }
+
+    if (isValidURL(this.siteURL as string)) {
+      this.disableStart = false;
+    };
   }
 
   async start(inputEvent: InputEvent) {
@@ -541,7 +547,7 @@ export class AppHome extends LitElement {
                       : null}
                   </div>
             
-                  <loading-button id="start-button" type="submit" class="navigation raise" ?loading="${this.gettingManifest}"
+                  <loading-button id="start-button" type="submit" class="navigation raise" ?loading="${this.gettingManifest}" ?disabled="${this.disableStart}"
                   @click="${(e: InputEvent) => this.start(e)}">Start</loading-button>
                   <p id="demo">Try a <button id="demo-action" aria-label="click here for demo url" @click=${() => this.placeDemoURL()}>demo url</button></p>
                 </div>


### PR DESCRIPTION
fixes #[issue number] 
#2906 

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
Feature
apps/pwabuilder 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
User can navigate (through mouse or using Win + CTRL + Enter then tab key) to start button without any text in the input field

## Describe the new behavior?
Text must be placed in the input field and validated before start button is accessible

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
