### PR TITLE
Fixes a typo in manifest checks

### DIFF
--- a/libraries/manifest-validation/src/validations.ts
+++ b/libraries/manifest-validation/src/validations.ts
@@ -429,13 +429,13 @@ export const maniTests: Array<Validation> = [
     },
     {
         infoString: "The shortcuts member defines an array of shortcuts or links to key tasks or pages within a web app. Shortcuts will show as jumplists on Windows and on the home screen on Android.",
-        displayString: "Shortcuts have atleast a 96x96 icon",
+        displayString: "Shortcuts have at least a 96x96 icon",
         category: "recommended",
         member: "shortcuts",
         defaultValue: [],
         docsLink:
             "https://docs.pwabuilder.com/#/builder/manifest?id=shortcuts-array",
-        errorString: "shortcuts should have atleast one icon with a size of 96x96",
+        errorString: "shortcuts should have at least one icon with a size of 96x96",
         quickFix: false,
         test: (value: any[]) => {
             const isArray = value && Array.isArray(value);


### PR DESCRIPTION
Previously: "Shortcuts have atleast a 96x96 icon"

Now: "Shortcuts have at least a 96x96 icon

## PR Type
 Bugfix

## Describe the current behavior?
Manifest checks would show "Shortcuts should have **atleast** a 96x96 icon" (no space between 'at' and 'least')

## Describe the new behavior?
Manifest checks show "Shortcuts have at least a 96x96 icon"