### PR TITLE
[SITE] Fix color picker breaking signing mode sub form inside the android form

### DIFF
--- a/apps/pwabuilder/src/script/components/app-package-form-base.ts
+++ b/apps/pwabuilder/src/script/components/app-package-form-base.ts
@@ -275,17 +275,22 @@ export class AppPackageFormBase extends LitElement {
   }
 
   private colorChanged(e: UIEvent, formInput: FormInput) {
-    const inputElement = e.target as HTMLInputElement | null;
+    interface HTMLSlColorPicker extends HTMLInputElement,  SlColorPicker {
+      size: any;
+      form: any;
+      addEventListener: any;
+      removeEventListener: any;
+    }
+    const inputElement = e.target as HTMLSlColorPicker;
 
-    if(!inputElement) return;
-
-    let formattedValue = (inputElement as unknown as SlColorPicker)!.getFormattedValue('hex').toLocaleUpperCase();
-
-    const colorValue = inputElement?.nextElementSibling;
+    if(!inputElement || !inputElement.nextElementSibling) return;
+    
+    const formattedValue = inputElement.getFormattedValue('hex').toLocaleUpperCase();
+    const colorValue = inputElement.nextElementSibling;
     const newValue = document.createElement('p');
     newValue.textContent = formattedValue;
     
-    colorValue!.replaceWith(newValue);
+    colorValue.replaceWith(newValue);
 
     // Fire the input handler
     if (formInput.inputHandler) {

--- a/apps/pwabuilder/src/script/components/app-package-form-base.ts
+++ b/apps/pwabuilder/src/script/components/app-package-form-base.ts
@@ -277,9 +277,12 @@ export class AppPackageFormBase extends LitElement {
   private colorChanged(e: UIEvent, formInput: FormInput) {
     const inputElement = e.target as HTMLInputElement | null;
     let formattedValue = (inputElement as unknown as SlColorPicker)!.getFormattedValue('hex').toLocaleUpperCase();
+
+    const colorValue = inputElement?.nextElementSibling;
+    const newValue = document.createElement('p');
+    newValue.textContent = formattedValue;
     
-    let colorValue = inputElement?.nextElementSibling;
-    colorValue!.innerHTML = formattedValue;
+    colorValue!.replaceWith(newValue);
 
     if (inputElement) {
       // Fire the input handler

--- a/apps/pwabuilder/src/script/components/app-package-form-base.ts
+++ b/apps/pwabuilder/src/script/components/app-package-form-base.ts
@@ -276,6 +276,9 @@ export class AppPackageFormBase extends LitElement {
 
   private colorChanged(e: UIEvent, formInput: FormInput) {
     const inputElement = e.target as HTMLInputElement | null;
+
+    if(!inputElement) return;
+
     let formattedValue = (inputElement as unknown as SlColorPicker)!.getFormattedValue('hex').toLocaleUpperCase();
 
     const colorValue = inputElement?.nextElementSibling;
@@ -284,19 +287,18 @@ export class AppPackageFormBase extends LitElement {
     
     colorValue!.replaceWith(newValue);
 
-    if (inputElement) {
-      // Fire the input handler
-      if (formInput.inputHandler) {
-        formInput.inputHandler(formattedValue, inputElement.checked, inputElement);
-      }
-
-      // Run validation if necessary.
-      if (formInput.validationErrorMessage) {
-        const errorMessage = this.inputHasValidationErrors(inputElement) ? formInput.validationErrorMessage : '';
-        inputElement.setCustomValidity(errorMessage);
-        inputElement.title = errorMessage;
-      }
+    // Fire the input handler
+    if (formInput.inputHandler) {
+      formInput.inputHandler(formattedValue, inputElement.checked, inputElement);
     }
+
+    // Run validation if necessary.
+    if (formInput.validationErrorMessage) {
+      const errorMessage = this.inputHasValidationErrors(inputElement) ? formInput.validationErrorMessage : '';
+      inputElement.setCustomValidity(errorMessage);
+      inputElement.title = errorMessage;
+    }
+    
   }
 
   private inputChanged(e: UIEvent, formInput: FormInput) {


### PR DESCRIPTION
fixes #4267 #4301
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
When you change the color using the color picker in the android form, it breaks the signing mode sub form for some reason. Had to do with the way we were setting the color picker color label using `.innerHTML` or `.textContent`

## Describe the new behavior?
We just completely replace the p element instead of changing the inner html. 

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
