### PR TITLE
fix(vscode): can choose other image types besides png

### DIFF
--- a/apps/pwabuilder-vscode/src/services/manifest/assets-service.ts
+++ b/apps/pwabuilder-vscode/src/services/manifest/assets-service.ts
@@ -91,7 +91,7 @@ export async function generateIcons() {
                 canSelectFiles: true,
                 canSelectMany: false,
                 filters: {
-                    'Images': ['png']
+                    'Images': ['png', 'jpg', 'jpeg'],
                 },
                 openLabel: 'Select your Icon file, 512x512 is preferred'
             });


### PR DESCRIPTION
fixes #3318
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
While PNG is the recommended format for icons because of transparency support (https://developer.chrome.com/docs/extensions/mv2/manifest/icons/#:~:text=Icons%20should%20generally%20be%20in%20PNG%20format%2C%20because,JPEG.%20Here%27s%20an%20example%20of%20specifying%20the%20icons%3A), we should still allow users to choose other supported image types.

## Describe the new behavior?
User can now choose other supported image types besides png

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
