### PR TITLE
Arrows/Community image are decorative only

### DIFF
--- a/apps/pwabuilder/src/script/components/community-card.ts
+++ b/apps/pwabuilder/src/script/components/community-card.ts
@@ -164,7 +164,7 @@ export class CommunityCard extends LitElement {
               html`
               <div class="card-link-box">
                 <a @click=${() => recordPWABuilderProcessStep("home.bottom." + link.text + "_clicked", AnalyticsBehavior.ProcessCheckpoint)} href=${link.link} target="_blank" rel="noopener">${link.text}</a>
-                <img src="/assets/new/arrow.svg" alt="arrow" />
+                <img src="/assets/new/arrow.svg" alt="arrow" role="presentation"/>
               </div>
               `
             )}

--- a/apps/pwabuilder/src/script/components/community-hub.ts
+++ b/apps/pwabuilder/src/script/components/community-hub.ts
@@ -166,7 +166,7 @@ export class CommunityHub extends LitElement {
     return html`
       <div id="community-panel">
         <div id="community-photo">
-          <img src="/assets/new/community-image.png" alt="social hub image" />
+          <img src="/assets/new/community-image.png" alt="social hub image" role="presentation"/>
         </div>
         <div id="community-content">
           <h2>Join our Community</h2>

--- a/apps/pwabuilder/src/script/pages/app-home.ts
+++ b/apps/pwabuilder/src/script/pages/app-home.ts
@@ -510,7 +510,7 @@ export class AppHome extends LitElement {
               <div class="intro-grid-item">
                 <div class="grid-item-header">  
                   <a @click=${() => recordPWABuilderProcessStep("home.top.PWAStarter_clicked", AnalyticsBehavior.ProcessCheckpoint)} href="https://github.com/pwa-builder/pwa-starter/wiki/Getting-Started" target="_blank" rel="noopener">Start a new PWA</a>
-                  <img src="/assets/new/arrow.svg" alt="arrow" />
+                  <img src="/assets/new/arrow.svg" alt="arrow" role="presentation"/>
                   
                 </div>
                 <p>
@@ -521,7 +521,7 @@ export class AppHome extends LitElement {
               <div class="intro-grid-item">
                 <div class="grid-item-header">  
                   <a @click=${() => recordPWABuilderProcessStep("home.top.PWAStudio_clicked", AnalyticsBehavior.ProcessCheckpoint)} href="https://aka.ms/install-pwa-studio" target="_blank" rel="noopener">Use dev tools</a>
-                  <img src="/assets/new/arrow.svg" alt="arrow" />
+                  <img src="/assets/new/arrow.svg" alt="arrow" role="presentation"/>
                 </div>
                 <p>
                   Use our VS Code extension to create, improve, and package your PWA directly in your code editor.


### PR DESCRIPTION
fixes #[issue number] 
[#2887](https://github.com/pwa-builder/PWABuilder/issues/2887)

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
 Code style update (formatting) 
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
Arrows and community image are scannable 

## Describe the new behavior?
They have a role of just presentation

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
