### PR TITLE
Generic color picker added to `app-package-form-base` to be used across all forms

### DIFF
--- a/apps/pwabuilder/src/script/components/android-form.ts
+++ b/apps/pwabuilder/src/script/components/android-form.ts
@@ -18,6 +18,15 @@ export class AndroidForm extends AppPackageFormBase {
   @state() packageOptions = emptyAndroidPackageOptions();
   @state() manifestContext: ManifestContext | undefined = getManifestContext();
 
+  // colors
+  @state() currentSelectedThemeColor: string = '';
+  @state() currentSelectedBackgroundColor: string = '';
+  @state() currentSelectedNavColor: string = '';
+  @state() currentSelectedNavDarkColor: string = '';
+  @state() currentSelectedNavDividerColor: string = '';
+  @state() currentSelectedNavDividerDarkColor: string = '';
+
+
   static get styles() {
 
     const localStyles = css`
@@ -229,6 +238,11 @@ export class AndroidForm extends AppPackageFormBase {
     recordPWABuilderProcessStep("android_form_all_settings_collapsed", AnalyticsBehavior.ProcessCheckpoint);
     let icon: any = this.shadowRoot!.querySelector('.dropdown_icon');
     icon!.style.transform = "rotate(90deg)";
+  }
+
+  handleColorUpdate(formSlot: any, colorSlot: string, val: string, inputElement: HTMLInputElement){
+    formSlot = val;
+    colorSlot = inputElement.getFormattedValue('hex');
   }
 
   public getPackageOptions(): PackageOptions {

--- a/apps/pwabuilder/src/script/components/android-form.ts
+++ b/apps/pwabuilder/src/script/components/android-form.ts
@@ -18,15 +18,6 @@ export class AndroidForm extends AppPackageFormBase {
   @state() packageOptions = emptyAndroidPackageOptions();
   @state() manifestContext: ManifestContext | undefined = getManifestContext();
 
-  // colors
-  @state() currentSelectedThemeColor: string = '';
-  @state() currentSelectedBackgroundColor: string = '';
-  @state() currentSelectedNavColor: string = '';
-  @state() currentSelectedNavDarkColor: string = '';
-  @state() currentSelectedNavDividerColor: string = '';
-  @state() currentSelectedNavDividerDarkColor: string = '';
-
-
   static get styles() {
 
     const localStyles = css`
@@ -103,7 +94,7 @@ export class AndroidForm extends AppPackageFormBase {
         font-weight: bold;
       }
 
-      
+
 
     `;
 
@@ -238,11 +229,6 @@ export class AndroidForm extends AppPackageFormBase {
     recordPWABuilderProcessStep("android_form_all_settings_collapsed", AnalyticsBehavior.ProcessCheckpoint);
     let icon: any = this.shadowRoot!.querySelector('.dropdown_icon');
     icon!.style.transform = "rotate(90deg)";
-  }
-
-  handleColorUpdate(formSlot: any, colorSlot: string, val: string, inputElement: HTMLInputElement){
-    formSlot = val;
-    colorSlot = inputElement.getFormattedValue('hex');
   }
 
   public getPackageOptions(): PackageOptions {
@@ -760,7 +746,7 @@ export class AndroidForm extends AppPackageFormBase {
           </sl-details>
         </div>
       </form>
-      
+
     </div>
     </div>
     `;

--- a/apps/pwabuilder/src/script/components/android-form.ts
+++ b/apps/pwabuilder/src/script/components/android-form.ts
@@ -94,8 +94,6 @@ export class AndroidForm extends AppPackageFormBase {
         font-weight: bold;
       }
 
-
-
     `;
 
     return [
@@ -746,7 +744,6 @@ export class AndroidForm extends AppPackageFormBase {
           </sl-details>
         </div>
       </form>
-
     </div>
     </div>
     `;

--- a/apps/pwabuilder/src/script/components/app-package-form-base.ts
+++ b/apps/pwabuilder/src/script/components/app-package-form-base.ts
@@ -7,6 +7,7 @@ import ModalStyles from '../../../styles/modal-styles.css';
 import '../components/info-circle-tooltip';
 import { customElement } from 'lit/decorators.js';
 import { PackageOptions } from '../utils/interfaces';
+import { SlColorPicker } from '@shoelace-style/shoelace';
 
 /**
  * Base class for app package forms, e.g. the Windows package form, the Android package form, the iOS package form, etc.
@@ -147,6 +148,17 @@ export class AppPackageFormBase extends LitElement {
         display: flex;
       }
 
+      .colorPickerAndValue {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .colorPickerAndValue p {
+        margin: 0;
+        color: var(--secondary-font-color);
+      }
+
 
       @media (min-height: 760px) and (max-height: 1000px) {
         form {
@@ -193,7 +205,9 @@ export class AppPackageFormBase extends LitElement {
   }
 
   private renderFormColorPicker(formInput: FormInput){
-    return html`<sl-color-picker
+    return html`
+    <div class="colorPickerAndValue">
+      <sl-color-picker
               id="${formInput.inputId}" 
               class="form-control" 
               placeholder="${formInput.placeholder || ''}"
@@ -213,7 +227,9 @@ export class AppPackageFormBase extends LitElement {
               ?disabled=${formInput.disabled}
               @sl-change="${(e: UIEvent) => this.colorChanged(e, formInput)}" 
               @sl-invalid=${this.inputInvalid}
-            ></sl-color-picker>`;
+            ></sl-color-picker>
+            <p>${formInput.value}</p>
+  </div>`;
   }
 
   private renderFormInputTextbox(formInput: FormInput): TemplateResult {
@@ -228,7 +244,7 @@ export class AppPackageFormBase extends LitElement {
         spellcheck="${ifDefined(formInput.spellcheck)}" ?checked="${formInput.checked}" ?readonly="${formInput.readonly}"
         custom-validation-error-message="${ifDefined(formInput.validationErrorMessage)}"
         ?disabled=${formInput.disabled}
-        @input="${(e: UIEvent) => this.colorChanged(e, formInput)}" @invalid=${this.inputInvalid} />
+        @input="${(e: UIEvent) => this.inputChanged(e, formInput)}" @invalid=${this.inputInvalid} />
     `;
   }
 
@@ -260,8 +276,11 @@ export class AppPackageFormBase extends LitElement {
 
   private colorChanged(e: UIEvent, formInput: FormInput) {
     const inputElement = e.target as HTMLInputElement | null;
-    let formattedValue = inputElement!.getFormattedValue('hex')
+    let formattedValue = (inputElement as unknown as SlColorPicker)!.getFormattedValue('hex').toLocaleUpperCase();
     
+    let colorValue = inputElement?.nextElementSibling;
+    colorValue!.innerHTML = formattedValue;
+
     if (inputElement) {
       // Fire the input handler
       if (formInput.inputHandler) {

--- a/apps/pwabuilder/src/script/components/app-package-form-base.ts
+++ b/apps/pwabuilder/src/script/components/app-package-form-base.ts
@@ -135,6 +135,18 @@ export class AppPackageFormBase extends LitElement {
         cursor: no-drop;
       }
 
+      sl-color-picker {
+        --grid-width: 315px;
+        height: 25px;
+      }
+
+      sl-color-picker::part(trigger){
+        border-radius: 0;
+        height: 25px;
+        width: 75px;
+        display: flex;
+      }
+
 
       @media (min-height: 760px) and (max-height: 1000px) {
         form {
@@ -166,11 +178,42 @@ export class AppPackageFormBase extends LitElement {
       `;
     }
 
+    if(formInput.type === 'color'){
+      return html`
+        ${this.renderFormInputLabel(formInput)}
+        ${this.renderFormColorPicker(formInput)}
+      `;
+    }
+
     // For all others, the label comes first.
     return html`
       ${this.renderFormInputLabel(formInput)}
       ${this.renderFormInputTextbox(formInput)}
     `;
+  }
+
+  private renderFormColorPicker(formInput: FormInput){
+    return html`<sl-color-picker
+              id="${formInput.inputId}" 
+              class="form-control" 
+              placeholder="${formInput.placeholder || ''}"
+              value="${(ifDefined(formInput.value) as string)}" 
+              type="color" 
+              ?required="${formInput.required}"
+              name="${ifDefined(formInput.name)}" 
+              minlength="${ifDefined(formInput.minLength)}"
+              maxlength="${ifDefined(formInput.maxLength)}"
+              min=${ifDefined(formInput.minValue)}
+              max="${ifDefined(formInput.maxValue)}" 
+              pattern="${ifDefined(formInput.pattern)}"
+              spellcheck="${ifDefined(formInput.spellcheck)}" 
+              ?checked="${formInput.checked}" 
+              ?readonly="${formInput.readonly}"
+              custom-validation-error-message="${ifDefined(formInput.validationErrorMessage)}"
+              ?disabled=${formInput.disabled}
+              @sl-change="${(e: UIEvent) => this.colorChanged(e, formInput)}" 
+              @sl-invalid=${this.inputInvalid}
+            ></sl-color-picker>`;
   }
 
   private renderFormInputTextbox(formInput: FormInput): TemplateResult {
@@ -185,7 +228,7 @@ export class AppPackageFormBase extends LitElement {
         spellcheck="${ifDefined(formInput.spellcheck)}" ?checked="${formInput.checked}" ?readonly="${formInput.readonly}"
         custom-validation-error-message="${ifDefined(formInput.validationErrorMessage)}"
         ?disabled=${formInput.disabled}
-        @input="${(e: UIEvent) => this.inputChanged(e, formInput)}" @invalid=${this.inputInvalid} />
+        @input="${(e: UIEvent) => this.colorChanged(e, formInput)}" @invalid=${this.inputInvalid} />
     `;
   }
 
@@ -213,6 +256,25 @@ export class AppPackageFormBase extends LitElement {
       <info-circle-tooltip text="${formInput.tooltip}" link="${ifDefined(formInput.tooltipLink)}">
       </info-circle-tooltip>
     `;
+  }
+
+  private colorChanged(e: UIEvent, formInput: FormInput) {
+    const inputElement = e.target as HTMLInputElement | null;
+    let formattedValue = inputElement!.getFormattedValue('hex')
+    
+    if (inputElement) {
+      // Fire the input handler
+      if (formInput.inputHandler) {
+        formInput.inputHandler(formattedValue, inputElement.checked, inputElement);
+      }
+
+      // Run validation if necessary.
+      if (formInput.validationErrorMessage) {
+        const errorMessage = this.inputHasValidationErrors(inputElement) ? formInput.validationErrorMessage : '';
+        inputElement.setCustomValidity(errorMessage);
+        inputElement.title = errorMessage;
+      }
+    }
   }
 
   private inputChanged(e: UIEvent, formInput: FormInput) {

--- a/apps/pwabuilder/src/script/components/windows-form.ts
+++ b/apps/pwabuilder/src/script/components/windows-form.ts
@@ -302,7 +302,7 @@ export class WindowsForm extends AppPackageFormBase {
     `;
   }
 
-  renderColorPicker(formInput: FormInput): TemplateResult {
+  renderColorToggle(formInput: FormInput): TemplateResult {
     return html`
       <label for="${formInput.inputId}">
         ${formInput.label}
@@ -321,11 +321,7 @@ export class WindowsForm extends AppPackageFormBase {
           </sl-radio-group>
           ${this.customSelected ? html`
           <div id="color-input-holder">
-            <sl-color-picker
-              id="icon-bg-color"
-              value=${this.packageOptions.images!.backgroundColor || 'transparent'}
-              @sl-change=${() => this.switchIconBgColor()}
-            ></sl-color-picker>
+            ${this.renderFormInput(formInput)}
             <p>${this.currentSelectedColor}</p>
           </div>
           ` : html``}
@@ -346,14 +342,13 @@ export class WindowsForm extends AppPackageFormBase {
     }
   }
 
-  switchIconBgColor(){
-    let input = (this.shadowRoot?.getElementById("icon-bg-color") as any);
-    let formattedValue = input.getFormattedValue('hex')
-    this.packageOptions.images!.backgroundColor = this.currentSelectedColor = formattedValue;
-  }
-
   handleLanguage(e: any){
     this.packageOptions.resourceLanguage = e.target.value;
+  }
+
+  handleColorUpdate(val: string, inputElement: HTMLInputElement){
+    this.packageOptions.images!.backgroundColor = val;
+    this.currentSelectedColor = inputElement.getFormattedValue('hex');
   }
 
 
@@ -504,16 +499,16 @@ export class WindowsForm extends AppPackageFormBase {
                 })}
               </div>
               <div class="form-group">
-                ${this.renderColorPicker({
+                ${this.renderColorToggle({
                   label: 'Icon Background Color',
                   tooltip: `Optional. The background color of the Windows icons that will be generated with your .msix.`,
                   tooltipLink:
                     'https://learn.microsoft.com/en-us/windows/apps/design/style/iconography/app-icon-design#color-contrast',
                   inputId: 'icon-bg-color-input',
+                  type: 'color',
                   value: this.packageOptions.images!.backgroundColor || 'transparent',
                   placeholder: 'transparent',
-                  inputHandler: (val: string) =>
-                    (this.packageOptions.images!.backgroundColor = val),
+                  inputHandler: (val: string, _, inputElement) => this.handleColorUpdate(val, inputElement),
                 })}
               </div>
               <div class="form-group">

--- a/apps/pwabuilder/src/script/components/windows-form.ts
+++ b/apps/pwabuilder/src/script/components/windows-form.ts
@@ -96,17 +96,6 @@ export class WindowsForm extends AppPackageFormBase {
           color: rgba(0,0,0,.5);
         }
 
-        #color-input-holder {
-          display: flex;
-          align-items: center;
-          gap: 10px;
-        }
-
-        #color-input-holder p {
-          margin: 0;
-          color: var(--secondary-font-color);
-        }
-
         :host{
           --sl-focus-ring-width: 3px;
           --sl-input-focus-ring-color: #4f3fb670;
@@ -280,7 +269,7 @@ export class WindowsForm extends AppPackageFormBase {
           <p class="sub-multi">Select Multiple Languages</p>
           <sl-select id="languageDrop" 
             placeholder="Select one or more languages"
-            @sl-change=${(e: any) => this.handleLanguage(e)} 
+            @sl-change=${(e: any) => this.packageOptions.resourceLanguage = e.target.value} 
             value=${this.packageOptions.resourceLanguage!}
             ?stayopenonselect=${true} 
             multiple
@@ -320,10 +309,7 @@ export class WindowsForm extends AppPackageFormBase {
             <sl-radio class="color-radio" size="small" value="custom">Custom Color</sl-radio>
           </sl-radio-group>
           ${this.customSelected ? html`
-          <div id="color-input-holder">
             ${this.renderFormInput(formInput)}
-            <p>${this.currentSelectedColor}</p>
-          </div>
           ` : html``}
         </div>
       </div>
@@ -341,16 +327,6 @@ export class WindowsForm extends AppPackageFormBase {
       this.currentSelectedColor = this.initialBgColor;
     }
   }
-
-  handleLanguage(e: any){
-    this.packageOptions.resourceLanguage = e.target.value;
-  }
-
-  handleColorUpdate(val: string, inputElement: HTMLInputElement){
-    this.packageOptions.images!.backgroundColor = val;
-    this.currentSelectedColor = inputElement.getFormattedValue('hex');
-  }
-
 
   render() {
     return html`
@@ -508,7 +484,7 @@ export class WindowsForm extends AppPackageFormBase {
                   type: 'color',
                   value: this.packageOptions.images!.backgroundColor || 'transparent',
                   placeholder: 'transparent',
-                  inputHandler: (val: string, _, inputElement) => this.handleColorUpdate(val, inputElement),
+                  inputHandler: (val: string) => this.packageOptions.images!.backgroundColor = val,
                 })}
               </div>
               <div class="form-group">


### PR DESCRIPTION
fixes #3898
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
Feature

## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
I originally created a new color picker option in the Windows packaging form for the Icon background color. I then realized that the android and ios forms also use color pickers and things were not uniform.

## Describe the new behavior?
I created a generic color picker that can just be used by calling the same `renderFormInput` still with `type='color'` and the new color picker will be generated for all forms.

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
This is what it looks like:
![image](https://user-images.githubusercontent.com/51131738/227971177-ada7b3e6-961f-4f9d-9ff7-ddb5df9d436b.png)
