### PR TITLE
Remove upper char limit on android package id

### DIFF
--- a/apps/pwabuilder/src/script/components/android-form.ts
+++ b/apps/pwabuilder/src/script/components/android-form.ts
@@ -191,7 +191,7 @@ export class AndroidForm extends AppPackageFormBase {
                 placeholder: 'MyCompany.MyApp',
                 value: this.packageOptions.packageId,
                 minLength: 3,
-                maxLength: 50,
+                maxLength: Number.MAX_SAFE_INTEGER,
                 spellcheck: false,
                 pattern: "[a-zA-Z0-9.-_]*$",
                 validationErrorMessage: "Package ID must contain only letters, numbers, periods, hyphens, and underscores.",


### PR DESCRIPTION
fixes #3344 

## PR Type
Bugfix

## Describe the current behavior?
There was an upper limit on the number of chars that could be in the android package id. This is incorrect as there can be longer id's.

## Describe the new behavior?
New upper limit set to Number. MAX_SAFE_INT to simulate no char limit.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
