### PR TITLE
Disabled widgets checkbox if manifest doesn't have widgets

### DIFF
--- a/apps/pwabuilder/src/script/components/app-package-form-base.ts
+++ b/apps/pwabuilder/src/script/components/app-package-form-base.ts
@@ -131,6 +131,10 @@ export class AppPackageFormBase extends LitElement {
         border: 1px solid var(--error-color);
       }
 
+      input:disabled {
+        cursor: no-drop;
+      }
+
 
       @media (min-height: 760px) and (max-height: 1000px) {
         form {
@@ -180,6 +184,7 @@ export class AppPackageFormBase extends LitElement {
         max="${ifDefined(formInput.maxValue)}" pattern="${ifDefined(formInput.pattern)}"
         spellcheck="${ifDefined(formInput.spellcheck)}" ?checked="${formInput.checked}" ?readonly="${formInput.readonly}"
         custom-validation-error-message="${ifDefined(formInput.validationErrorMessage)}"
+        ?disabled=${formInput.disabled}
         @input="${(e: UIEvent) => this.inputChanged(e, formInput)}" @invalid=${this.inputInvalid} />
     `;
   }
@@ -284,5 +289,6 @@ export interface FormInput {
   readonly?: boolean;
   validationErrorMessage?: string;
   checked?: boolean;
+  disabled?: boolean;
   inputHandler?: (val: string, checked: boolean, input: HTMLInputElement) => void;
 }

--- a/apps/pwabuilder/src/script/components/windows-form.ts
+++ b/apps/pwabuilder/src/script/components/windows-form.ts
@@ -499,6 +499,7 @@ export class WindowsForm extends AppPackageFormBase {
                     inputId: 'widget-checkbox',
                     type: 'checkbox',
                     checked: this.packageOptions.enableWebAppWidgets,
+                    disabled: !this.packageOptions.enableWebAppWidgets,
                     inputHandler: (_val: string, checked: boolean) => 
                       (this.packageOptions.enableWebAppWidgets = checked),
                   })}


### PR DESCRIPTION
fixes #3873
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
 Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
If you didn't have widgets, you were still able to check the box in the windows form saying to serve widgets for your package which changes the way the .msix is built unnecessarily. 

## Describe the new behavior?
You can only toggle the widgets checkbox if you already have widgets in your manifest. Otherwise, it'll be disabled. 

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
