### PR TITLE
typos and links that I could fix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ You can use PWA Studio to:
   
 * Manage your app’s manifest, service workers, and icons
   
-* Package your app’s for the Microsoft, Google, and Apple Stores
+* Package your apps for the Microsoft, Google, and Apple Stores
   
 * Validate your PWA across several metrics
   

--- a/docs/studio/create-new.md
+++ b/docs/studio/create-new.md
@@ -1,5 +1,5 @@
 # Create a New PWA
-Creating a new progressive web app with PWA Studio is easy: the extension has a built in command to clone the [PWA Starter template.]()
+Creating a new progressive web app with PWA Studio is easy: the extension has a built in command to clone the [PWA Starter template.](https://github.com/pwa-builder/pwa-starter)
 The PWA Starter is a lightweight, fast, extensible template that allows you to get your progressive web app off the ground right away. 
 Combined with the extension, it's perfect for someone to looking to build their first PWA.
 
@@ -32,7 +32,7 @@ You can also start a new PWA with a command. To do this:
    
 3. Select `PWABuilder: New PWA`.
    
-4. Enter a repoitory name and hit enter.
+4. Enter a repository name and hit enter.
    
 5. Choose a location for your repository to live.
    

--- a/docs/studio/existing-app.md
+++ b/docs/studio/existing-app.md
@@ -12,7 +12,7 @@ PWA Studio comes with tooling for adding both manifests and service workers for 
 
 To add a manifest using the interface:
 
-1. Click the PWA Studio icon on the left side of the VSCode Window.
+1. Click the PWA Studio icon on the left side of the VS Code Window.
    
 2. One the left side of your Code window, you should see the PWA Studio UI.
    
@@ -38,7 +38,7 @@ This tutorial also uses the interface to create a service worker, but can also b
 
 The extension uses [Workbox](https://developers.google.com/web/tools/workbox/) to generate a Service Worker. Workbox is a helpful tool for creating and managing service workers that abstracts away a lot of the complexity.
 
-1. Tap the PWABuilder icon on the right side of the VSCode Window
+1. Tap the PWABuilder icon on the right side of the VS Code Window
 
 2. Tap the `Generate Service Worker` button
 
@@ -58,7 +58,7 @@ Be sure to check out the [Workbox documentation](https://developers.google.com/w
 
 ## Generate Icons
 
-Currently, PWAs running on different platforms, such as Windows, Android and iOS all require different sized icons for your PWA to display properly. The PWA Studio extension can help you generate the correct sized Icons for your application, using your [existing 512x512 sized icon](https://blog.pwabuilder.com/docs/image-recommendations-for-windows-pwa-packages/) and add them directly to your manifest.
+Currently, PWAs running on different platforms, such as Windows, Android and iOS all require different sized icons for your PWA to display properly. The PWA Studio extension can help you generate the correct sized icons for your application, using your [existing 512x512 sized icon](https://blog.pwabuilder.com/docs/image-recommendations-for-windows-pwa-packages/) and add them directly to your manifest.
 
 To generate icons:
 

--- a/docs/studio/faq.md
+++ b/docs/studio/faq.md
@@ -20,4 +20,4 @@ You most likely have not saved your `index.html` file. The extension will insert
 1. [Open our Github Actions](https://github.com/pwa-builder/pwa-studio/actions)
 2. Choose your workflow run. Normally the first one is the latest one.
 3. Click on the workflow run, scroll to the bottom, and download the vsix file in the `Artifacts` section.
-4. Install [this extension](https://marketplace.visualstudio.com/items?itemName=fabiospampinato.vscode-install-vsix&msclkid=d9be3152b46711ecb569dbe40d0a72c0) to install that VSIX file we downloaded in step 3
+4. Install [this extension](https://marketplace.visualstudio.com/items?itemName=fabiospampinato.vscode-install-vsix&msclkid=d9be3152b46711ecb569dbe40d0a72c0) to install that VSIX file we downloaded in step 3.

--- a/docs/studio/package.md
+++ b/docs/studio/package.md
@@ -1,5 +1,5 @@
 # Package for Stores
-Once your app is published to the web, PWA Studio can use [PWABuilder]() APIs to package your PWA for various app stores, including iOS, Google Play, and Microsoft. Your PWA just needs to be available on the web, and you're all set. If you need help publishing your app to the web, check out this documentation on using [Azure Static Web Apps]().
+Once your app is published to the web, PWA Studio can use [PWABuilder](https://www.pwabuilder.com) APIs to package your PWA for various app stores, including iOS, Google Play, and Microsoft. Your PWA just needs to be available on the web, and you're all set. If you need help publishing your app to the web, check out this documentation on using [Azure Static Web Apps]().
 
 ## Add Your App's URL
 You can use PWA Studio to associate your progressive web app with a URL.

--- a/docs/studio/quick-start.md
+++ b/docs/studio/quick-start.md
@@ -4,14 +4,14 @@ PWA Studio is an extension for Visual Studio Code that provides tooling for work
 
 You can use PWA Studio to: 
 
-* Create a new PWA using the [starter template]()
+* Create a new PWA using the [starter template](https://github.com/pwa-builder/pwa-starter)
 * Convert an existing web app into a PWA
 * Manage your app's manifest, service workers, and icons
-* Package your app's for the Microsoft, Google, and Apple Stores
+* Package your apps for the Microsoft, Google, and Apple Stores
 * Validate your PWA across several metrics
 * Add web capabilities with code snippets
 
-If you're new to developing PWAs and aren't sure where to start, check out this [blog series.]()
+If you're new to developing PWAs and aren't sure where to start, check out this [blog series.](https://microsoft.github.io/win-student-devs/#/)
 
 ## Getting the Extension
 The PWABuilder Code extension is available within Visual Studio Code in the extensions tab. If you search for `PWA Studio` or `PWABuilder`, it should be the first result. 
@@ -56,12 +56,12 @@ Here are a few places to check out in the documentation if you are using the ext
 <br>
 **Looking to build a new PWA from scratch?**
 <br>
-Check out how to [clone the PWA Starter application](https://github.com/pwa-builder/pwabuilder-vscode/wiki/Start-building-a-new-PWA) with the extension.
+Check out how to [clone the PWA Starter application](https://github.com/pwa-builder/pwa-studio/wiki/Create-a-New-PWA) with the extension.
 
 **Want to convert your web app into a PWA?**
 <br>
-Take a look at [adding a web manifest](https://github.com/pwa-builder/pwabuilder-vscode/wiki/Make-a-Web-App-a-Progressive-Web-App) to your existing web applicatioon.
+Take a look at [adding a web manifest](https://github.com/pwa-builder/pwa-studio/wiki/Convert-an-Existing-Web-App) to your existing web applicatioon.
 
 **Have a PWA already and want to get it Store-ready?**
 <br>
-Learn how to [validate your PWA](https://github.com/pwa-builder/pwabuilder-vscode/wiki/Validate-your-PWA) and then [package it for stores.](https://github.com/pwa-builder/pwabuilder-vscode/wiki/Package-your-PWA-for-the-app-stores!)
+Learn how to [validate your PWA](https://github.com/pwa-builder/pwa-studio/wiki/Validate) and then [package it for stores.](https://github.com/pwa-builder/pwa-studio/wiki/Package)


### PR DESCRIPTION
Just reading through the PWA Studio docs looking for broken links and typos. I fixed a few with this PR but there are still a few broken links that I'll note below. I added @jgw96 to verify that I am making corrections that are consistent with what you intended to write and also @zateutsch so he can add the correct links.

Format is **location = problem**
quick start / First steps = full of broken github wiki links
create new / next steps = broken github wiki link
existing app / first paragraph =  "validate" has no link (idk where its supposed to go)
existing app / adding a manifest = does adding a manifest still work like this in 1.0?
existing app / generate icons = 512x512 link links to documentation @ blog.pwabuilder.com
existing app / generate icons = instruction 1 broken link to validation documentation
package / first paragraph = Azure Static Web Apps documentation link missing
package / validate your pwa = last link doesn't work

Question about small detail:
whenever there is a "Note" block should it be 
Note blah blah .. or
Note: blah blah .. with a colon?