### PR TITLE
Fixed protocol validation to include web+ protocols.

### DIFF
--- a/libraries/manifest-validation/src/validations.ts
+++ b/libraries/manifest-validation/src/validations.ts
@@ -618,7 +618,7 @@ export const maniTests: Array<Validation> = [
                 const allValid = value.every((protocolHandler: any) => {
                     const isRelativeUrl = protocolHandler.url && protocolHandler.url.startsWith("/");
                     const hasProtocol = protocolHandler.protocol && protocolHandler.protocol.length > 0;
-                    const isProtocolValid = hasProtocol && validProtocols.includes(protocolHandler.protocol);
+                    const isProtocolValid = hasProtocol && (validProtocols.includes(protocolHandler.protocol) || protocolHandler.protocol.startsWith("web+"));
                     const hasUrl = protocolHandler.url && protocolHandler.url.length > 0;
 
                     return isRelativeUrl && hasProtocol && hasUrl && isProtocolValid;


### PR DESCRIPTION
fixes #3912

## PR Type

Bugfix 


## Describe the current behavior?
Protocol validation doesn't include web+ protocols.

## Describe the new behavior?
Protocol validation now includes web+ protocols.

## PR Checklist

- [x ] Test: run `npm run test` and ensure that all tests pass
- [x ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
