### PR TITLE
Added DMC resources and changed Mozilla->MDN

### DIFF
--- a/docs/home/resources.md
+++ b/docs/home/resources.md
@@ -22,10 +22,18 @@ If you want a hands-on alternative to learning about PWAs, checkout [this worksh
 
 The workshop is a guided walk through of building a sample application with the PWA Starter.
 
-## Mozzilla PWA Resources
+## Microsoft Edge PWA Resources
+
+Microsoft Edge has a lot of technical docs to learn about progressive web apps and the many features that make it easy to build apps that feel native on desktop operating systems:
+
+* [**Get started with Progressive Web Apps**](https://docs.microsoft.com/microsoft-edge/progressive-web-apps-chromium/how-to/)
+
+* [**Integrate PWAs on desktop**](https://docs.microsoft.com/microsoft-edge/progressive-web-apps-chromium/how-to/icon-theme-color)
+
+## MDN PWA Resources
 
 MDN has plenty of resources related to progressive web apps and web capabilities available:
 
-* [**Mozilla PWA Guidance Homepage**](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps)
+* [**MDN PWA Guidance Homepage**](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps)
 
 * [**MDN Web API documentation**](https://developer.mozilla.org/en-US/docs/Web/API)


### PR DESCRIPTION
## PR Type

Documentation content changes

## Summary of changes

Mozilla was misspelled in this article (Mozzilla), so I changed it, but then realized that MDN is a far more well-known term to refer to the docs than Mozilla. So I changed it to MDN.

I also realized there was no mention of our own docs here, so I added a section.