### PR TITLE
Updated /imageGenerator to properly change when the inputs are changed

### DIFF
--- a/apps/pwabuilder/package.json
+++ b/apps/pwabuilder/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "A starter kit for building PWAs!",
   "main": "index.js",
+  "engines": { "node": "14.15.1" },
   "scripts": {
     "preinstall": "node ../../scripts/setupDeps.js",
     "dev": "vite --open",

--- a/apps/pwabuilder/src/script/pages/image-generator.ts
+++ b/apps/pwabuilder/src/script/pages/image-generator.ts
@@ -247,7 +247,7 @@ export class ImageGenerator extends LitElement {
 
   handlePaddingChange(event: Event) {
 
-    const input = <HTMLInputElement | HTMLSelectElement>event.target;
+    const input = <HTMLInputElement>event.target;
     let updatedValue = input.value;
     this.padding = parseFloat(updatedValue);
   }

--- a/apps/pwabuilder/src/script/pages/image-generator.ts
+++ b/apps/pwabuilder/src/script/pages/image-generator.ts
@@ -158,14 +158,14 @@ export class ImageGenerator extends LitElement {
                 <div class="padding-section">
                   <h3>${loc.padding}</h3>
                   <sl-input name="padding" type="number" max="1" min="0" step="0.1" value=${this.padding}
-                    @change=${this.handlePaddingChange} required></sl-input>
+                    @sl-change=${this.handlePaddingChange} required></sl-input>
                   <small>${loc.padding_text}</small>
                 </div>
                 <div class="color-section">
                   <h3>${loc.background_color}</h3>
                   <div class="color-radio">
                     <sl-radio-group orientation="vertical" .value=${this.colorOption}
-                      @change=${this.handleBackgroundRadioChange}>
+                      @sl-change=${this.handleBackgroundRadioChange}>
                       <sl-radio name="colorOption" value="best guess">
                         ${loc.best_guess}
                       </sl-radio>
@@ -208,7 +208,7 @@ export class ImageGenerator extends LitElement {
     return platformsData.map(
       (platform, i) => html`
         <sl-checkbox type="checkbox" name="platform" value="${platform.value}" ?checked=${this.platformSelected[i]}
-          @change=${this.handleCheckbox} data-index=${i}>
+          @sl-change=${this.handleCheckbox} data-index=${i}>
           ${platform.label}
         </sl-checkbox>
       `
@@ -246,8 +246,10 @@ export class ImageGenerator extends LitElement {
   }
 
   handlePaddingChange(event: Event) {
-    const input = event.target as HTMLInputElement;
-    this.padding = Number(input.value);
+
+    const input = <HTMLInputElement | HTMLSelectElement>event.target;
+    let updatedValue = input.value;
+    this.padding = parseFloat(updatedValue);
   }
 
   handleCheckbox(event: Event) {
@@ -298,6 +300,10 @@ export class ImageGenerator extends LitElement {
       platformsData
         .filter((_, index) => this.platformSelected[index])
         .forEach(data => form.append('platform', data.value));
+
+        for (const value of form.values()) {
+          console.log(value);
+        }
 
       const res = await fetch(`${baseUrl}/api/image`, {
         method: 'POST',

--- a/apps/pwabuilder/src/script/pages/image-generator.ts
+++ b/apps/pwabuilder/src/script/pages/image-generator.ts
@@ -246,7 +246,6 @@ export class ImageGenerator extends LitElement {
   }
 
   handlePaddingChange(event: Event) {
-
     const input = <HTMLInputElement>event.target;
     let updatedValue = input.value;
     this.padding = parseFloat(updatedValue);

--- a/apps/pwabuilder/src/script/pages/image-generator.ts
+++ b/apps/pwabuilder/src/script/pages/image-generator.ts
@@ -301,10 +301,6 @@ export class ImageGenerator extends LitElement {
         .filter((_, index) => this.platformSelected[index])
         .forEach(data => form.append('platform', data.value));
 
-        for (const value of form.values()) {
-          console.log(value);
-        }
-
       const res = await fetch(`${baseUrl}/api/image`, {
         method: 'POST',
         body: form,


### PR DESCRIPTION
fixes #3650

## PR Type
 Bugfix

## Describe the current behavior?
When we switched the page /imageGenerator to use shoelace instead of fast elements I didn't change the input events to be `@sl-change` rather than just `@change` therefore, no changes were being tracked.

## Describe the new behavior?
Changed `@change` to be `@sl-change` so that change is properly tracked on the padding input, color radio group and packaging checkboxes.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
