### PR TITLE
fix(mani-editor): use shoelace from npm instead of CDN

### DIFF
--- a/components/manifest-editor/package-lock.json
+++ b/components/manifest-editor/package-lock.json
@@ -13,6 +13,7 @@
         "@ionic/core": "^6.1.4",
         "@pwabuilder/manifest-previewer": "file:../manifest-previewer",
         "@pwabuilder/manifest-validation": "file:../../libraries/manifest-validation",
+        "@shoelace-style/shoelace": "^2.0.0-beta.83",
         "lit": "^2.2.1"
       },
       "devDependencies": {
@@ -87,6 +88,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.2.tgz",
+      "integrity": "sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.1"
+      }
+    },
     "node_modules/@ionic/core": {
       "version": "6.1.5",
       "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.1.5.tgz",
@@ -97,10 +111,15 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@lit-labs/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-5qQzixu/bVqI819cNgr/fY8KX0v5C3FmanMaT7Q8qzUJ+EpB4BsOSQwacdaWfNkm7SV4jkWerSHxa9hvncszCA=="
+    },
     "node_modules/@lit/reactive-element": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.2.tgz",
-      "integrity": "sha512-A2e18XzPMrIh35nhIdE4uoqRzoIpEU5vZYuQN4S3Ee1zkGdYC27DP12pewbw/RLgPHzaE4kx/YqxMzebOpm0dA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.4.1.tgz",
+      "integrity": "sha512-qDv4851VFSaBWzpS02cXHclo40jsbAjRXnebNXpm0uVg32kCneZPo9RYVQtrTNICtZ+1wAYHu1ZtxWSWMbKrBw=="
     },
     "node_modules/@pwabuilder/manifest-previewer": {
       "resolved": "../manifest-previewer",
@@ -145,6 +164,41 @@
       },
       "peerDependencies": {
         "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@shoelace-style/animations": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/animations/-/animations-1.1.0.tgz",
+      "integrity": "sha512-Be+cahtZyI2dPKRm8EZSx3YJQ+jLvEcn3xzRP7tM4tqBnvd/eW/64Xh0iOf0t2w5P8iJKfdBbpVNE9naCaOf2g==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/claviska"
+      }
+    },
+    "node_modules/@shoelace-style/localize": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.0.1.tgz",
+      "integrity": "sha512-nmv1syJ3ormbGq29GsuxGRK6BFq7Jhx+kVFyuuozz0Pckkvk1SGk2vpZZcdnj2vRZCETvlVB7KYgakUwgGmn+A=="
+    },
+    "node_modules/@shoelace-style/shoelace": {
+      "version": "2.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.0.0-beta.83.tgz",
+      "integrity": "sha512-dHVBtapuqxSRu3klBZhf9/LtEtircaLLnDajNbhuiBiY7PVCxjjf/9Kyd/S/BpbhKwMICqJr+PaKoCTd2iWDJA==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@lit-labs/react": "^1.0.7",
+        "@shoelace-style/animations": "^1.1.0",
+        "@shoelace-style/localize": "^3.0.1",
+        "color": "4.2",
+        "lit": "^2.2.8",
+        "qr-creator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14.17.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/claviska"
       }
     },
     "node_modules/@stencil/core": {
@@ -649,6 +703,18 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -661,8 +727,32 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/command-line-args": {
       "version": "5.2.1",
@@ -1712,13 +1802,13 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.4.tgz",
-      "integrity": "sha512-O7t+uizo1/Br0y+5RaWRzPkd4MsoL4XY2eq7n2wrESyCCjeagq4ERZKsyKX40jbmsz4bAAs7/0qNRX11TuXzoA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.1.tgz",
+      "integrity": "sha512-TejktDR4mqG3qB32Y8Lm5Lye3c8SUehqz7qRsxe1PqGYL6me2Ef+jeQAEqh20BnnGncv4Yxy2njEIT0kzK1WCw==",
       "dependencies": {
-        "@lit/reactive-element": "^1.3.0",
+        "@lit/reactive-element": "^1.4.0",
         "lit-element": "^3.2.0",
-        "lit-html": "^2.2.0"
+        "lit-html": "^2.3.0"
       }
     },
     "node_modules/lit-element": {
@@ -1731,9 +1821,9 @@
       }
     },
     "node_modules/lit-html": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.4.tgz",
-      "integrity": "sha512-IPY0V0z/QWcTduxb6DlP46Un8n6tG+mHSAijGcPozfXTjVkvFLN4/irPzthtq/eC8RU+7CUqh6h4KB7tnRPJfg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.3.1.tgz",
+      "integrity": "sha512-FyKH6LTW6aBdkfNhNSHyZTnLgJSTe5hMk7HFtc/+DcN1w74C215q8B+Cfxc2OuIEpBNcEKxgF64qL8as30FDHA==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -2128,6 +2218,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/qr-creator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz",
+      "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ=="
+    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -2342,6 +2437,19 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -2747,6 +2855,19 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@floating-ui/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.2.tgz",
+      "integrity": "sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==",
+      "requires": {
+        "@floating-ui/core": "^1.0.1"
+      }
+    },
     "@ionic/core": {
       "version": "6.1.5",
       "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.1.5.tgz",
@@ -2757,10 +2878,15 @@
         "tslib": "^2.1.0"
       }
     },
+    "@lit-labs/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-5qQzixu/bVqI819cNgr/fY8KX0v5C3FmanMaT7Q8qzUJ+EpB4BsOSQwacdaWfNkm7SV4jkWerSHxa9hvncszCA=="
+    },
     "@lit/reactive-element": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.2.tgz",
-      "integrity": "sha512-A2e18XzPMrIh35nhIdE4uoqRzoIpEU5vZYuQN4S3Ee1zkGdYC27DP12pewbw/RLgPHzaE4kx/YqxMzebOpm0dA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.4.1.tgz",
+      "integrity": "sha512-qDv4851VFSaBWzpS02cXHclo40jsbAjRXnebNXpm0uVg32kCneZPo9RYVQtrTNICtZ+1wAYHu1ZtxWSWMbKrBw=="
     },
     "@pwabuilder/manifest-previewer": {
       "version": "file:../manifest-previewer",
@@ -2810,6 +2936,30 @@
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
         "picomatch": "^2.2.2"
+      }
+    },
+    "@shoelace-style/animations": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/animations/-/animations-1.1.0.tgz",
+      "integrity": "sha512-Be+cahtZyI2dPKRm8EZSx3YJQ+jLvEcn3xzRP7tM4tqBnvd/eW/64Xh0iOf0t2w5P8iJKfdBbpVNE9naCaOf2g=="
+    },
+    "@shoelace-style/localize": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.0.1.tgz",
+      "integrity": "sha512-nmv1syJ3ormbGq29GsuxGRK6BFq7Jhx+kVFyuuozz0Pckkvk1SGk2vpZZcdnj2vRZCETvlVB7KYgakUwgGmn+A=="
+    },
+    "@shoelace-style/shoelace": {
+      "version": "2.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.0.0-beta.83.tgz",
+      "integrity": "sha512-dHVBtapuqxSRu3klBZhf9/LtEtircaLLnDajNbhuiBiY7PVCxjjf/9Kyd/S/BpbhKwMICqJr+PaKoCTd2iWDJA==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.0",
+        "@lit-labs/react": "^1.0.7",
+        "@shoelace-style/animations": "^1.1.0",
+        "@shoelace-style/localize": "^3.0.1",
+        "color": "4.2",
+        "lit": "^2.2.8",
+        "qr-creator": "^1.0.0"
       }
     },
     "@stencil/core": {
@@ -3231,6 +3381,30 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "requires": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3243,8 +3417,16 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "command-line-args": {
       "version": "5.2.1",
@@ -4020,13 +4202,13 @@
       }
     },
     "lit": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.4.tgz",
-      "integrity": "sha512-O7t+uizo1/Br0y+5RaWRzPkd4MsoL4XY2eq7n2wrESyCCjeagq4ERZKsyKX40jbmsz4bAAs7/0qNRX11TuXzoA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.1.tgz",
+      "integrity": "sha512-TejktDR4mqG3qB32Y8Lm5Lye3c8SUehqz7qRsxe1PqGYL6me2Ef+jeQAEqh20BnnGncv4Yxy2njEIT0kzK1WCw==",
       "requires": {
-        "@lit/reactive-element": "^1.3.0",
+        "@lit/reactive-element": "^1.4.0",
         "lit-element": "^3.2.0",
-        "lit-html": "^2.2.0"
+        "lit-html": "^2.3.0"
       }
     },
     "lit-element": {
@@ -4039,9 +4221,9 @@
       }
     },
     "lit-html": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.4.tgz",
-      "integrity": "sha512-IPY0V0z/QWcTduxb6DlP46Un8n6tG+mHSAijGcPozfXTjVkvFLN4/irPzthtq/eC8RU+7CUqh6h4KB7tnRPJfg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.3.1.tgz",
+      "integrity": "sha512-FyKH6LTW6aBdkfNhNSHyZTnLgJSTe5hMk7HFtc/+DcN1w74C215q8B+Cfxc2OuIEpBNcEKxgF64qL8as30FDHA==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -4342,6 +4524,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "qr-creator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz",
+      "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ=="
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -4492,6 +4679,21 @@
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
+      }
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
       }
     },
     "spdx-correct": {

--- a/components/manifest-editor/package.json
+++ b/components/manifest-editor/package.json
@@ -14,9 +14,10 @@
   "license": "ISC",
   "dependencies": {
     "@ionic/core": "^6.1.4",
-    "lit": "^2.2.1",
     "@pwabuilder/manifest-previewer": "file:../manifest-previewer",
-    "@pwabuilder/manifest-validation":  "file:../../libraries/manifest-validation"
+    "@pwabuilder/manifest-validation": "file:../../libraries/manifest-validation",
+    "@shoelace-style/shoelace": "^2.0.0-beta.83",
+    "lit": "^2.2.1"
   },
   "devDependencies": {
     "@web/dev-server": "^0.1.31",

--- a/components/manifest-editor/src/components/manifest-icons-form.ts
+++ b/components/manifest-editor/src/components/manifest-icons-form.ts
@@ -7,7 +7,7 @@ import {
 } from '../utils/interfaces';
 import { resolveUrl } from '../utils/urls';
 
-import 'https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.73/dist/components/checkbox/checkbox.js';
+import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';
 
 const baseUrl = 'https://appimagegenerator-prod.azurewebsites.net';
 

--- a/components/manifest-editor/src/components/pwa-manifest-editor.ts
+++ b/components/manifest-editor/src/components/pwa-manifest-editor.ts
@@ -10,7 +10,7 @@ import "./manifest-screenshots-form"
 import "./manifest-preview-form"
 import "./manifest-code-form"
 
-import 'https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.73/dist/components/tab-group/tab-group.js';
+import '@shoelace-style/shoelace/dist/components/tab-group/tab-group.js';
 import { prettyString } from '../utils/pretty-json';
 import { ManifestInfoForm } from './manifest-info-form';
 import { ManifestPlatformForm } from './manifest-platform-form';

--- a/libraries/manifest-validation/src/index.ts
+++ b/libraries/manifest-validation/src/index.ts
@@ -14,7 +14,6 @@ export async function validateManifest(manifest: Manifest): Promise<Validation[]
 
         let data = await loopThroughKeys(manifest);
 
-        console.log("data", data);
 
         if (data && data.length > 0) {
             resolve(data);

--- a/libraries/manifest-validation/src/index.ts
+++ b/libraries/manifest-validation/src/index.ts
@@ -6,7 +6,6 @@ export async function validateManifest(manifest: Manifest): Promise<Validation[]
     return new Promise(async(resolve, reject) => {
         const validJSON = isValidJSON(manifest);
 
-        console.log("manifest", manifest);
 
         if (validJSON === false) {
             reject('Manifest is not valid JSON');

--- a/libraries/manifest-validation/src/index.ts
+++ b/libraries/manifest-validation/src/index.ts
@@ -6,11 +6,15 @@ export async function validateManifest(manifest: Manifest): Promise<Validation[]
     return new Promise(async(resolve, reject) => {
         const validJSON = isValidJSON(manifest);
 
+        console.log("manifest", manifest);
+
         if (validJSON === false) {
             reject('Manifest is not valid JSON');
         }
 
         let data = await loopThroughKeys(manifest);
+
+        console.log("data", data);
 
         if (data && data.length > 0) {
             resolve(data);

--- a/libraries/manifest-validation/tsconfig.json
+++ b/libraries/manifest-validation/tsconfig.json
@@ -4,7 +4,7 @@
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
     "rootDir": "./src",
     "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
-    "removeComments": true,                           /* Disable emitting comments. */
+    "removeComments": false,                           /* Disable emitting comments. */
     "moduleResolution": "node",
     "esModuleInterop": true,
     "module": "CommonJS",

--- a/libraries/manifest-validation/tsconfig.json
+++ b/libraries/manifest-validation/tsconfig.json
@@ -4,7 +4,7 @@
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
     "rootDir": "./src",
     "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
-    "removeComments": false,                           /* Disable emitting comments. */
+    "removeComments": true,                           /* Disable emitting comments. */
     "moduleResolution": "node",
     "esModuleInterop": true,
     "module": "CommonJS",


### PR DESCRIPTION
fixes #[issue number] 
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Was having problems using the manifest-editor during the hackathon because of Webpack complaining about the CDN URLs and them using dynamic imports, which Webpack STILL has limited support for in 2022.

## Describe the new behavior?
I now import the two shoelace components we are using from the shoelace NPM package.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
