### PR TITLE
Fixed test package page, fixed small padding issue and also a margin …

### DIFF
--- a/apps/pwabuilder/src/script/components/test-publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/test-publish-pane.ts
@@ -64,12 +64,12 @@ export class TestPublishPane extends LitElement {
 
       #pp-frame-wrapper {
         width: 100%;
-        height: 90vh;
+        height: fit-content;
       }
       #pp-frame-content {
         display: flex;
         flex-direction: column;
-        height: 100%;
+        height: fit-content;
       }
       #pp-frame-header {
         display: flex;
@@ -89,7 +89,7 @@ export class TestPublishPane extends LitElement {
       }
       .card-wrapper {
         width: 100%;
-        height: 50%;
+        height: fit-content;
         display: flex;
         flex-direction: column;
         box-shadow: 0px 4px 10px 4px rgba(0, 0, 0, 0.05);
@@ -149,7 +149,7 @@ export class TestPublishPane extends LitElement {
       }
       #store-cards {
         width: 100%;
-        height: 100%;
+        height: fit-content;
         display: grid;
         grid-template-columns: 1fr 1fr;
         grid-gap: .75em;

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -246,10 +246,9 @@ export class AppReport extends LitElement {
           display: -webkit-box !important;
           -webkit-line-clamp: 6;
           -webkit-box-orient: vertical;
-          margin-left: 1em;
         }
         #app-card-footer {
-          padding: .4em 1em;
+          padding: .432em 1em;
           display: flex;
           width: 100%;
           align-items: center;


### PR DESCRIPTION
- Desc in the app-card in top left had an unneeded margin, removed that
- the bottom strip of the top two cards were uneven height, fixed that
- on shorter screens, the test package screen was having the text overflow the cards so i fixed that