### PR TITLE
removed 96x96 requirement from shortcut validation

### DIFF
--- a/libraries/manifest-validation/src/mani-tests.ts
+++ b/libraries/manifest-validation/src/mani-tests.ts
@@ -488,7 +488,8 @@ export const maniTests: Array<Validation> = [
                 return false;
             }
 
-            /* we use every here bc every shortcut needs at 
+            // Commenting this block out, this shouldn't be an error but instead a warning.
+            /* /* we use every here bc every shortcut needs at 
                 least one icon with size 96x96 no  icons at all */
             const has96x96Icon = value.every((shortcut: {icons?: Icon[]}) => {
                 if (!shortcut.icons) return true;
@@ -500,7 +501,7 @@ export const maniTests: Array<Validation> = [
             if (!has96x96Icon) {
                 this.errorString = "One or more of your shortcuts has icons but does not have one with size 96x96";
                 return false;
-            }
+            } */
 
             return true;
         }

--- a/libraries/manifest-validation/src/mani-tests.ts
+++ b/libraries/manifest-validation/src/mani-tests.ts
@@ -489,8 +489,8 @@ export const maniTests: Array<Validation> = [
             }
 
             // Commenting this block out, this shouldn't be an error but instead a warning.
-            /* /* we use every here bc every shortcut needs at 
-                least one icon with size 96x96 no  icons at all */
+            /* we use every here bc every shortcut needs at 
+                least one icon with size 96x96 no  icons at all
             const has96x96Icon = value.every((shortcut: {icons?: Icon[]}) => {
                 if (!shortcut.icons) return true;
                 // we use some here bc only one icon has to be that size


### PR DESCRIPTION
This shouldn't be causes people to FAIL the test. Edge doesn't raise an error. In the future we can raise this as a warning.