### PR TITLE
fix(validation): shortcuts are validated for minimum icon size

### DIFF
--- a/libraries/manifest-validation/src/index.ts
+++ b/libraries/manifest-validation/src/index.ts
@@ -4,10 +4,13 @@ import { findMissingKeys, isValidJSON } from "./utils/validation-utils";
 export { required_fields, reccommended_fields, optional_fields, validateSingleRelatedApp, validateSingleProtocol } from "./utils/validation-utils";
 import { maniTests, findSingleField, loopThroughKeys, loopThroughRequiredKeys } from "./validations";
 
+export let currentManifest: Manifest | undefined = undefined;
+
 export async function validateManifest(manifest: Manifest): Promise<Validation[]> {
     return new Promise(async(resolve, reject) => {
         const validJSON = isValidJSON(manifest);
 
+        currentManifest = manifest;
 
         if (validJSON === false) {
             reject('Manifest is not valid JSON');
@@ -91,6 +94,6 @@ export async function isInstallReady(manifest: Manifest): Promise<boolean> {
     const validations = await validateRequiredFields(manifest);
 
     return validations.length === 0;
-}
+}   
 
 export * from './interfaces';

--- a/libraries/manifest-validation/src/validations.ts
+++ b/libraries/manifest-validation/src/validations.ts
@@ -1,4 +1,4 @@
-import { Manifest, singleFieldValidation, Validation } from "./interfaces";
+import { Icon, Manifest, singleFieldValidation, Validation } from "./interfaces";
 import { containsStandardCategory, isAtLeast, isStandardOrientation, isValidLanguageCode } from "./utils/validation-utils";
 
 export const maniTests: Array<Validation> = [
@@ -344,6 +344,31 @@ export const maniTests: Array<Validation> = [
         quickFix: true,
         test: (value: string) =>
             value && Array.isArray(value) && value.length > 0 ? true : false,
+    },
+    {
+        infoString: "The shortcuts member defines an array of shortcuts or links to key tasks or pages within a web app. Shortcuts will show as jumplists on Windows and on the home screen on Android.",
+        displayString: "Shortcuts have atleast a 96x96 icon",
+        category: "recommended",
+        member: "shortcuts",
+        defaultValue: [],
+        docsLink:
+            "https://docs.pwabuilder.com/#/builder/manifest?id=shortcuts-array",
+        errorString: "shortcuts should have atleast one icon with a size of 96x96",
+        quickFix: false,
+        test: (value: any[]) => {
+            const isArray = value && Array.isArray(value);
+            if (isArray === true) {
+                const has96x96Icon = value.some((shortcut) => {
+                    return shortcut.icons.some((icon: Icon) => {
+                        return icon.sizes === "96x96";
+                    });
+                });
+                return has96x96Icon;
+            }
+            else {
+                return false;
+            }
+        }
     },
     {
         infoString: "The shortcuts member defines an array of shortcuts or links to key tasks or pages within a web app. Shortcuts will show as jumplists on Windows and on the home screen on Android.",

--- a/libraries/manifest-validation/src/validations.ts
+++ b/libraries/manifest-validation/src/validations.ts
@@ -1,3 +1,4 @@
+import { currentManifest } from ".";
 import { Icon, Manifest, singleFieldValidation, Validation } from "./interfaces";
 import { containsStandardCategory, isAtLeast, isStandardOrientation, isValidLanguageCode } from "./utils/validation-utils";
 
@@ -27,7 +28,7 @@ export const maniTests: Array<Validation> = [
                 "title": "title",
                 "text": "text",
                 "url": "url"
-              }
+            }
         }),
         docsLink: "https://web.dev/web-share-target/",
         errorString: "share_target must be an object",
@@ -88,7 +89,7 @@ export const maniTests: Array<Validation> = [
         quickFix: true,
         test: (value: any[]) => {
             const isArray = value && Array.isArray(value) && value.length > 0 ? true : false;
-            
+
             if (isArray) {
                 const anyIcon = value.find(icon => icon.purpose === "any");
 
@@ -123,7 +124,7 @@ export const maniTests: Array<Validation> = [
         quickFix: false,
         test: (value: any[]) => {
             const isArray = value && Array.isArray(value) && value.length > 0 ? true : false;
-            
+
             if (isArray) {
                 const anyIcon = value.find(icon => isAtLeast(icon.sizes, 512, 512) && (icon.type === 'image/png' || icon.src.endsWith(".png")));
 
@@ -158,7 +159,7 @@ export const maniTests: Array<Validation> = [
         quickFix: true,
         test: (value: any[]) => {
             const isArray = value && Array.isArray(value) && value.length > 0 ? true : false;
-            
+
             if (isArray) {
                 const wrongIcon = value.find(icon => icon.purpose === "any maskable");
 
@@ -209,8 +210,8 @@ export const maniTests: Array<Validation> = [
         errorString: "short_name is required and must be a string with a length >= 2",
         quickFix: true,
         test: (value: string) => {
-          const existsAndLength = value && value.length >= 2;
-          return existsAndLength;
+            const existsAndLength = value && value.length >= 2;
+            return existsAndLength;
         },
     },
     {
@@ -241,6 +242,28 @@ export const maniTests: Array<Validation> = [
         quickFix: true,
         test: (value: string) =>
             value && typeof value === "string" && value.length > 0
+    },
+    {
+        infoString: "The start_url member is a string that represents the start URL of the web application — the preferred URL that should be loaded when the user launches the web application",
+        displayString: "start_url is relative to the scope of the app",
+        category: "required",
+        member: "start_url",
+        defaultValue: "/",
+        docsLink:
+            "https://docs.pwabuilder.com/#/builder/manifest?id=start_url-string",
+        errorString: "start_url must be relative to the scope",
+        quickFix: false,
+        test: (value: string) => {
+            const currentMani = currentManifest;
+            if (currentMani && currentMani.scope) {
+                const relativeCheck = checkRelativeUrl(value, currentMani.scope);
+                console.log("relativeCheck", relativeCheck);
+                return relativeCheck;
+            }
+            else {
+                return false;
+            }
+        }
     },
     {
         infoString: "The display member is a string that determines the developers' preferred display mode for the website. The display mode changes how much of browser UI is shown to the user and can range from browser (when the full browser window is shown) to fullscreen (when the app is fullscreened).",
@@ -436,9 +459,9 @@ export const maniTests: Array<Validation> = [
         defaultValue: false,
         docsLink:
             "https://docs.pwabuilder.com/#/builder/manifest?id=prefer_related_applications-boolean",
-        quickFix: false, // @ Justin Willis, I added this but left it false because idk how to do quick fixes lol.
+        quickFix: false,
         test: (value: any) => {
-            return typeof(value)  === "boolean"
+            return typeof (value) === "boolean"
         },
         errorString: "prefer_related_applications should be set to a boolean value",
     },
@@ -454,12 +477,12 @@ export const maniTests: Array<Validation> = [
         quickFix: true,
         test: (value: any[]) => {
             let isGood;
-            if(value){
-                containsStandardCategory(value) && Array.isArray(value) 
-                ? 
-                isGood = true 
-                : 
-                isGood = false;
+            if (value) {
+                containsStandardCategory(value) && Array.isArray(value)
+                    ?
+                    isGood = true
+                    :
+                    isGood = false;
             }
 
             return isGood
@@ -477,7 +500,7 @@ export const maniTests: Array<Validation> = [
         errorString: "lang should be set to a valid language code",
         quickFix: true,
         test: (value: string) =>
-                value && typeof value === "string" && value.length > 0 && isValidLanguageCode(value)
+            value && typeof value === "string" && value.length > 0 && isValidLanguageCode(value)
     },
     {
         member: "dir",
@@ -490,7 +513,7 @@ export const maniTests: Array<Validation> = [
             "https://docs.pwabuilder.com/#/builder/manifest?id=dir-string",
         quickFix: true,
         test: (value: string) =>
-                value && typeof value === "string" && value.length > 0 && (value === "ltr" || value === "rtl" || value === "auto")
+            value && typeof value === "string" && value.length > 0 && (value === "ltr" || value === "rtl" || value === "auto")
     },
     {
         member: "description",
@@ -583,88 +606,100 @@ export const maniTests: Array<Validation> = [
 export async function loopThroughKeys(manifest: Manifest): Promise<Array<Validation>> {
     return new Promise((resolve) => {
         let data: Array<Validation> = [];
-  
+
         const keys = Object.keys(manifest);
-  
+
         keys.forEach((key) => {
             maniTests.forEach(async (test) => {
                 if (test.member === key && test.test) {
                     const testResult = await test.test(manifest[key]);
-  
-    
-                    if(testResult){
-                      test.valid = true;
-                      data.push(test);
+
+
+                    if (testResult) {
+                        test.valid = true;
+                        data.push(test);
                     }
                     else {
-                      test.valid = false;
-                      data.push(test);
+                        test.valid = false;
+                        data.push(test);
                     }
                 }
             })
         })
-  
+
         resolve(data);
     })
-  }
-  
-  export async function loopThroughRequiredKeys(manifest: Manifest): Promise<Array<Validation>> {
+}
+
+export async function loopThroughRequiredKeys(manifest: Manifest): Promise<Array<Validation>> {
     return new Promise((resolve) => {
-      let data: Array<Validation> = [];
-  
-      const keys = Object.keys(manifest);
-  
-      keys.forEach((key) => {
-        maniTests.forEach(async (test) => {
-          if (test.category === "required") {
-            if (test.member === key && test.test) {
-              const testResult = await test.test(manifest[key]);
-  
-              if (testResult === false) {
-                test.valid = false;
-                data.push(test);
-              }
-              else {
-                test.valid = true;
-                data.push(test);
-              }
-            }
-          }
+        let data: Array<Validation> = [];
+
+        const keys = Object.keys(manifest);
+
+        keys.forEach((key) => {
+            maniTests.forEach(async (test) => {
+                if (test.category === "required") {
+                    if (test.member === key && test.test) {
+                        const testResult = await test.test(manifest[key]);
+
+                        if (testResult === false) {
+                            test.valid = false;
+                            data.push(test);
+                        }
+                        else {
+                            test.valid = true;
+                            data.push(test);
+                        }
+                    }
+                }
+            })
         })
-      })
-  
-      resolve(data);
+
+        resolve(data);
     })
-  }
-  
-  export async function findSingleField(field: string, value: any): Promise<singleFieldValidation> {
+}
+
+export async function findSingleField(field: string, value: any): Promise<singleFieldValidation> {
     return new Promise(async (resolve) => {
-  
-      // For && operations, true is the base.
-      let singleField = true;
-      let failedTests: string[] | undefined = [];
-  
-      maniTests.forEach((test) => {
-        if (test.member === field && test.test) {
-        
-          const testResult = test.test(value);
-  
-          if(!testResult){
-            failedTests!.push(test.errorString!);
-          }
-  
-          // If the test passes true && true = true.
-          // If the test fails true && false = false
-          // If a field has MULTIPLE tests, they will stack
-          // ie: true (base) && true (test 1) && false (ie test 2 fails).
-          singleField = singleField && testResult;
+
+        // For && operations, true is the base.
+        let singleField = true;
+        let failedTests: string[] | undefined = [];
+
+        maniTests.forEach((test) => {
+            if (test.member === field && test.test) {
+
+                const testResult = test.test(value);
+
+                if (!testResult) {
+                    failedTests!.push(test.errorString!);
+                }
+
+                // If the test passes true && true = true.
+                // If the test fails true && false = false
+                // If a field has MULTIPLE tests, they will stack
+                // ie: true (base) && true (test 1) && false (ie test 2 fails).
+                singleField = singleField && testResult;
+            }
+        });
+
+        if (singleField) {
+            resolve({ "valid": singleField })
         }
-      });
-  
-      if(singleField){
-        resolve({"valid": singleField})
-      }
-  
-      resolve({"valid": singleField, "errors": failedTests});
+
+        resolve({ "valid": singleField, "errors": failedTests });
     })
-  }
+}
+
+export function checkRelativeUrl(url: string, scope: string): boolean {
+    if (scope.endsWith("/")) {
+        return true;
+    }
+    else if (url.startsWith(scope)) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}

--- a/libraries/manifest-validation/test/validation-tests.js
+++ b/libraries/manifest-validation/test/validation-tests.js
@@ -89,7 +89,7 @@ test('includes missing fields', async () => {
 test('returns correct number of fields', async () => {
   const data = await maniLib.validateManifest(test_manifest);
 
-  assert.equal(data.length, 23);
+  assert.equal(data.length, 24);
 });
 
 /*
@@ -142,6 +142,13 @@ test('Can validate the inner structure of shortcuts, should fail', async () => {
   ]);
 
   assert.equal(validity.valid, false);
+});
+
+test('start_url is within app scope, should pass', async () => {
+  const validity = await maniLib.validateSingleField("start_url", "/app");
+  console.log("validity", validity);
+
+  assert.equal(validity.valid, true);
 });
 
 /*

--- a/libraries/manifest-validation/test/validation-tests.js
+++ b/libraries/manifest-validation/test/validation-tests.js
@@ -40,7 +40,7 @@ const test_manifest = {
       "short_name": "Start Live",
       "description": "Jump direction into starting or joining a live session",
       "url": "/?startLive",
-      "icons": [{ "src": "icons/android/maskable_icon_192.png", "sizes": "192x192" }]
+      "icons": [{ "src": "icons/android/maskable_icon_96.png", "sizes": "96x96" }]
     }
   ],
   "icons": [
@@ -89,7 +89,7 @@ test('includes missing fields', async () => {
 test('returns correct number of fields', async () => {
   const data = await maniLib.validateManifest(test_manifest);
 
-  assert.equal(data.length, 22);
+  assert.equal(data.length, 23);
 });
 
 /*
@@ -113,10 +113,35 @@ test('can validate a single field, should return true', async () => {
 
 test('can validate a single field, should return false', async () => {
   const validity = await maniLib.validateSingleField("theme_color", "black");
-  
+
   assert.equal(validity.valid, false);
   assert.equal(validity.errors[0], 'theme_color should be a valid hex color');
   assert.equal(1, validity.errors.length);
+});
+
+/*
+  * inner validation testing
+*/
+
+test('Can validate the inner structure of shortcuts', async () => {
+  const validity = await maniLib.validateSingleField("shortcuts", test_manifest.shortcuts);
+
+  assert.equal(validity.valid, true);
+});
+
+// should fail because of missing 96x96 icon
+test('Can validate the inner structure of shortcuts, should fail', async () => {
+  const validity = await maniLib.validateSingleField("shortcuts", [
+    {
+      "name": "Start Live Session",
+      "short_name": "Start Live",
+      "description": "Jump direction into starting or joining a live session",
+      "url": "/?startLive",
+      "icons": [{ "src": "icons/android/maskable_icon_192.png", "sizes": "192x192" }]
+    }
+  ]);
+
+  assert.equal(validity.valid, false);
 });
 
 /*

--- a/libraries/manifest-validation/test/validation-tests.js
+++ b/libraries/manifest-validation/test/validation-tests.js
@@ -89,7 +89,7 @@ test('includes missing fields', async () => {
 test('returns correct number of fields', async () => {
   const data = await maniLib.validateManifest(test_manifest);
 
-  assert.equal(data.length, 19);
+  assert.equal(data.length, 22);
 });
 
 /*
@@ -108,14 +108,15 @@ test('can validate a single field, should return true', async () => {
   const validity = await maniLib.validateSingleField("short_name", "Webboard");
 
   // validity should be a boolean, and true in this case
-  assert.strictEqual(validity, true);
+  assert.equal(validity.valid, true);
 });
 
 test('can validate a single field, should return false', async () => {
   const validity = await maniLib.validateSingleField("theme_color", "black");
-
-  // validity should return a Validation, and we check that its the right validation
-  assert.strictEqual(validity, false);
+  
+  assert.equal(validity.valid, false);
+  assert.equal(validity.errors[0], 'theme_color should be a valid hex color');
+  assert.equal(1, validity.errors.length);
 });
 
 /*


### PR DESCRIPTION
fixes part of https://github.com/pwa-builder/PWABuilder/issues/3417

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Shortcut icons were not validated for size

## Describe the new behavior?
Shortcut icons are now validated to have atleast one 96x96 icon.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
