### PR TITLE
fix(): if reporter is not available dont try to call

### DIFF
--- a/apps/pwabuilder-vscode/package.json
+++ b/apps/pwabuilder-vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "PWABuilder Studio",
   "description": "PWABuilder Studio makes VSCode the best development environment for building PWAs!",
   "publisher": "PWABuilder",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "icon": "store_assets/icon_512.png",
   "repository": {
     "type": "git",

--- a/apps/pwabuilder-vscode/src/services/usage-analytics.ts
+++ b/apps/pwabuilder-vscode/src/services/usage-analytics.ts
@@ -1,17 +1,13 @@
 import TelemetryReporter from '@vscode/extension-telemetry';
 import { getFlag } from '../flags';
 
-let reporter: TelemetryReporter;
+let reporter: TelemetryReporter | undefined;
 
 export function initAnalytics() {
   try {
-    // check flag first
-    if (getFlag("analytics") === true) {
-      // key is not sensitive 
-      // https://www.npmjs.com/package/@vscode/extension-telemetry#:~:text=Follow%20guide%20to%20set%20up%20Application%20Insights%20in%20Azure%20and%20get%20your%20key.%20Don%27t%20worry%20about%20hardcoding%20it%2C%20it%20is%20not%20sensitive.
-      reporter = new TelemetryReporter("f6d86710-4415-4bd6-a2e0-e95bbdfe51be");
-      return reporter;
-    }
+    // https://www.npmjs.com/package/@vscode/extension-telemetry#:~:text=Follow%20guide%20to%20set%20up%20Application%20Insights%20in%20Azure%20and%20get%20your%20key.%20Don%27t%20worry%20about%20hardcoding%20it%2C%20it%20is%20not%20sensitive.
+    reporter = new TelemetryReporter("f6d86710-4415-4bd6-a2e0-e95bbdfe51be");
+    return reporter;
   }
   catch (err) {
     console.error("Error initializing analytics", err);
@@ -20,26 +16,26 @@ export function initAnalytics() {
 
 // function to trackEvent
 export function trackEvent(name: string, properties: any) {
-  try {
-    if (getFlag("analytics") === true) {
+  if (reporter) {
+    try {
       reporter.sendTelemetryEvent(name, properties);
     }
-  }
-  catch (err) {
-    console.error("Error tracking event", err);
-    throw new Error(`Error tracking event: ${err}`);
+    catch (err) {
+      console.error("Error tracking event", err);
+      throw new Error(`Error tracking event: ${err}`);
+    }
   }
 }
 
 
 export function trackException(err: Error) {
-  try {
-    if (getFlag("analytics") === true) {
+  if (reporter) {
+    try {
       reporter.sendTelemetryException(err);
     }
-  }
-  catch (err) {
-    console.error("Error tracking exception", err);
-    throw new Error(`Error tracking exception: ${err}`);
+    catch (err) {
+      console.error("Error tracking exception", err);
+      throw new Error(`Error tracking exception: ${err}`);
+    }
   }
 }


### PR DESCRIPTION
fixes #3732
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
There is an underlying issue with the reporter library, however this fix gets past the issue that keeps people from being able to use the command.

## Describe the new behavior?
Check if the reporter object is available before using. This object should always be there, but due to an issue with the reporter library, it is not.

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
