### PR TITLE
fixed overflow issue with error boxes

### DIFF
--- a/apps/pwabuilder/src/script/components/publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/publish-pane.ts
@@ -405,6 +405,7 @@ export class PublishPane extends LitElement {
         padding: .5em;
         border-radius: 3px;
         width: 100%;
+        word-break: break-word;
       }
 
       .type-error {
@@ -446,6 +447,12 @@ export class PublishPane extends LitElement {
       .error-actions > *:hover {
         cursor: pointer;
         border-bottom: 1px solid black;
+      }
+
+      .error-desc {
+        max-height: 175px;
+        overflow-y: auto;
+        line-height: normal;
       }
 
       .close_feedback {

--- a/apps/pwabuilder/src/script/components/test-publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/test-publish-pane.ts
@@ -237,6 +237,12 @@ export class TestPublishPane extends LitElement {
         font-size: 14px;
       }
 
+      .error-desc {
+        max-height: 175px;
+        overflow-y: auto;
+        line-height: normal;
+      }
+
       .error-title {
         font-weight: bold;
       }

--- a/apps/pwabuilder/src/script/components/test-publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/test-publish-pane.ts
@@ -218,6 +218,7 @@ export class TestPublishPane extends LitElement {
         padding: .5em;
         border-radius: 3px;
         width: 100%;
+        word-break: break-word;
       }
 
       .type-error {


### PR DESCRIPTION
There was an issue with our error boxes that would cause them to overflow in some scenarios and this PR fixes that.