### PR TITLE
Nonfocusable decorative icons

### DIFF
--- a/apps/pwabuilder/src/script/components/info-card.ts
+++ b/apps/pwabuilder/src/script/components/info-card.ts
@@ -151,7 +151,7 @@ export class Infocard extends LitElement {
     return html`
       <div class="card">
         <div class="card-content">
-          <img src=${this.imageUrl} alt="${this.cardTitle} icon" />
+          <img src=${this.imageUrl} alt="${this.cardTitle} icon" role="presentation"/>
           <h3>${this.cardTitle}</h3>
           <p>${this.description}</p>
         </div>


### PR DESCRIPTION
fixes #[issue number] 
#2887

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
 Code style update (formatting)
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
Decorative icons on the homepage cards were scanned when opening the screen reader and pressing the down key


## Describe the new behavior?
Decorative icons on the homepage are no longer scanned

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
