### PR TITLE
Categories was missing isArray check

### DIFF
--- a/libraries/manifest-validation/src/validations.ts
+++ b/libraries/manifest-validation/src/validations.ts
@@ -421,6 +421,7 @@ export const maniTests: Array<Validation> = [
         infoString: "The categories member is an array of strings that represent the categories of the web application.",
         displayString: "Manifest has categories field",
         category: "optional",
+        testRequired: true,
         member: "categories",
         defaultValue: [],
         docsLink:

--- a/libraries/manifest-validation/src/validations.ts
+++ b/libraries/manifest-validation/src/validations.ts
@@ -427,12 +427,16 @@ export const maniTests: Array<Validation> = [
             "https://docs.pwabuilder.com/#/builder/manifest?id=categories-array",
         quickFix: true,
         test: (value: any[]) => {
-            if (value) {
-                const isGood = containsStandardCategory(value);
-                return isGood;
+            let isGood;
+            if(value){
+                containsStandardCategory(value) && Array.isArray(value) 
+                ? 
+                isGood = true 
+                : 
+                isGood = false;
             }
 
-            return false;
+            return isGood
         },
         errorString: "categories should be a non-empty array"
     },


### PR DESCRIPTION
fixes #3675

## PR Type
Bugfix


## Describe the current behavior?
Categories validation check doesn't check if the value is an array which leads to packaging errors.

## Describe the new behavior?
Categories validation check lets you know you failed if your field is not an array.

## PR Checklist
- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
