### PR TITLE
High contrast css

### DIFF
--- a/apps/pwabuilder/src/script/components/app-footer.ts
+++ b/apps/pwabuilder/src/script/components/app-footer.ts
@@ -74,6 +74,21 @@ export class AppFooter extends LitElement {
         padding: 3px;
       }
 
+      @media screen and (-ms-high-contrast: black-on-white) {
+          /* All high contrast styling rules */
+          ion-icon {
+            color: black;
+          }
+      } 
+
+      @media screen and (-ms-high-contrast: white-on-black) {
+          /* All high contrast styling rules */
+          ion-icon {
+            color: black;
+          }
+          
+      } 
+
       ${xxxLargeBreakPoint(
         css`
           footer {

--- a/apps/pwabuilder/src/script/pages/app-home.ts
+++ b/apps/pwabuilder/src/script/pages/app-home.ts
@@ -346,6 +346,19 @@ export class AppHome extends LitElement {
             width: 600px;
           }
         }
+        @media screen and (-ms-high-contrast: white-on-black) {
+          #input-form fast-text-field::part(control):focus:not(:focus-visible) {
+            outline: none;
+          }
+          #input-form fast-text-field::part(control):focus-visible {
+            outline: skyblue solid 3px;
+            outline-offset: 2px;
+          }
+          #input-form fast-text-field::part(control) {
+            color: white;
+          }
+        } 
+        
         /*1024px - 1365px*/ 
         ${xLargeBreakPoint(css`
             #home-block {


### PR DESCRIPTION
fixes #[issue number] 
[#2912](https://github.com/pwa-builder/PWABuilder/issues/2912)

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
Code style update (formatting) 
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
Icon color does not change in high contrast mode. The narrator keyboard indicator is not visible on the input field in high contrast mode. Text in the input field is dark in high contrast mode.  

## Describe the new behavior?
High contrast mode css is implemented for the icons, and input field.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
