### PR TITLE
Fixed link to starter docs

### DIFF
--- a/apps/pwabuilder/src/script/pages/app-home.ts
+++ b/apps/pwabuilder/src/script/pages/app-home.ts
@@ -517,7 +517,7 @@ export class AppHome extends LitElement {
             <section id="content-grid" slot="grid-container">
               <div class="intro-grid-item">
                 <div class="grid-item-header">  
-                  <a @click=${() => recordPWABuilderProcessStep("home.top.PWAStarter_clicked", AnalyticsBehavior.ProcessCheckpoint)} href="https://github.com/pwa-builder/pwa-starter/wiki/Getting-Started" target="_blank" rel="noopener">Start a new PWA</a>
+                  <a @click=${() => recordPWABuilderProcessStep("home.top.PWAStarter_clicked", AnalyticsBehavior.ProcessCheckpoint)} href="https://docs.pwabuilder.com/#/starter/quick-start" target="_blank" rel="noopener">Start a new PWA</a>
                   <img src="/assets/new/arrow.svg" alt="arrow" role="presentation"/>
                   
                 </div>


### PR DESCRIPTION


## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
"Start a new PWA" link is broken and points to the old wiki that doesn't exist anymore


## Describe the new behavior?
The link points to our new docs

## PR Checklist


## Additional Information
