### PR TITLE
Mouseover behavior for Community dropdown in nav bar

### DIFF
--- a/apps/pwabuilder/src/script/components/app-header.ts
+++ b/apps/pwabuilder/src/script/components/app-header.ts
@@ -219,9 +219,15 @@ export class AppHeader extends LitElement {
   }
 
   showMenu(){
-    recordPWABuilderProcessStep(`header.community_dropdown_expanded`, AnalyticsBehavior.ProcessCheckpoint)
     let menu = this.shadowRoot!.querySelector("sl-dropdown");
-    menu!.show();
+    if(menu!.open){
+      recordPWABuilderProcessStep(`header.community_dropdown_closed`, AnalyticsBehavior.ProcessCheckpoint)
+      menu!.hide()
+    } else {
+      recordPWABuilderProcessStep(`header.community_dropdown_expanded`, AnalyticsBehavior.ProcessCheckpoint)
+      menu!.show();
+
+    }
   }
 
   render() {


### PR DESCRIPTION
fixes n/a

## PR Type
Test


## Describe the current behavior?
When you mouse over community it appears but its doesn't disappear until you click

## Describe the new behavior?
If you mouseover the community label when its open, it will now close.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
