### PR TITLE
Screen reader only success stories titles

### DIFF
--- a/apps/pwabuilder/src/script/components/success-stories.ts
+++ b/apps/pwabuilder/src/script/components/success-stories.ts
@@ -52,7 +52,7 @@ export class SuccessStories extends LitElement {
         column-gap: 1em;
       }
 
-      //for screen reader only
+      /* for screen reader only */
       .screen-reader-only {
         border: 0; 
         clip: rect(0 0 0 0); 

--- a/apps/pwabuilder/src/script/components/success-stories.ts
+++ b/apps/pwabuilder/src/script/components/success-stories.ts
@@ -51,7 +51,18 @@ export class SuccessStories extends LitElement {
         row-gap: .8em;
         column-gap: 1em;
       }
-      
+
+      //for screen reader only
+      .screen-reader-only {
+        border: 0; 
+        clip: rect(0 0 0 0); 
+        height: 1px; 
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+      }   
       
       /* < 480px */
       ${smallBreakPoint(css`
@@ -173,6 +184,7 @@ export class SuccessStories extends LitElement {
           <h2>PWA success stories</h2>
           <div id="success-cards">
             ${this.cards.map((card: any) => html`
+            <span class="screen-reader-only">${card.company} success story</span>
             <success-card
             cardStat=${card.stat}
             description=${card.description}
@@ -180,7 +192,6 @@ export class SuccessStories extends LitElement {
             cardValue=${card.value}
             company=${card.company}
             source=${card.source}
-            aria-label="${card.company} success story"
             >
             </success-card>
             `)}


### PR DESCRIPTION
fixes #[issue number] 
[#2891](https://github.com/pwa-builder/PWABuilder/issues/2891)

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
 Refactoring (no functional changes, no api changes) 
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
User was not able to differentiate the different success stories through the screen reader

## Describe the new behavior?
Short title (ex: "Trivago's success story") added to signify the start of a new story. Only readable with a screen reader, not visible. 


## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
