### PR TITLE
scanner focuses on the percentage value first after tabbing onto card

### DIFF
--- a/apps/pwabuilder/src/script/components/success-card.ts
+++ b/apps/pwabuilder/src/script/components/success-card.ts
@@ -120,9 +120,9 @@ export class SuccessCard extends LitElement {
       <a @click=${() => recordPWABuilderProcessStep("home.middle." + this.company + "_clicked", AnalyticsBehavior.ProcessCheckpoint)} class="success-card" href="${this.source}" rel="noopener" target="_blank" aria-label=${"Success story of " + this.company + " link"}>
         <div class="success-line-one">
            <img src=${this.imageUrl} alt="${this.company} logo"/>
-           <h3 class="success-stat">
+           <h1 class="success-stat">
              <span>${this.cardValue}</span> ${this.cardStat}
-           </h3>    
+           </h1>    
         </div>
         <p class="success-desc">${this.description}</p>
   </a>

--- a/apps/pwabuilder/src/script/components/success-card.ts
+++ b/apps/pwabuilder/src/script/components/success-card.ts
@@ -42,6 +42,8 @@ export class SuccessCard extends LitElement {
         align-items: flex-start;
         justify-content: space-between;
         width: 100%;
+        /* for screen reader scan */
+        flex-direction: row-reverse;
       }
 
       .success-line-one h3 {
@@ -117,8 +119,8 @@ export class SuccessCard extends LitElement {
     return html`
       <a @click=${() => recordPWABuilderProcessStep("home.middle." + this.company + "_clicked", AnalyticsBehavior.ProcessCheckpoint)} class="success-card" href="${this.source}" rel="noopener" target="_blank" aria-label=${"Success story of " + this.company + " link"}>
         <div class="success-line-one">
-          <h3 tabindex="0">${this.cardValue}</h3>
-          <img src=${this.imageUrl} alt="${this.company} logo"/>
+           <img src=${this.imageUrl} alt="${this.company} logo"/>
+           <h3>${this.cardValue}</h3>
         </div>
         <p class="success-stat">${this.cardStat}</p>
         <p class="success-desc">${this.description}</p>

--- a/apps/pwabuilder/src/script/components/success-card.ts
+++ b/apps/pwabuilder/src/script/components/success-card.ts
@@ -46,19 +46,19 @@ export class SuccessCard extends LitElement {
         flex-direction: row-reverse;
       }
 
-      .success-line-one h3 {
-        margin: 0;
-        font-size: 36px;
-        line-height: 36px;
-        font-weight: bold;
-      }
-
       .success-stat {
         margin: 0;
         font-size: 20px;
         line-height: 28px;
         font-weight: bold;
         margin-bottom: .75em;
+      }
+
+      .success-stat span {
+        margin-right: 50%;
+        font-size: 36px;
+        line-height: 36px;
+        font-weight: bold;
       }
 
       .success-desc {
@@ -120,9 +120,10 @@ export class SuccessCard extends LitElement {
       <a @click=${() => recordPWABuilderProcessStep("home.middle." + this.company + "_clicked", AnalyticsBehavior.ProcessCheckpoint)} class="success-card" href="${this.source}" rel="noopener" target="_blank" aria-label=${"Success story of " + this.company + " link"}>
         <div class="success-line-one">
            <img src=${this.imageUrl} alt="${this.company} logo"/>
-           <h3>${this.cardValue}</h3>
+           <h3 class="success-stat">
+             <span>${this.cardValue}</span> ${this.cardStat}
+           </h3>    
         </div>
-        <p class="success-stat">${this.cardStat}</p>
         <p class="success-desc">${this.description}</p>
   </a>
     `;


### PR DESCRIPTION
fixes #2891 

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
Hit tab to a success card, after hit the down arrow key to focus on its contents. It should focus on the percentage at the top, but it does not.


## Describe the new behavior?
The focus starts at the percentage value and from there can be navigated down (using down arrow key) to read the rest of the content.


## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
