### PR TITLE
fixed background and theme color issue

### DIFF
--- a/libraries/manifest-validation/src/validations.ts
+++ b/libraries/manifest-validation/src/validations.ts
@@ -261,6 +261,7 @@ export const maniTests: Array<Validation> = [
         infoString: "The background_color member defines a placeholder background color for the application page to display before its stylesheet is loaded.",
         displayString: "Manifest has hex encoded background color",
         category: "recommended",
+        testRequired: true,
         member: "background_color",
         defaultValue: "#000000",
         docsLink:
@@ -281,6 +282,7 @@ export const maniTests: Array<Validation> = [
         infoString: "The theme_color member is a string that defines the default theme color for the application.",
         displayString: "Manifest has hex encoded theme color",
         category: "recommended",
+        testRequired: true,
         member: "theme_color",
         defaultValue: "#000000",
         docsLink:


### PR DESCRIPTION
fixes #3635

## PR Type
Bugfix

## Describe the current behavior?
We were allowing people to see the package for store button if they had non-hex encoded color strings for background and theme colors.

## Describe the new behavior?
If they choose to use those two fields, the test requires it to be hex or else they can't package.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
