### PR TITLE
Bug fixes listed Below

### DIFF
--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -1159,47 +1159,48 @@ export class AppReport extends LitElement {
     this.manifestDataLoading = true;
     let details = (this.shadowRoot!.getElementById("mani-details") as any);
     details!.disabled = true;
-    let manifest = JSON.parse(sessionStorage.getItem("PWABuilderManifest")!).manifest;
+    let manifest;
 
-    this.validationResults = await validateManifest(manifest);
+    if(!this.createdManifest){
+      manifest = JSON.parse(sessionStorage.getItem("PWABuilderManifest")!).manifest;
+      this.validationResults = await validateManifest(manifest);
 
-    //  This just makes it so that the valid things are first
-    // and the invalid things show after.
-    this.validationResults.sort((a, b) => {
-      if(a.valid && !b.valid){
-        return 1;
-      } else if(b.valid && !a.valid){
-        return -1;
-      } else {
-        return a.member.localeCompare(b.member);
-      }
-    });
-    this.manifestTotalScore = this.validationResults.length;
+      //  This just makes it so that the valid things are first
+      // and the invalid things show after.
+      this.validationResults.sort((a, b) => {
+        if(a.valid && !b.valid){
+          return 1;
+        } else if(b.valid && !a.valid){
+          return -1;
+        } else {
+          return a.member.localeCompare(b.member);
+        }
+      });
+      this.manifestTotalScore = this.validationResults.length;
 
-     if(this.createdManifest){
+      this.validationResults.forEach((test: Validation) => {
+        if(test.valid){
+          this.manifestValidCounter++;
+        } else {
+          let status ="";
+          if(test.category === "required" || test.testRequired){
+            status = "red";
+            this.manifestRequiredCounter++;
+          } else if(test.category === "recommended"){
+            status = "yellow";
+            this.manifestReccCounter++;
+          } else {
+            status = "yellow";
+          }
+
+          this.todoItems.push({"card": "mani-details", "field": test.member, "displayString": test.displayString ?? "", "fix": test.errorString, "status": status});
+          
+        }
+      });
+    } else {
+      manifest = {};
       this.todoItems.push({"card": "mani-details", "field": "Open Manifest Modal", "fix": "Edit and download your created manifest (Manifest not found before detection tests timed out)", "status": "red"});
     }
-
-    this.validationResults.forEach((test: Validation) => {
-      if(test.valid){
-        this.manifestValidCounter++;
-      } else {
-        let status ="";
-        if(test.category === "required" || test.testRequired){
-          status = "red";
-          this.manifestRequiredCounter++;
-        } else if(test.category === "recommended"){
-          status = "yellow";
-          this.manifestReccCounter++;
-        } else {
-          status = "yellow";
-        }
-
-        if(!this.createdManifest){
-          this.todoItems.push({"card": "mani-details", "field": test.member, "displayString": test.displayString ?? "", "fix": test.errorString, "status": status});
-        }
-      }
-    });
 
     if(this.manifestRequiredCounter > 0){
       this.canPackageList[0] = false;
@@ -1532,20 +1533,22 @@ export class AppReport extends LitElement {
       this.thingToAdd = e.detail.displayString;
       this.showConfirmationModal = true;
       return;
+    } else if(e.detail.field === "Open Manifest Modal"){
+      let frame = this.shadowRoot!.querySelector("manifest-editor-frame");
+      (frame?.shadowRoot!.querySelector(".dialog")! as any).show();
+      return;
+    } else if(e.detail.field === "Open SW Modal"){
+      let frame = this.shadowRoot!.querySelector("sw-selector");
+      (frame?.shadowRoot!.querySelector(".dialog")! as any).show();
+      return;
     }
 
     let details = this.shadowRoot!.getElementById(e.detail.card);
 
-    //this.detailsClicked(e.detail.card)
-
     await (details as any)!.show();
 
     details!.scrollIntoView({behavior: "smooth"});
-
-    if(e.detail.field === "Open SW Modal"){
-      this.swSelectorOpen = true;
-    }
-
+    
     let itemList = this.shadowRoot!.querySelectorAll('[data-field="' + e.detail.field + '"]');
 
     // The below block is just to get the specific item to animate if a field has more than 1 test.

--- a/components/manifest-editor/src/components/manifest-info-form.ts
+++ b/components/manifest-editor/src/components/manifest-info-form.ts
@@ -255,6 +255,7 @@ export class ManifestInfoForm extends LitElement {
 
         // Validation Failed
         if(!passed){
+
           let input = this.shadowRoot!.querySelector('[data-field="' + field + '"]');
 
           // Structure of these two fields are different so they need their own logic.
@@ -284,8 +285,8 @@ export class ManifestInfoForm extends LitElement {
           } else { // All other fields
             
             // Remove old errors
-            if(this.shadowRoot!.querySelector(".error-div")){
-              let error_div = this.shadowRoot!.querySelector(".error-div");
+            if(this.shadowRoot!.querySelector(`.${field}-error-div`)){
+              let error_div = this.shadowRoot!.querySelector(`.${field}-error-div`);
               error_div!.parentElement!.removeChild(error_div!);
             }
   

--- a/components/manifest-editor/src/components/manifest-platform-form.ts
+++ b/components/manifest-editor/src/components/manifest-platform-form.ts
@@ -360,6 +360,13 @@ export class ManifestPlatformForm extends LitElement {
         }
 
         if(!passed){
+          // Remove old errors
+          if(this.shadowRoot!.querySelector(`.${field}-error-div`)){
+            let error_div = this.shadowRoot!.querySelector(`.${field}-error-div`);
+            console.log(error_div);
+            error_div!.parentElement!.removeChild(error_div!);
+          }
+
           // update error list with new errors
           if(validation.errors){
             let div = document.createElement('div');

--- a/components/manifest-editor/src/components/manifest-settings-form.ts
+++ b/components/manifest-editor/src/components/manifest-settings-form.ts
@@ -563,7 +563,7 @@ export class ManifestSettingsForm extends LitElement {
               <div class="header-left">
                 <h3>Language</h3>
                 <a
-                  href="https://developer.mozilla.org/en-US/docs/Web/Manifest/language"
+                  href="https://www.w3.org/TR/appmanifest/#lang-member"
                   target="_blank"
                   rel="noopener"
                 >


### PR DESCRIPTION
fixes 
- #3557 
- #3548 
- #3563 3563
- Duplicating error messages in ME
- Added feature to open ME or SW picker if you click the below action items
![image](https://user-images.githubusercontent.com/51131738/195370385-aae1377d-f779-49ce-89ea-97e3e20f46d3.png)

## PR Type
Bugfixes
Feature

## Describe the current behavior
- If you don't have a manifest, we create one and then score the created manifest
- MDN dropped full support for the `lang` field and removed the URL so on our site it is a dead link
- populateAppCard choses the first icon in the list of icons for app-card which sometimes is the smallest icon so it appears blurry
- After you generate a screenshot, error messages on the info tab were showing twice
- When you click those action items it just opens the details.
Respective to the fixes list.

## Describe the new behavior?
- Even if we create a manifest, we will score an empty one and still show them the created one in the ME. This will make sure that in the drop down, they have all the action items missing.
- Point to the w3 manifest lang description instead
- Preferences the 512x512 but if that doesn't exist then it just choses the largest icon since we scale down this guarantee's quality.
- Error messages show the correct amount of times
- When you click those action items it opens the ME or SW picker.
Respective to the fixes list.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
