### PR TITLE
Small UI Tweaks

### DIFF
--- a/apps/pwabuilder/src/script/pages/app-publish.ts
+++ b/apps/pwabuilder/src/script/pages/app-publish.ts
@@ -411,7 +411,7 @@ export class AppPublish extends LitElement {
           letter-spacing: 0px;
           text-align: center;
           width: 100%;
-          height: 100%;
+          white-space: nowrap;
           margin: 0;
           padding: 10px 0;
         }

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -198,9 +198,10 @@ export class AppReport extends LitElement {
               display: none;
             }
             .reportCard h1 {
-              font-size: 33px;
+              font-size: 24px;
+              line-height: 30px;
               margin-top: 0;
-              margin-bottom: 1em;
+              margin-bottom: 2em;
             }
             .reportCard p {
               display: none;


### PR DESCRIPTION
fixes N/A

## PR Type
Bugfix

## Describe the current behavior?
1. On the report card page on smaller screens the text in the banner overflows into the header.
2. The tab switcher for the android form was broken completely on small screens

## Describe the new behavior?
Fixed both
1. Lower font size
2. Lower font size and no text wrapping

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information