### PR TITLE
Action items pane doesn't resize on page change

### DIFF
--- a/apps/pwabuilder/src/script/components/todo-list-item.ts
+++ b/apps/pwabuilder/src/script/components/todo-list-item.ts
@@ -29,6 +29,7 @@ export class TodoItem extends LitElement {
         border-radius: 10px;
         padding: .5em;
         margin-bottom: 10px;
+        height: 30px;
       }
 
       #item-wrapper:hover {

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -1850,7 +1850,20 @@ export class AppReport extends LitElement {
   // Pages the action items
   paginate() {
     let array = this.sortTodos();
-    return array.slice((this.pageNumber - 1) * this.pageSize, this.pageNumber * this.pageSize);
+    let itemsOnPage = array.slice((this.pageNumber - 1) * this.pageSize, this.pageNumber * this.pageSize);
+
+    let holder = (this.shadowRoot?.querySelector(".todo-items-holder") as HTMLElement);
+    if(itemsOnPage.length < this.pageSize && this.pageNumber == 1){
+      holder.style.display = 'flex';
+      holder.style.flexDirection = 'column';
+      holder.style.gridTemplateRows = 'unset';
+    } else {
+      holder.style.height = '280px;'
+      holder.style.display = 'grid';
+      holder.style.gridTemplateRows = 'repeat(5, 1fr)';
+      holder.style.flexDirection = 'unset';
+    }
+    return itemsOnPage;
   }
 
   // Moves to the next window in the action items list
@@ -2022,18 +2035,19 @@ export class AppReport extends LitElement {
                   <img class="dropdown_icon" data-card="todo" src="/assets/new/dropdownIcon.svg" alt="dropdown toggler"/>
                 
               </div>
-             ${(!this.manifestDataLoading && !this.swDataLoading && !this.secDataLoading) ? this.paginate().map((todo: any) =>
-                html`
-                  <todo-item
-                    .status=${todo.status}
-                    .field=${todo.field}
-                    .fix=${todo.fix}
-                    .card=${todo.card}
-                    .displayString=${todo.displayString}
-                    @todo-clicked=${(e: CustomEvent) => this.animateItem(e)}>
-                  </todo-item>`
-              ) : html`<span class="loader"></span>`}
-
+              <div class="todo-items-holder">
+                ${(!this.manifestDataLoading && !this.swDataLoading && !this.secDataLoading) ? this.paginate().map((todo: any) =>
+                    html`
+                      <todo-item
+                        .status=${todo.status}
+                        .field=${todo.field}
+                        .fix=${todo.fix}
+                        .card=${todo.card}
+                        .displayString=${todo.displayString}
+                        @todo-clicked=${(e: CustomEvent) => this.animateItem(e)}>
+                      </todo-item>`
+                  ) : html`<span class="loader"></span>`}
+              </div>
             ${((!this.manifestDataLoading && !this.swDataLoading && !this.secDataLoading) && (this.todoItems.length > this.pageSize)) ?
               html`
               <div id="pagination-actions">


### PR DESCRIPTION
fixes #3586
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
Bugfix

## Describe the current behavior?
When you switch pages, the action items pane resizes.

## Describe the new behavior?
The pane is now a set height and the todo items are aswell, when you switch pages, everything stays. Only thing is that everything is a bit thicker, but the space feels good.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
