### PR TITLE
Fix broken link to Apple App Store's next steps

### DIFF
--- a/docs/builder/quick-start.md
+++ b/docs/builder/quick-start.md
@@ -53,4 +53,4 @@ If you're looking for more specific guidance on how to publish a PWA to a specif
 
 **[Google Play Store](/builder/android)**
 
-**[iOS App Store](/builder/ios)**
+**[iOS App Store](/builder/app-store)**


### PR DESCRIPTION
The `iOS` folder was renamed at some point to `app-store` but the next steps link was missed with the rename.

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
- Documentation content changes 

## Describe the current behavior?
User clicks on the `iOS App Store` link at `https://docs.pwabuilder.com/#/builder/quick-start` and gets a 404

## Describe the new behavior?
User clicks on the `iOS App Store` link at `https://docs.pwabuilder.com/#/builder/quick-start` and gets routed to the correct content

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
