### PR TITLE
New docs for new manifest fields

### DIFF
--- a/docs/builder/manifest.md
+++ b/docs/builder/manifest.md
@@ -317,3 +317,162 @@ If you only want to provide a single icon, your icons array could also look like
 ```
 
 ?> You can use PWABuilder to help you generate screenshots.
+
+## Share
+
+### share_target: `Object`
+
+`share_target` is an optional member that allows installed apps to be registered as a share target in the given operating systems share dialog.
+
+The `share_target` member is an object which can contain the following members:
+
+*  `action`: The URL within the scope of your app that your app will handle the share action. ***Required member*** 
+*  `method`: `GET` or `POST`. Use `POST` if the shared data includes binary data like images.
+* `enctype`: The encoding of the data when the method is a `POST` request. Otherwise, ignored.
+* `params`: The object that allows you to configure the share parameters. Should corresponded to the object exposed by `navigator.share()`. ***Required member*** 
+    * `title`: Name of the query parameter for the title of the doucument being shared.
+    * `text`: Name of the query parameter for the body of the message being shared.
+    * `url`: Name of the query parameter for the URL being shared.
+    * `files`
+        * `name`: Name of the form field used to share files.
+        * `accept`: A string or array of strings of accepted MIME types of extensions.
+
+```json
+"share_target": {
+  "action": "/handle-shared-content/",
+  "method": "GET",
+  "params": {
+    "title": "title",
+    "url": "url"
+  }
+}
+
+"share_target": {
+    "action": "/collect-files",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url",
+      "files": [
+        {
+          "name": "lists",
+          "accept": ["text/csv", ".csv"]
+        }
+      ]
+    }
+  }
+```
+
+## Handlers
+
+### file_handlers: `Array`
+
+`file_handlers` is an optional member that specifies an array of file types that your app can handle and how to handle them.
+
+The `file_handlers` member is an array of `file_handler` objects, which can contain the following members:
+
+*  `action`: The URL within the scope of your app that your app will open to when handling the given file type.
+*  `accept`: An object that contains the MIME-types that the above url can handle as keys and file extensions as values.
+* `icons`: A list of `icon` objects that will show when given the option to open the given file with your app.
+* `launch_type`: Dictates the amount of app instances launch when handling multiple files at once. `single-client` is the default but this field can also be set to `multiple-clients` if you want an app instance to launch for each file  being handled.
+
+```json
+"file_handlers": [
+    {
+      "action": "/open-pdf",
+      "accept": {
+        "application/pdf": [".pdf"]
+      },
+      "icons": [
+        {
+          "src": "pdf-icon.png",
+          "sizes": "256x256",
+          "type": "image/png"
+        }
+      ],
+      "launch_type": "single-client"
+    },
+    {
+      "action": "/show-model",
+      "accept": {
+        "application/sla": ".stl",
+        "application/octet-stream": ".fbx"
+      },
+      "icons": [
+        {
+          "src": "3d-printer-icon.png",
+          "sizes": "256x256",
+          "type": "image/png"
+        }
+      ],
+      "launch_type": "multiple-clients"
+    }
+
+]
+```
+
+### launch_handlers: `string` | `Array`
+
+`launch_handlers` is an optional member that controls the launch of a web application. It's singular value `client_mode` can take on the following values:
+
+* `auto`: the user agent makes the decision based on the context.
+* `focus-existing`: If the web app is already open, it is brought into focus without navigating to the launch target URL.
+* `navigate-existing`: If the web app is already open, it is brought into focus and naviagates to the URL made available by `Window.launchQueue`
+* `navigate-new`: A new instance of the web app is opened and it navigates to the URL made available by `Window.launchQueue`
+
+In the second example below, if `navigate-existing` is unavailable it will fallback to the next value in the list.
+
+```json
+"launch_handler": {
+    "client_mode": "navigate-existing"
+}
+
+"launch_handler": {
+    "client_mode": ["navigate-existing, auto"]
+}
+```
+
+?> In any instance where the app is not already running, `navigate-new` will be used instead.
+
+### handle_links: `string`
+
+`handle_links` is an optional member that specifies the default link handling for the web app. It can take on the following values:
+
+* `auto`: The user agent should select the appropriate behavior for the platform (Default if not otherwise specified).
+* `preferred`: the user agent should open in-scope links within the installed application.
+* `not-preferred`: The user agent should not open links within the installed application.
+
+```json
+"handle_links": "preferred"
+```
+
+?> In any instance where the app is not already running, `navigate-new` will be used instead.
+
+### scope_extensions: `Array`
+
+`scope_extensions` is an optional member that specifies a list of origin patterns to associate with. This allows for your app to control multiple subdomains and top level domains to behave as one.
+
+```json
+"scope_extensions": [
+    {"origin": "*.pwabuilder.com"},
+    {"origin": "docs.pwabuilder.co.uk"},
+    {"origin": "*.pwabuilder.co.uk"},
+  ]
+```
+
+In order to allow for your app to intercept links, you must specify `web-app-origin-association.json` that must be located at `https://<associated origin>/.well-known/web-app-origin-association.json`.
+
+```json
+{
+  "web_apps": {
+     "https://docs.pwabuilder.com/": {
+       "scope": "/",
+       "authorize": ["intercept-links"]
+     }
+  }
+}
+```
+
+?> The combination of `handle_links` and `scope_extensions` is intended to be a replacement for the `url_handlers` field.


### PR DESCRIPTION
New documentation for new manifest fields that are coming to PWABuilder soon. Including:
- share_target
- file_handlers
- launch_handlers
- scope_extensions
- handle_links