### PR TITLE
Fixed CSS issue on report card page + more comments in code on new functions in the modals of the RC page.

### DIFF
--- a/apps/pwabuilder/src/script/components/manifest-editor-frame.ts
+++ b/apps/pwabuilder/src/script/components/manifest-editor-frame.ts
@@ -215,6 +215,7 @@ export class ManifestEditorFrame extends LitElement {
     super();
   }
 
+  // grabs the manifest, manifest url and site base url on load
   connectedCallback(): void {
     super.connectedCallback();
     this.manifest = getManifestContext().manifest;
@@ -222,6 +223,7 @@ export class ManifestEditorFrame extends LitElement {
     this.baseURL = sessionStorage.getItem("current_url")!;
   }
 
+  // downloads manifest and tells the site they need to retest to see new manifest changes
   downloadManifest(){
     let editor = (this.shadowRoot!.querySelector("pwa-manifest-editor") as any);
     editor.downloadManifest();
@@ -233,6 +235,7 @@ export class ManifestEditorFrame extends LitElement {
     this.dispatchEvent(readyForRetest);
   }
 
+  // hides modal
   async hideDialog(e: any){
     let dialog: any = this.shadowRoot!.querySelector(".dialog");
     if(e.target === dialog){

--- a/apps/pwabuilder/src/script/components/publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/publish-pane.ts
@@ -793,6 +793,9 @@ export class PublishPane extends LitElement {
     }
   }
 
+  // takes the information from the selectedStore and error and forms a card to 
+  // convey the error message to the user in a user friendly way
+  // directs users towards FAQ
   renderErrorMessage(err: any){
     let response = err.response;
     let stack_trace = `The site I was testing is: ${getURL()}\n`; // stored in copy st button
@@ -839,6 +842,7 @@ export class PublishPane extends LitElement {
     this.feedbackMessages.push(error);
   }
 
+  // renders successfully downloaded message upon successful downloads
   renderSuccessMessage(){
     this.feedbackMessages.push(html`
       <div class="feedback-holder type-success">
@@ -849,10 +853,13 @@ export class PublishPane extends LitElement {
     `);
   }
 
+  // copy string to clipboard
   copyText(text: string){
     navigator.clipboard.writeText(text);
   }
 
+  // before we downloaded the package using a service
+  // now we just do it the vanilla js way
   async downloadPackage(){
     let blob = (this.blob || this.testBlob);
     if (blob) {
@@ -873,6 +880,7 @@ export class PublishPane extends LitElement {
     }
   }
 
+  // renders the store cards with their associated factoids from this.platforms
   renderContentCards(): TemplateResult[] {
     return this.platforms.map(
       platform => html`
@@ -910,20 +918,20 @@ export class PublishPane extends LitElement {
     }
   }
 
-  
-
   handleRequestClose(e: Event) {
     if (this.preventClosing) {
       e.preventDefault();
     }
   }
 
+  // goes from form back to cards when you click the back arrow
   backToCards(){
     this.cardsOrForm = !this.cardsOrForm;
     this.feedbackMessages = [];
     recordPWABuilderProcessStep(`left_${this.selectedStore}_form`, AnalyticsBehavior.ProcessCheckpoint);
   }
 
+  // the footer of the pane that has links to packaging instructions and download button
   renderFormFooter(){
     // Special case for Android since we have to toggle some info due to the "Other Android" scenario
     if(this.selectedStore === "Android"){
@@ -976,6 +984,8 @@ export class PublishPane extends LitElement {
     `
   }
 
+  // validates packaging options and downloads package if valid
+  // reports validity if not
   submitForm(){
     let platForm = (this.shadowRoot!.getElementById("packaging-form") as AppPackageFormBase); // windows-form | android-form | ios-form | oculus-form
     let form = platForm.getForm(); // the actual form element inside the platform form.

--- a/apps/pwabuilder/src/script/components/sw-selector.ts
+++ b/apps/pwabuilder/src/script/components/sw-selector.ts
@@ -185,6 +185,7 @@ export class SWSelector extends LitElement {
     super();
   }
 
+  // hides modal
   async hideDialog(e: any){
     let dialog: any = this.shadowRoot!.querySelector(".dialog");
     if(e.target === dialog){
@@ -194,11 +195,13 @@ export class SWSelector extends LitElement {
     }
   }
 
+  // sets selected SW so we know which to download
   setSelectedSW(e: any){
     this.selectedSW = e.detail.name;
     recordPWABuilderProcessStep(`${this.selectedSW}_tab_clicked`, AnalyticsBehavior.ProcessCheckpoint)
   }
 
+  // downloads selected SW
   downloadSW(){
     let filename = "pwabuilder-sw.js";
     var element = document.createElement('a');

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -679,7 +679,7 @@ export class AppReport extends LitElement {
           row-gap: 0.5em;
           border-bottom: 1px solid #c4c4c4;
           padding: 1em;
-          min-height: 280px;
+          min-height: 318px;
           justify-content: space-between;
         }
 
@@ -737,7 +737,7 @@ export class AppReport extends LitElement {
           row-gap: .5em;
           padding: 1em;
           border-bottom: 1px solid #c4c4c4;
-          min-height: 280px;
+          min-height: 318px;
         }
         #sec-top {
           display: flex;


### PR DESCRIPTION
- When the user didn't have a SW the last two cards would become misaligned for about 100px before the snapped into a column, that is now fixed.
- Added comments to `publish-pane`, `sw-selector` and `manifest-editor-frame` on new functions that didn't exist pre redesign. Just adding clarity on future devs to come.