### PR TITLE
[Manifest Editor] display_override fix

### DIFF
--- a/components/manifest-editor/src/components/manifest-settings-form.ts
+++ b/components/manifest-editor/src/components/manifest-settings-form.ts
@@ -435,7 +435,7 @@ export class ManifestSettingsForm extends LitElement {
     return "";
   }
 
-  async toggleOverrideList(label: string, e: any){
+  async toggleOverrideList(label: string, origin: string){
 
     let fieldChangeAttempted = new CustomEvent('fieldChangeAttempted', {
       detail: {
@@ -446,7 +446,9 @@ export class ManifestSettingsForm extends LitElement {
     });
     this.dispatchEvent(fieldChangeAttempted);
 
-    let active = !e.path[0].checked;
+    let checkbox = origin === "checkbox" ? this.shadowRoot!.querySelector(`sl-checkbox[value="${label}"]`) : this.shadowRoot!.querySelector(`sl-menu-item[value="${label}"]`);
+
+    let active = !(checkbox as HTMLInputElement)!.checked;
     
     if(active){
       // remove from active list
@@ -680,7 +682,7 @@ export class ManifestSettingsForm extends LitElement {
                 ${this.activeOverrideItems.length != 0 ?
                 this.activeOverrideItems.map((item: string, index: number) =>
                   html`
-                    <sl-menu-item class="override-item" value=${item} @click=${(e: CustomEvent) => this.toggleOverrideList(item, e)}>
+                    <sl-menu-item class="override-item" value=${item} @click=${() => this.toggleOverrideList(item, "menu-item")}>
                       <p slot="prefix" class="menu-prefix">${index + 1}</p>
                       ${item}
                     </sl-menu-item>
@@ -691,7 +693,7 @@ export class ManifestSettingsForm extends LitElement {
                 <div id="override-options-grid">
                   ${overrideOptions.map((item: string) =>
                       html`
-                        <sl-checkbox class="override-item" value=${item} @sl-change=${(e: CustomEvent) => this.toggleOverrideList(item, e)} ?checked=${this.activeOverrideItems.includes(item)}>
+                        <sl-checkbox class="override-item" value=${item} @sl-change=${() => this.toggleOverrideList(item, "checkbox")} ?checked=${this.activeOverrideItems.includes(item)}>
                           ${item}
                         </sl-checkbox>
                       `)}


### PR DESCRIPTION

## PR Type
Bugfix

## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
In the manifest editor, despite clicking a checkbox, nothing would happen when trying to edit the display_override field

## Describe the new behavior?
Now it works as expected.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
