### PR TITLE
Cookies banner fixed to bottom + Mobile size font increase

### DIFF
--- a/apps/pwabuilder/src/script/components/community-card.ts
+++ b/apps/pwabuilder/src/script/components/community-card.ts
@@ -129,7 +129,7 @@ export class CommunityCard extends LitElement {
             height: auto;
           }
           .community-card-content p {
-            font-size: .825em;
+            font-size: 14px;
           }
       `)}
 

--- a/apps/pwabuilder/src/script/components/community-card.ts
+++ b/apps/pwabuilder/src/script/components/community-card.ts
@@ -129,7 +129,7 @@ export class CommunityCard extends LitElement {
             height: auto;
           }
           .community-card-content p {
-            font-size: 14px;
+            font-size: 16px;
           }
       `)}
 

--- a/apps/pwabuilder/src/script/components/cookie-banner.ts
+++ b/apps/pwabuilder/src/script/components/cookie-banner.ts
@@ -18,6 +18,11 @@ export class CookieBanner extends LitElement {
         padding: 16px;
         font-weight: 700;
         font-size: var(--small-font-size);
+        position: fixed;
+        bottom: 0;
+        z-index: 2;
+        width: 100%;
+        box-sizing: border-box;
       }
 
       #cookie-info {
@@ -93,7 +98,7 @@ export class CookieBanner extends LitElement {
   firstUpdated() {
     // by default, non essential cookies are denied.
     const savedValue = localStorage.getItem('PWABuilderGDPR');
-
+    
     if (!savedValue) {
       this.show = true;
       localStorage.setItem('PWABuilderGDPR', JSON.stringify(false));

--- a/apps/pwabuilder/src/script/components/info-card.ts
+++ b/apps/pwabuilder/src/script/components/info-card.ts
@@ -93,8 +93,11 @@ export class Infocard extends LitElement {
             max-width: 300px;
             height: 15em;
           }
+          .card-content img {
+            width: 6em;
+          }
           .card-content p {
-            font-size: .825em;
+            font-size: 14px;
           }
           .card-content h3 {
             font-size: 20px;

--- a/apps/pwabuilder/src/script/pages/app-home.ts
+++ b/apps/pwabuilder/src/script/pages/app-home.ts
@@ -139,7 +139,7 @@ export class AppHome extends LitElement {
         .intro-grid-item p {
           margin: 0;
           color: #292C3A;
-          font-size: .75em;
+          font-size: 16px;
           width: 15em;
         }
         #input-form {
@@ -160,28 +160,25 @@ export class AppHome extends LitElement {
         }
         #input-area {
           display: grid;
-          grid-template-columns: 1fr 1fr;
+          grid-template-columns: repeat(6, 1fr);
           grid-template-rows: 1fr 1fr;
+          row-gap: 5px;
+          place-items: center;
         }
         #input-and-error {
-          grid-column: 1;
-          grid-row: 1;
+          grid-area: 1 / 1 / auto / 5;
           display: flex;
           flex-direction: column;
         }
         #start-button {
-          grid-column: 2;
-          grid-row: 1;
+          grid-area: 1 / 5 / auto / auto;
+          width: 100%;
         }
         .raise:hover:not(disabled){
           transform: scale(1.01);
         }
         .raise:focus:not(disabled) {
           transform: scale(1.01);
-        }
-        #demo {
-          grid-column: 1 / 2;
-          grid-row: 2;
         }
         #input-form sl-input {
           margin-right: 10px;
@@ -218,7 +215,6 @@ export class AppHome extends LitElement {
           color: white;
           font-size: 14px;
           height: 3em;
-          width: 25%;
           border-radius: 50px;
         }
 
@@ -234,10 +230,11 @@ export class AppHome extends LitElement {
           width: 100%;
         }
         #demo {
-          font-size: .55em;
-          margin: 0;
-          margin-top: 5px;
+          font-size: 12px;
           color: #292C3A;
+          margin: 0;
+          grid-area: 2 / 1 / auto / 2;
+          place-self: start;
         }
         #demo-action {
           margin: 0;
@@ -312,6 +309,9 @@ export class AppHome extends LitElement {
           #input-form .navigation::part(base) {
             width: 8em;
           }
+          #demo {
+            grid-area: 2 / 1 / auto / 3;
+          }
         `)}
 
         @media (min-width: 480px) and (max-width: 580px) {
@@ -323,7 +323,6 @@ export class AppHome extends LitElement {
             display: flex;
             flex-direction: column;
             align-items: flex-start;
-            row-gap: 5px;
           }
         }
 

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -1053,7 +1053,11 @@ export class AppReport extends LitElement {
             width: 100%;
           }
 
-          #app-actions button:not(#test-download) {
+          #app-actions button:not(#test-download) { /* #pfs */
+            font-size: 16px;
+          }
+
+          #app-actions .arrow_link {
             font-size: 12px;
           }
 
@@ -1090,9 +1094,16 @@ export class AppReport extends LitElement {
             width: 100%;
           }
 
+          #actions-footer p {
+            font-size: 14px;
+          }
+
           #actions-footer img {
-            height: 16px;
+            height: 18px;
             width: auto;
+          }
+          #last-edited {
+            font-size: 14px;
           }
         `)}
       `,

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -332,6 +332,10 @@ export class AppReport extends LitElement {
           font-weight: bold;
         }
 
+        #card-info p:not(#site-name) {
+          font-size: 16px;
+        }
+
         #app-card-desc {
           margin: 0;
           font-size: 14px;
@@ -1067,6 +1071,7 @@ export class AppReport extends LitElement {
 
           #package{
             width: 50%;
+            row-gap: .75em;
           }
 
           #test-download {
@@ -1104,6 +1109,12 @@ export class AppReport extends LitElement {
           }
           #last-edited {
             font-size: 14px;
+          }
+          #manifest-header, #sw-header, #sec-header {
+            padding-bottom: 2.5em;
+          }
+          #mh-actions, #sw-actions, #sec-header {
+            row-gap: 1.5em;
           }
         `)}
       `,


### PR DESCRIPTION
fixes #3606
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
Bugfix

## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Some fonts were too small on mobile sizes and the cookies banner makes putting promotional stuff at the top banner area a big stacking mess.

## Describe the new behavior?
Cookies banner floats at the bottom until interacted with
Font size increase where necessary on mobile sizes

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
