### PR TITLE
potential fix to close button issue on ios

### DIFF
--- a/apps/pwabuilder/src/script/components/manifest-editor-frame.ts
+++ b/apps/pwabuilder/src/script/components/manifest-editor-frame.ts
@@ -155,6 +155,7 @@ export class ManifestEditorFrame extends LitElement {
         position: absolute;
         top: 5px;
         right: 5px;
+        z-index: 1000;
       }
 
       @media(max-width: 600px){  

--- a/apps/pwabuilder/src/script/components/publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/publish-pane.ts
@@ -364,6 +364,7 @@ export class PublishPane extends LitElement {
         position: absolute;
         top: 5px;
         right: 5px;
+        z-index: 1000;
       }
 
       #unsigned-tooltip{

--- a/apps/pwabuilder/src/script/components/sw-selector.ts
+++ b/apps/pwabuilder/src/script/components/sw-selector.ts
@@ -75,6 +75,7 @@ export class SWSelector extends LitElement {
         position: absolute;
         top: 5px;
         right: 5px;
+        z-index: 1000;
       }
 
       #frame-footer {


### PR DESCRIPTION
## PR Type
Bugfix

## Describe the current behavior?
You can't X out any modal on the report card page on ios

## Describe the new behavior?
I noticed it was technically a lower z-index than other things ahead of it which could contribute to why you couldn't click. This is more of an experiment just to see if it will work on ios. This change has no other visible or functional effect.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
