### PR TITLE
fix(vscode): specific sw register check added back for starter

### DIFF
--- a/apps/pwabuilder-vscode/src/services/validation/sw-view.ts
+++ b/apps/pwabuilder-vscode/src/services/validation/sw-view.ts
@@ -69,9 +69,12 @@ export class ServiceWorkerProvider implements vscode.TreeDataProvider<any> {
         if (indexFileExists) {
           const indexContents = await readFile(indexFile.fsPath, "utf8");
 
+          console.log('indexContents', indexContents);
+
+          // second check here after the or is specific to pwa-starter apps
           if (
             indexContents &&
-            indexContents.includes("serviceWorker.register")
+            indexContents.includes("serviceWorker.register") || indexContents && indexContents.includes('<script src="registerSW.js"></script>')
           ) {
             items.push(
               new ValidationItem(


### PR DESCRIPTION
fixes #3315 
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Studio would not see that a service worker had been registered in the PWA Starter as we use the Vite "regsiterSW.js" script in the starter for prod builds. 

## Describe the new behavior?
Added back a specific check for the starter. Note: Stuff like this could be used to help know if an app is a PWA Starter app or not.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
