### PR TITLE
Text is too big on mobile for success cards

### DIFF
--- a/apps/pwabuilder/src/script/components/success-card.ts
+++ b/apps/pwabuilder/src/script/components/success-card.ts
@@ -82,7 +82,7 @@ export class SuccessCard extends LitElement {
           box-sizing: border-box;
         }
         .success-line-one h3 {
-          font-size: 28px;
+          font-size: 22px;
         }
       `)}
 


### PR DESCRIPTION
fixes #3335 
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->
 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Text is too big making it not fit on iphone mobile

## Describe the new behavior?
Text is smaller - should fit but needs to be merged to know

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
