### PR TITLE
URL Input field associated to header

### DIFF
--- a/apps/pwabuilder/src/script/pages/app-home.ts
+++ b/apps/pwabuilder/src/script/pages/app-home.ts
@@ -544,7 +544,7 @@ export class AppHome extends LitElement {
                 <div id="input-area">
                   <div id="input-and-error">
                     <fast-text-field slot="input-container" type="text" id="input-box" placeholder="Enter the URL to your PWA" name="url-input"
-                      class="${classMap({ error: this.errorGettingURL })}" @input="${(e: InputEvent) => this.handleURL(e)}">
+                      class="${classMap({ error: this.errorGettingURL })}" aria-labelledby="input-header" @input="${(e: InputEvent) => this.handleURL(e)}">
                     </fast-text-field>
               
                     ${this.errorMessage && this.errorMessage.length > 0


### PR DESCRIPTION
fixes #[issue number] 
[#2907](https://github.com/pwa-builder/PWABuilder/issues/2907)

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
 Code style update (formatting) 
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
‘Ship your PWA to apps store’ label is not associated with ‘Enter the URL to PWA’ edit field. Screen reader dependent user will not be able to figure out the meaning of the Edit field.


## Describe the new behavior?
Ship your PWA to apps store label is associated with ‘Enter the URL to PWA’ edit field

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
