### PR TITLE
fix(): dont use onStartupFinished event

### DIFF
--- a/apps/pwabuilder-vscode/package.json
+++ b/apps/pwabuilder-vscode/package.json
@@ -17,7 +17,6 @@
     "Snippets"
   ],
   "activationEvents": [
-    "onStartupFinished",
     "onCommand:pwa-studio.helloWorld",
     "onCommand:pwa-studio.newPwaStarter",
     "onCommand:pwa-studio.serviceWorker",


### PR DESCRIPTION
fixes https://github.com/pwa-builder/PWABuilder/issues/3556
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
The extension would always try to activate after VSCode had finished loading, meaning it would use the CPU even if you had never used the extension.

## Describe the new behavior?
We now only activate the relevant parts of the code when they are needed, instead of trying to activate the whole extension. This could also mean that it may take just a little longer to find the manifest and service worker, but respects the user MUCH better by only doing this once they start using the extension.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
