### PR TITLE
added widgets toggle

### DIFF
--- a/apps/pwabuilder/src/script/components/manifest-editor-frame.ts
+++ b/apps/pwabuilder/src/script/components/manifest-editor-frame.ts
@@ -248,6 +248,7 @@ export class ManifestEditorFrame extends LitElement {
   /* Next functions are for analytics */
 
   handleTabSwitch(e: CustomEvent){
+    recordPWABuilderProcessStep(`manifest_editor.tab_switched`, AnalyticsBehavior.ProcessCheckpoint);
     recordPWABuilderProcessStep(`manifest_editor.${e.detail.tab}_tab_selected`, AnalyticsBehavior.ProcessCheckpoint);
   }
 

--- a/apps/pwabuilder/src/script/components/windows-form.ts
+++ b/apps/pwabuilder/src/script/components/windows-form.ts
@@ -493,7 +493,7 @@ export class WindowsForm extends AppPackageFormBase {
                       'https://learn.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/widgets',
                     inputId: 'widget-checkbox',
                     type: 'checkbox',
-                    checked: false,
+                    checked: this.packageOptions.enableWebAppWidgets,
                     inputHandler: (_val: string, checked: boolean) => 
                       (this.packageOptions.enableWebAppWidgets = checked),
                   })}

--- a/apps/pwabuilder/src/script/components/windows-form.ts
+++ b/apps/pwabuilder/src/script/components/windows-form.ts
@@ -481,6 +481,24 @@ export class WindowsForm extends AppPackageFormBase {
                   })}
                 </div>
               </div>
+              <div class="form-group" id="target-device-families">
+                <label>Widgets</label>
+                <div class="form-check">
+                  ${this.renderFormInput({
+                    label: 'Enable Widgets',
+                    value: 'Widgets',
+                    tooltip:
+                      'Enables your Windows package to serve the widgets listed in your web manifest to the Widgets Panel.',
+                    tooltipLink:
+                      'https://learn.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/widgets',
+                    inputId: 'widget-checkbox',
+                    type: 'checkbox',
+                    checked: false,
+                    inputHandler: (_val: string, checked: boolean) => 
+                      (this.packageOptions.enableWebAppWidgets = checked),
+                  })}
+                </div>
+              </div>
             </div>
           </sl-details>
         </div>

--- a/apps/pwabuilder/src/script/services/publish/windows-publish.ts
+++ b/apps/pwabuilder/src/script/services/publish/windows-publish.ts
@@ -138,6 +138,7 @@ export function createWindowsPackageOptionsFromManifest(
       padding: 0.0,
     },
     resourceLanguage: languages,
+    enableWebAppWidgets: Object.keys(manifest).includes("widgets")
   };
 
   return options;

--- a/apps/pwabuilder/src/script/utils/win-validation.ts
+++ b/apps/pwabuilder/src/script/utils/win-validation.ts
@@ -46,6 +46,7 @@ export interface WindowsPackageOptions  extends PackageOptions {
   publisher: WindowsPublisherOptions;
   resourceLanguage?: string | string[];
   targetDeviceFamilies?: string[];
+  enableWebAppWidgets?: boolean;
 }
 
 type WindowsPackageValidationError = {


### PR DESCRIPTION
fixes https://github.com/pwa-builder/PWABuilder/issues/3816

## PR Type
Feature

## Describe the current behavior?
No way to flag that you have widgets


## Describe the new behavior?
way to flag that you have widgets. 
**Note: Checked by default if widgets are present in the manifest**

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
![image](https://user-images.githubusercontent.com/51131738/217077481-8ecc3dec-2e44-4b3a-90eb-4acfec915be2.png)
You may not be able to get there with the preview link but it looks like this at the bottom of the windows packaging form

Also, I snuck in adding a new analytic tag to count for when tabs are swapped in the manifest editor.