### PR TITLE
[SITE] Re-Enabled Experimental Tag for iOS

### DIFF
--- a/apps/pwabuilder/src/script/components/publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/publish-pane.ts
@@ -183,6 +183,27 @@ export class PublishPane extends LitElement {
         line-height: 12px;
         font-weight: bold;
       }
+      .experimental-tracker {
+        height: max-content;
+        width: 33%;
+        background-color: #fecaca;
+        align-self: flex-end;
+        justify-self: flex-end;
+        border-bottom-left-radius: 5px;
+        padding: 7px;
+        padding-left: 9px;
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+      .experimental-tracker p {
+        margin: 0;
+        text-align: center;
+        color: #dc2626;
+        font-size: 10px;
+        line-height: 12px;
+        font-weight: bold;
+      }
       .title-block {
         box-sizing: border-box;
         display: flex;
@@ -898,10 +919,10 @@ export class PublishPane extends LitElement {
     return this.platforms.map(
       platform => html`
         <div class="card-wrapper">
-          ${true ? html`` :
+          ${platform.title != "iOS" ? html`` :
             html`
-            <div class="packaged-tracker"> <!-- This will eventually be in an "if packaged previously" -->
-            <p>Packaged Previously</p>
+            <div class="experimental-tracker">
+            <p>Experimental</p>
             </div>`
           }
           <div class="title-block">

--- a/apps/pwabuilder/src/script/components/test-publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/test-publish-pane.ts
@@ -118,6 +118,27 @@ export class TestPublishPane extends LitElement {
         line-height: 12px;
         font-weight: bold;
       }
+      .experimental-tracker {
+        height: max-content;
+        width: 33%;
+        background-color: #fecaca;
+        align-self: flex-end;
+        justify-self: flex-end;
+        border-bottom-left-radius: 5px;
+        padding: 7px;
+        padding-left: 9px;
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+      .experimental-tracker p {
+        margin: 0;
+        text-align: center;
+        color: #dc2626;
+        font-size: 10px;
+        line-height: 12px;
+        font-weight: bold;
+      }
       .title-block {
         box-sizing: border-box;
         display: flex;
@@ -477,12 +498,12 @@ export class TestPublishPane extends LitElement {
     return this.platforms.map(
       platform => html`
         <div class="card-wrapper">
-          ${true ? html`` :
+          ${platform.title != "iOS" ? html`` :
             html`
-            <div class="packaged-tracker"> <!-- This will eventually be in an "if packaged previously" -->
-            <p>Packaged Previously</p>
+            <div class="experimental-tracker">
+            <p>Experimental</p>
             </div>`
-          }
+          } 
           <div class="title-block">
             <img class="platform-icon" src="${platform.icon}" alt="platform icon" />
             <h3>${platform.title}</h3>

--- a/docs/builder/faq.md
+++ b/docs/builder/faq.md
@@ -7,6 +7,11 @@ Welcome to the PWA Builder FAQ!
 Questions are separated by platform. If you're looking for a specific answer and don't see it right away, try entering some keywords in the search feature on the sidebar.
 
 If you have a question that isn't addressed here or elsewhere in the documentation, feel free to open an [issue.](https://github.com/pwa-builder/PWABuilder/issues/new/choose)
+## General
+
+#### How do I update my store listings? Do I have to republish my PWA?
+
+You don't have to republish to stores when you want to deliver new content to your progressive web app. Just update the content that is being served on the web, and those changes will be automatically reflected in the versions installed from app stores.
 
 ## Windows
 

--- a/docs/builder/manifest.md
+++ b/docs/builder/manifest.md
@@ -41,6 +41,16 @@ It is recommended that `short_name` be 12 characters or less in length.
 
 ?> `short_name` isn't required by Web Standards, but is a required member for packaging with the PWABuilder service. `short_name` must be 3 or more characters to ensure you can package for all stores.
 
+### id: `string`
+
+`id` is an optional member that functions as a unique identifier for your Progressive Web App that is separate from members that may change over time (such as `name` or `start_url`). `id` allows the browser to properly associate your app's identity with a specific install, regardless of whether or not the value of other manifest members changes.
+
+```json
+{
+  id: "/?homescreen=1"
+}
+```
+
 ### description: `string`
 
 `description` is an optional member that can be used to describe the functionality and purpose of your app.
@@ -151,11 +161,11 @@ It has three values to choose from:
 
 `display_override` is similar to the `display` member, but allows you to select a fallback order for different display modes.
 
-In addition to the four display values above, `display_override` can also take the value `window-control-overlay`. `Window-control-overlay` is a desktop-only display mode and adds a native-style overlay to the top of your application.
+In addition to the four display values above, `display_override` can also take the value `window-controls-overlay`. `window-controls-overlay` is a desktop-only display mode and adds a native-style overlay to the top of your application.
 
 ```json
 "display_override": [
-  "window-control-overlay",
+  "window-controls-overlay",
   "standalone",
   "browser"
 ]
@@ -249,6 +259,20 @@ The `shortcuts` member is an array of `shortcut` objects, which can contain the 
 
 ```json
 "categories": ["games", "finance", "navigation"]
+```
+
+### edge_side_panel: `Object`
+
+`edge_side_panel` is an optional member that specifies whether or not your app supports the side panel view in Microsoft Edge. The side panel provides an alternative view that allows your app to display UI in a manner conducive to side-by-side browsing. You can learn more about side panel use cases [here.](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/SidePanel/explainer.md)
+
+You can also specify the `preferred_width` member as part of your `edge_side_panel` specification.
+
+```json
+{
+  "edge_side_panel": {
+    "preferred_width": 400
+  }
+}
 ```
 
 ## Icons

--- a/docs/builder/quick-start.md
+++ b/docs/builder/quick-start.md
@@ -45,7 +45,13 @@ You can have an application package for your PWA in just a few steps:
      <img src="../assets/builder/quick-start/package-download.png" alt="" width=600>
 </div>
 
-## Next Steps 
+## Updating Packages
+
+Progressive Web Apps that are published to app stores using PWA Builder have a huge benefit: they don't need to be republished to their respective listings when you update the content of your apps.
+
+In order to deliver a new version of your app, you just need to update the version of your PWA being served on the web, and this will be reflected in all distributions of your app. The only time a user might see outdated data is if they are using a cached version of your app or aren't currently connected to the web.
+
+## Next Steps
 
 If you're looking for more specific guidance on how to publish a PWA to a specific store, check out the platform-specific articles:
 


### PR DESCRIPTION
fixes #4112 

Added new CSS for experimental to change color to red (welcome to push back to this). Also we can separate from the previously packaged look later on.