### PR TITLE
[PWABUILDER] Empty alt added to decorative css generated background imgs

### DIFF
--- a/apps/pwabuilder/src/script/components/success-stories.ts
+++ b/apps/pwabuilder/src/script/components/success-stories.ts
@@ -19,6 +19,9 @@ export class SuccessStories extends LitElement {
   static get styles() {
     return [
     css`
+      #success-panel::before {
+        content: "";
+      }
       #success-panel {
         display: flex;
         flex-direction: column;

--- a/apps/pwabuilder/src/script/pages/app-home.ts
+++ b/apps/pwabuilder/src/script/pages/app-home.ts
@@ -45,6 +45,9 @@ export class AppHome extends LitElement {
     return [
       style,
       css`
+        #home-block::before {
+          content: "";
+        }
         #home-block {
           background: url(/assets/new/HeroBackground1920.jpg);
           background-position: center center;


### PR DESCRIPTION
fixes #2889 

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
Background image missing alt to signify decorative purpose


## Describe the new behavior?
Empty alt added to signify decorative purpose

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
