### PR TITLE
feat(studio): use vscode telemetry module

### DIFF
--- a/apps/pwabuilder-vscode/package-lock.json
+++ b/apps/pwabuilder-vscode/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "pwa-studio",
-  "version": "1.0.5",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pwa-studio",
-      "version": "1.0.5",
+      "version": "1.2.2",
       "dependencies": {
+        "@vscode/extension-telemetry": "^0.7.3-preview",
         "@vscode/webview-ui-toolkit": "^0.9.0",
         "applicationinsights": "^2.3.3",
         "dotenv": "^16.0.1",
@@ -38,7 +39,7 @@
         "typescript": "^4.4.4"
       },
       "engines": {
-        "vscode": "^1.62.0"
+        "vscode": "^1.63.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -3264,6 +3265,95 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/@microsoft/1ds-core-js": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.8.tgz",
+      "integrity": "sha512-9o9SUAamJiTXIYwpkQDuueYt83uZfXp8zp8YFix1IwVPwC9RmE36T2CX9gXOeq1nDckOuOduYpA8qHvdh5BGfQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "2.8.9",
+        "@microsoft/applicationinsights-shims": "^2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      }
+    },
+    "node_modules/@microsoft/1ds-post-js": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.8.tgz",
+      "integrity": "sha512-SjlRoNcXcXBH6WQD/5SkkaCHIVqldH3gDu+bI7YagrOVJ5APxwT1Duw9gm3L1FjFa9S2i81fvJ3EVSKpp9wULA==",
+      "dependencies": {
+        "@microsoft/1ds-core-js": "3.2.8",
+        "@microsoft/applicationinsights-shims": "^2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.8.9.tgz",
+      "integrity": "sha512-fMBsAEB7pWtPn43y72q9Xy5E5y55r6gMuDQqRRccccVoQDPXyS57VCj5IdATblctru0C6A8XpL2vRyNmEsu0Vg==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "2.8.9",
+        "@microsoft/applicationinsights-core-js": "2.8.9",
+        "@microsoft/applicationinsights-shims": "2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.8.9.tgz",
+      "integrity": "sha512-mObn1moElyxZaGIRF/IU3cOaeKMgxghXnYEoHNUCA2e+rNwBIgxjyKkblFIpmGuHf4X7Oz3o3yBWpaC6AoMpig==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "2.8.9",
+        "@microsoft/applicationinsights-shims": "2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.9.tgz",
+      "integrity": "sha512-HRuIuZ6aOWezcg/G5VyFDDWGL8hDNe/ljPP01J7ImH2kRPEgbtcfPSUMjkamGMefgdq81GZsSoC/NNGTP4pp2w==",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-shims": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.2.tgz",
+      "integrity": "sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg=="
+    },
+    "node_modules/@microsoft/applicationinsights-web-basic": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-2.8.9.tgz",
+      "integrity": "sha512-CH0J8JFOy7MjK8JO4pXXU+EML+Ilix+94PMZTX5EJlBU1in+mrik74/8qSg3UC4ekPi12KwrXaHCQSVC3WseXQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-channel-js": "2.8.9",
+        "@microsoft/applicationinsights-common": "2.8.9",
+        "@microsoft/applicationinsights-core-js": "2.8.9",
+        "@microsoft/applicationinsights-shims": "2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web-snippet": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
+      "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.7.tgz",
+      "integrity": "sha512-SK3D3aVt+5vOOccKPnGaJWB5gQ8FuKfjboUJHedMP7gu54HqSCXX5iFXhktGD8nfJb0Go30eDvs/UDoTnR2kOA=="
+    },
     "node_modules/@microsoft/fast-element": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.7.0.tgz",
@@ -3900,6 +3990,20 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "node_modules/@vscode/extension-telemetry": {
+      "version": "0.7.3-preview",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.7.3-preview.tgz",
+      "integrity": "sha512-V+TanZXj8jhCX8mwGHbRDOTJ5YSWCmngHKs7ZrRoR7sXc4vZYQX+1syp07hDX2BVnPpuBHJiovZ8GZ4zbmQvYw==",
+      "dependencies": {
+        "@microsoft/1ds-core-js": "^3.2.8",
+        "@microsoft/1ds-post-js": "^3.2.8",
+        "@microsoft/applicationinsights-web-basic": "^2.8.9",
+        "applicationinsights": "2.3.6"
+      },
+      "engines": {
+        "vscode": "^1.74.0"
+      }
+    },
     "node_modules/@vscode/test-electron": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
@@ -4159,11 +4263,12 @@
       }
     },
     "node_modules/applicationinsights": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.3.3.tgz",
-      "integrity": "sha512-Q4o6gexNhzukgmzzWYzXLa2gdJ6DhM+c35tw0lRNNjc/qldWxGHVxV65DMRYrQIp4vetLdCK7Pyd/dmEsGO4qA==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.3.6.tgz",
+      "integrity": "sha512-ZzXXpZpDRGcy6Pp5V319nDF9/+Ey7jNknEXZyaBajtC5onN0dcBem6ng5jcb3MPH2AjYWRI8XgyNEuzP/6Y5/A==",
       "dependencies": {
         "@azure/core-http": "^2.2.3",
+        "@microsoft/applicationinsights-web-snippet": "^1.0.1",
         "@opentelemetry/api": "^1.0.4",
         "@opentelemetry/core": "^1.0.1",
         "@opentelemetry/sdk-trace-base": "^1.0.1",
@@ -15549,6 +15654,83 @@
       "dev": true,
       "optional": true
     },
+    "@microsoft/1ds-core-js": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.8.tgz",
+      "integrity": "sha512-9o9SUAamJiTXIYwpkQDuueYt83uZfXp8zp8YFix1IwVPwC9RmE36T2CX9gXOeq1nDckOuOduYpA8qHvdh5BGfQ==",
+      "requires": {
+        "@microsoft/applicationinsights-core-js": "2.8.9",
+        "@microsoft/applicationinsights-shims": "^2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      }
+    },
+    "@microsoft/1ds-post-js": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.8.tgz",
+      "integrity": "sha512-SjlRoNcXcXBH6WQD/5SkkaCHIVqldH3gDu+bI7YagrOVJ5APxwT1Duw9gm3L1FjFa9S2i81fvJ3EVSKpp9wULA==",
+      "requires": {
+        "@microsoft/1ds-core-js": "3.2.8",
+        "@microsoft/applicationinsights-shims": "^2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      }
+    },
+    "@microsoft/applicationinsights-channel-js": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.8.9.tgz",
+      "integrity": "sha512-fMBsAEB7pWtPn43y72q9Xy5E5y55r6gMuDQqRRccccVoQDPXyS57VCj5IdATblctru0C6A8XpL2vRyNmEsu0Vg==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.8.9",
+        "@microsoft/applicationinsights-core-js": "2.8.9",
+        "@microsoft/applicationinsights-shims": "2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      }
+    },
+    "@microsoft/applicationinsights-common": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.8.9.tgz",
+      "integrity": "sha512-mObn1moElyxZaGIRF/IU3cOaeKMgxghXnYEoHNUCA2e+rNwBIgxjyKkblFIpmGuHf4X7Oz3o3yBWpaC6AoMpig==",
+      "requires": {
+        "@microsoft/applicationinsights-core-js": "2.8.9",
+        "@microsoft/applicationinsights-shims": "2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      }
+    },
+    "@microsoft/applicationinsights-core-js": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.9.tgz",
+      "integrity": "sha512-HRuIuZ6aOWezcg/G5VyFDDWGL8hDNe/ljPP01J7ImH2kRPEgbtcfPSUMjkamGMefgdq81GZsSoC/NNGTP4pp2w==",
+      "requires": {
+        "@microsoft/applicationinsights-shims": "2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      }
+    },
+    "@microsoft/applicationinsights-shims": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.2.tgz",
+      "integrity": "sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg=="
+    },
+    "@microsoft/applicationinsights-web-basic": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-2.8.9.tgz",
+      "integrity": "sha512-CH0J8JFOy7MjK8JO4pXXU+EML+Ilix+94PMZTX5EJlBU1in+mrik74/8qSg3UC4ekPi12KwrXaHCQSVC3WseXQ==",
+      "requires": {
+        "@microsoft/applicationinsights-channel-js": "2.8.9",
+        "@microsoft/applicationinsights-common": "2.8.9",
+        "@microsoft/applicationinsights-core-js": "2.8.9",
+        "@microsoft/applicationinsights-shims": "2.0.2",
+        "@microsoft/dynamicproto-js": "^1.1.7"
+      }
+    },
+    "@microsoft/applicationinsights-web-snippet": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
+      "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
+    },
+    "@microsoft/dynamicproto-js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.7.tgz",
+      "integrity": "sha512-SK3D3aVt+5vOOccKPnGaJWB5gQ8FuKfjboUJHedMP7gu54HqSCXX5iFXhktGD8nfJb0Go30eDvs/UDoTnR2kOA=="
+    },
     "@microsoft/fast-element": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.7.0.tgz",
@@ -16024,6 +16206,17 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@vscode/extension-telemetry": {
+      "version": "0.7.3-preview",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.7.3-preview.tgz",
+      "integrity": "sha512-V+TanZXj8jhCX8mwGHbRDOTJ5YSWCmngHKs7ZrRoR7sXc4vZYQX+1syp07hDX2BVnPpuBHJiovZ8GZ4zbmQvYw==",
+      "requires": {
+        "@microsoft/1ds-core-js": "^3.2.8",
+        "@microsoft/1ds-post-js": "^3.2.8",
+        "@microsoft/applicationinsights-web-basic": "^2.8.9",
+        "applicationinsights": "2.3.6"
+      }
+    },
     "@vscode/test-electron": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
@@ -16221,11 +16414,12 @@
       }
     },
     "applicationinsights": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.3.3.tgz",
-      "integrity": "sha512-Q4o6gexNhzukgmzzWYzXLa2gdJ6DhM+c35tw0lRNNjc/qldWxGHVxV65DMRYrQIp4vetLdCK7Pyd/dmEsGO4qA==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.3.6.tgz",
+      "integrity": "sha512-ZzXXpZpDRGcy6Pp5V319nDF9/+Ey7jNknEXZyaBajtC5onN0dcBem6ng5jcb3MPH2AjYWRI8XgyNEuzP/6Y5/A==",
       "requires": {
         "@azure/core-http": "^2.2.3",
+        "@microsoft/applicationinsights-web-snippet": "^1.0.1",
         "@opentelemetry/api": "^1.0.4",
         "@opentelemetry/core": "^1.0.1",
         "@opentelemetry/sdk-trace-base": "^1.0.1",

--- a/apps/pwabuilder-vscode/package.json
+++ b/apps/pwabuilder-vscode/package.json
@@ -354,6 +354,7 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
+    "@vscode/extension-telemetry": "^0.7.3-preview",
     "@vscode/webview-ui-toolkit": "^0.9.0",
     "applicationinsights": "^2.3.3",
     "dotenv": "^16.0.1",

--- a/apps/pwabuilder-vscode/src/extension.ts
+++ b/apps/pwabuilder-vscode/src/extension.ts
@@ -60,7 +60,11 @@ export let storageManager: LocalStorageService | undefined = undefined;
 export function activate(context: vscode.ExtensionContext) {
   storageManager = new LocalStorageService(context.workspaceState);
 
-  initAnalytics();
+  const telemReporter = initAnalytics();
+
+  if (telemReporter) {
+    context.subscriptions.push(telemReporter);
+  }
 
   const packageStatusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,

--- a/apps/pwabuilder-vscode/src/services/dashboard/dev-dashboard.ts
+++ b/apps/pwabuilder-vscode/src/services/dashboard/dev-dashboard.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { trackException } from "../usage-analytics";
 
 export let scriptsObject: any = {};
 
@@ -71,7 +72,8 @@ export function findPackageJSON(): Promise<vscode.Uri> {
             } else {
                 reject("No package.json found");
             }
-        } catch (err) {
+        } catch (err: any) {
+            trackException(err);
             reject(`Error finding package.json: ${err}`);
         }
     });
@@ -92,7 +94,8 @@ export function findScripts(packageJSON: vscode.Uri) {
             } else {
                 reject("No scripts found in package.json");
             }
-        } catch (err) {
+        } catch (err: any) {
+            trackException(err);
             reject(`Error finding scripts in package.json: ${err}`);
         }
     });

--- a/apps/pwabuilder-vscode/src/services/manifest/assets-service.ts
+++ b/apps/pwabuilder-vscode/src/services/manifest/assets-service.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 const fetch = require('node-fetch');
 import { writeFile } from 'fs/promises';
 import { Manifest } from '../../interfaces';
-import { trackEvent } from "../usage-analytics";
+import { trackEvent, trackException } from "../usage-analytics";
 import { findManifest } from './manifest-service';
 
 const pwaAssetGenerator = require('pwa-asset-generator');
@@ -79,8 +79,9 @@ export async function generateScreenshots(skipPrompts?: boolean) {
 
                     resolve(manifestFile);
 
-                } catch (err) {
+                } catch (err: any) {
                     console.error("error", err);
+                    trackException(err);
                     progress.report({ message: `Screenshots could not be generated: ${err}` });
                     reject(err);
                 }
@@ -91,7 +92,7 @@ export async function generateScreenshots(skipPrompts?: boolean) {
 export async function generateIcons(options: any = {}, skipPrompts?: boolean) {
     return new Promise(async (resolve, reject) => {
         try {
-            trackEvent("generate", { type: "icons" });
+            trackEvent("generate", { "type": "icons" });
 
             let iconFile: vscode.Uri[] | undefined;
 
@@ -185,10 +186,12 @@ export async function generateIcons(options: any = {}, skipPrompts?: boolean) {
             });
 
         }
-        catch (err) {
+        catch (err: any) {
             vscode.window.showErrorMessage(
                 `There was an error generaring icons: ${err}`
             );
+
+            trackException(err);
 
             reject(err);
         }

--- a/apps/pwabuilder-vscode/src/services/manifest/manifest-service.ts
+++ b/apps/pwabuilder-vscode/src/services/manifest/manifest-service.ts
@@ -1,16 +1,12 @@
 import { open } from "fs/promises";
 import { resolve } from "path";
 import * as vscode from "vscode";
-import { getAnalyticsClient } from "../usage-analytics";
+import { trackEvent } from "../usage-analytics";
 
 let manifest: any | undefined;
 
 export async function generateManifest(skipPrompts?: boolean) {
-  const analyticsClient = getAnalyticsClient();
-  analyticsClient.trackEvent({
-    name: "generate",
-    properties: { type: "manifest" }
-  });
+  trackEvent("generate", { "type": "manifest" })
 
   // open information message about generating manifest
   // with an ok button

--- a/apps/pwabuilder-vscode/src/services/new-pwa-starter.ts
+++ b/apps/pwabuilder-vscode/src/services/new-pwa-starter.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { getAnalyticsClient } from "./usage-analytics";
+import { trackEvent } from "./usage-analytics";
 const shell = require("shelljs");
 
 const repositoryInputPrompt: string =
@@ -24,11 +24,7 @@ const gitFileWatcher = vscode.workspace.createFileSystemWatcher(
 );
 
 export async function setUpLocalPwaStarterRepository(): Promise<void> {
-  const analyticsClient = getAnalyticsClient();
-  analyticsClient.trackEvent({ 
-    name: "generate",  
-    properties: { type: "starter"} 
-  });
+  trackEvent("generate", { "type": "starter"});
 
   return new Promise(async (resolve, reject) => {
     await getRepositoryInfoFromInput();

--- a/apps/pwabuilder-vscode/src/services/package/package-android-app.ts
+++ b/apps/pwabuilder-vscode/src/services/package/package-android-app.ts
@@ -6,18 +6,14 @@ import {
   AndroidSigningOptions,
 } from "../../android-interfaces";
 import { getURL } from "../web-publish";
-import { getAnalyticsClient } from "../usage-analytics";
+import { trackEvent, trackException } from "../usage-analytics";
 
 export async function packageForAndroid(options: any): Promise<any> {
   const responseData = await buildAndroidPackage(options);
 
   if (responseData) {
     const appUrl = getURL();
-    const analyticsClient = getAnalyticsClient();
-    analyticsClient.trackEvent({ 
-      name: "package",  
-      properties: { packageType: "Android", url: appUrl, stage: "complete" } 
-    });
+    trackEvent("package", { "packageType": "Android", "url": appUrl, "stage": "complete" })
 
     return await responseData.blob();
   }
@@ -338,7 +334,8 @@ export function validateUrl(url: string, base?: string): string | null {
   try {
     new URL(url, base);
     return null;
-  } catch (urlError) {
+  } catch (urlError: any) {
+    trackException(urlError);
     return `${urlError}`;
   }
 }

--- a/apps/pwabuilder-vscode/src/services/service-workers/adv-service-worker.ts
+++ b/apps/pwabuilder-vscode/src/services/service-workers/adv-service-worker.ts
@@ -3,8 +3,8 @@ import * as vscode from "vscode";
 import { injectManifest } from "workbox-build";
 import { isNpmInstalled, noNpmInstalledWarning } from "../new-pwa-starter";
 
-import { getAnalyticsClient } from "../usage-analytics";
 import { findWorker, handleAddingToIndex } from "./service-worker";
+import { trackEvent, trackException } from "../usage-analytics";
 
 const vsTerminal = vscode.window.createTerminal();
 
@@ -51,7 +51,8 @@ export async function updateAdvServiceWorker(): Promise<void> {
                     swDest,
                     globDirectory: buildDir[0].fsPath,
                 });
-            } catch (err) {
+            } catch (err: any) {
+                trackException(err);
                 await Promise.reject(err);
             }
         } else {
@@ -113,27 +114,26 @@ export async function handleAdvServiceWorkerCommand(): Promise<void> {
                     swDest,
                     globDirectory: buildDir[0].fsPath,
                 });
-            } catch (err) {
+            } catch (err: any) {
+                trackException(err);
                 console.error("error", err);
             }
 
             vscode.window.showInformationMessage(
                 "Your Service Worker will now precache your assets. Remember to tap the `Update Precache Manifest` button when you do a new build of your PWA"
             );
-        } catch (err) {
+        } catch (err: any) {
             await vscode.window.showErrorMessage(
                 `Error writing file to your PWA: ${err}`
             );
+
+            trackException(err);
         }
     }
 }
 
 export async function handleServiceWorkerCommandAdv(): Promise<void> {
-    const analyticsClient = getAnalyticsClient();
-    analyticsClient.trackEvent({
-        name: "generate",
-        properties: { type: "service-worker" }
-    });
+    trackEvent("generate", { "type": "service-worker" });
 
     //setup file watcher for workbox config file
     const watcher = vscode.workspace.createFileSystemWatcher(
@@ -200,7 +200,8 @@ async function runWorkboxTool(): Promise<void> {
             } else {
                 noNpmInstalledWarning();
             }
-        } catch (err) {
+        } catch (err: any) {
+            trackException(err);
             reject(err);
         }
     });

--- a/apps/pwabuilder-vscode/src/services/service-workers/service-worker.ts
+++ b/apps/pwabuilder-vscode/src/services/service-workers/service-worker.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { handleServiceWorkerCommandAdv } from './adv-service-worker';
 import { handleServiceWorkerCommand } from './simple-service-worker';
+import { trackException } from '../usage-analytics';
 
 export async function handleSW() {
     const answer = await vscode.window.showQuickPick(
@@ -69,7 +70,8 @@ export async function findWorker(): Promise<any | undefined> {
                 // await vscode.commands.executeCommand("pwa-studio.refreshPackageView");
                 resolve(undefined);
             }
-        } catch (err) {
+        } catch (err: any) {
+            trackException(err);
             reject(`Error adding service worker to index file: ${err}`);
         }
     });

--- a/apps/pwabuilder-vscode/src/services/service-workers/simple-service-worker.ts
+++ b/apps/pwabuilder-vscode/src/services/service-workers/simple-service-worker.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
-import { getAnalyticsClient } from "../usage-analytics";
 import { findWorker, handleAddingToIndex } from "./service-worker";
+import { trackEvent, trackException } from "../usage-analytics";
 
 let existingWorker: vscode.Uri | undefined = undefined;
 
@@ -100,11 +100,7 @@ const simple_worker = `
 `;
 
 export async function handleServiceWorkerCommand() {
-    const analyticsClient = getAnalyticsClient();
-    analyticsClient.trackEvent({
-        name: "generate",
-        properties: { type: "service-worker" }
-    });
+    trackEvent("generate", { "type": "service-worker" })
 
     // first, check if the service worker already exists
     existingWorker = await findWorker();
@@ -188,7 +184,8 @@ async function getServiceWorkerContents(): Promise<string | undefined> {
     return new Promise<string | undefined>(async (resolve, reject) => {
         try {
             resolve(simple_worker);
-        } catch (err) {
+        } catch (err: any) {
+            trackException(err);
             reject(`Error getting service worker contents: ${err}`);
         }
     });

--- a/apps/pwabuilder-vscode/src/services/usage-analytics.ts
+++ b/apps/pwabuilder-vscode/src/services/usage-analytics.ts
@@ -1,23 +1,16 @@
-import { setup, defaultClient } from 'applicationinsights';
+import TelemetryReporter from '@vscode/extension-telemetry';
 import { getFlag } from '../flags';
 
-// urls packaged during this session
-const packagedURLs: Array<string> = [];
+let reporter: TelemetryReporter;
 
 export function initAnalytics() {
   try {
     // check flag first
     if (getFlag("analytics") === true) {
-      setup("#{ANALYTICS_CODE}#")
-      .setAutoDependencyCorrelation(false)
-      .setAutoCollectRequests(false)
-      .setAutoCollectPerformance(false, false)
-      .setAutoCollectExceptions(true)
-      .setAutoCollectDependencies(false)
-      .setAutoCollectConsole(false)
-      .setUseDiskRetryCaching(false)
-      .setSendLiveMetrics(false)
-      .start();
+      // key is not sensitive 
+      // https://www.npmjs.com/package/@vscode/extension-telemetry#:~:text=Follow%20guide%20to%20set%20up%20Application%20Insights%20in%20Azure%20and%20get%20your%20key.%20Don%27t%20worry%20about%20hardcoding%20it%2C%20it%20is%20not%20sensitive.
+      reporter = new TelemetryReporter("f6d86710-4415-4bd6-a2e0-e95bbdfe51be");
+      return reporter;
     }
   }
   catch (err) {
@@ -25,19 +18,11 @@ export function initAnalytics() {
   }
 }
 
-export function getAnalyticsClient() {
-  return defaultClient;
-}
-
 // function to trackEvent
 export function trackEvent(name: string, properties: any) {
   try {
     if (getFlag("analytics") === true) {
-
-      defaultClient.trackEvent({ 
-        name,  
-        properties
-      });
+      reporter.sendTelemetryEvent(name, properties);
     }
   }
   catch (err) {
@@ -50,9 +35,7 @@ export function trackEvent(name: string, properties: any) {
 export function trackException(err: Error) {
   try {
     if (getFlag("analytics") === true) {
-      defaultClient.trackException({ 
-        exception: err
-      });
+      reporter.sendTelemetryException(err);
     }
   }
   catch (err) {

--- a/apps/pwabuilder-vscode/src/services/validation/validation-view.ts
+++ b/apps/pwabuilder-vscode/src/services/validation/validation-view.ts
@@ -3,6 +3,7 @@ import { readFile } from "fs/promises";
 import { testManifest } from "./validation";
 import { findManifest, getManifest } from "../manifest/manifest-service";
 import { pathExists } from "../../library/file-utils";
+import { trackException } from "../usage-analytics";
 
 /**
  * This is the Web Manifest Panel
@@ -87,7 +88,8 @@ export class PWAValidationProvider implements vscode.TreeDataProvider<any> {
       const testResults = await testManifest(manifestContents);
 
       return testResults;
-    } catch (err) {
+    } catch (err: any) {
+      trackException(err);
       throw new Error(`Error loading and testing manifest: ${err}`);
     }
   }

--- a/apps/pwabuilder-vscode/src/services/validation/validation.ts
+++ b/apps/pwabuilder-vscode/src/services/validation/validation.ts
@@ -2,6 +2,7 @@ import { readFile } from "fs/promises";
 import * as vscode from "vscode";
 import { handleWebhint } from "../../library/handle-webhint";
 import { maniTests } from "../../manifest-utils";
+import { trackException } from "../usage-analytics";
 
 let manifestFileRead: string | undefined;
 
@@ -83,8 +84,9 @@ export function refreshDiagnostics(
 
     maniDiagnostics.set(doc.uri, diagnostics);
   }
-  catch (err) {
+  catch (err: any) {
     // the manifest.json file is most likely empty
+    trackException(err);
     return;
   }
 }
@@ -132,8 +134,9 @@ function createDiagnostic(
 
         testResult = testValue.test(textToTest[testString]);
         test = testValue;
-      } catch (err) {
+      } catch (err: any) {
         console.error("Could not parse JSON value", err);
+        trackException(err);
       }
     }
   });
@@ -583,7 +586,8 @@ export async function testManifest(manifestFile: any): Promise<any[] | undefined
       },
     ];
   }
-  catch (err) {
+  catch (err: any) {
+    trackException(err);
     return undefined;
   }
 }

--- a/apps/pwabuilder-vscode/src/services/web-publish.ts
+++ b/apps/pwabuilder-vscode/src/services/web-publish.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { storageManager } from "../extension";
 import { isNpmInstalled, noNpmInstalledWarning } from "./new-pwa-starter";
+import { trackException } from "./usage-analytics";
 
 let url: string | undefined = undefined;
 
@@ -72,7 +73,8 @@ async function doCLIDeploy(terminal: vscode.Terminal): Promise<void> {
         resolve();
       }
     }
-    catch (err) {
+    catch (err: any) {
+      trackException(err);
       reject(err);
     }
   })
@@ -114,7 +116,8 @@ async function initPublish(terminal: vscode.Terminal): Promise<void> {
       } else {
         noNpmInstalledWarning();
       }
-    } catch (err) {
+    } catch (err: any) {
+      trackException(err);
       reject(err);
     }
   });

--- a/apps/pwabuilder-vscode/src/test/runTest.ts
+++ b/apps/pwabuilder-vscode/src/test/runTest.ts
@@ -16,7 +16,7 @@ async function main() {
 
     // Download VS Code, unzip it and run the integration test
     await runTests({ extensionDevelopmentPath, extensionTestsPath});
-  } catch (err) {
+  } catch (err: any) {
     console.error("Failed to run tests");
     process.exit(1);
   }

--- a/apps/pwabuilder-vscode/src/views/icon-view.ts
+++ b/apps/pwabuilder-vscode/src/views/icon-view.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { Manifest } from "../interfaces";
 import { findManifest } from "../services/manifest/manifest-service";
-import { trackEvent } from "../services/usage-analytics";
+import { trackEvent, trackException } from "../services/usage-analytics";
 import { getUri } from "../utils";
 import { writeFile } from 'fs/promises';
 import path = require("path");
@@ -263,7 +263,7 @@ export class IconViewPanel {
     async generateIcons(options: any = {}, skipPrompts?: boolean) {
         return new Promise(async (resolve, reject) => {
             try {
-                trackEvent("generate", { type: "icons" });
+                trackEvent("generate", { "type": "icons" });
 
                 let iconFile: vscode.Uri[] | undefined;
 
@@ -363,10 +363,12 @@ export class IconViewPanel {
                 });
 
             }
-            catch (err) {
+            catch (err: any) {
                 vscode.window.showErrorMessage(
                     `There was an error generaring icons: ${err}`
                 );
+
+                trackException(err);
 
                 reject(err);
             }


### PR DESCRIPTION
fixes #3718 
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
We are using the applicationinsights lib directly, which does not work well for a vscode environment (or really any local node experience).

## Describe the new behavior?
We are now using the (currently in preview) vscode telemetry module. While it is in preview, the upsides of using this official module and how it solves issues with our analytics is worth the preview module.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
