### PR TITLE
fix(mani-validation): whitespace tests return false instead of value.…

### DIFF
--- a/libraries/manifest-validation/src/validations.ts
+++ b/libraries/manifest-validation/src/validations.ts
@@ -57,7 +57,7 @@ export const maniTests: Array<Validation> = [
         quickFix: true,
         test: (value: string) => {
             if (value.trim() !== value) {
-                return value.trim();
+                return false;
             }
             else {
                 return true;
@@ -89,7 +89,7 @@ export const maniTests: Array<Validation> = [
         quickFix: true,
         test: (value: string) => {
             if (value.trim() !== value) {
-                return value.trim();
+                return false;
             }
             else {
                 return true;
@@ -296,7 +296,7 @@ export const maniTests: Array<Validation> = [
         quickFix: true,
         test: (value: string) => {
             if (value.trim() !== value) {
-                return value.trim();
+                return false;
             }
             else {
                 return true;


### PR DESCRIPTION
…trim()

fixes #[issue number] 
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->
Fixes #3176 

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Whitespace tests returned value.trim() if the test failed, instead of a boolean

## Describe the new behavior?
Will now return false instead of value.trim() when the test fails, matching the behavior of the other tests.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
