### PR TITLE
Separated Terms and conditions analytic call.

### DIFF
--- a/apps/pwabuilder/src/script/pages/qualification/app-token.ts
+++ b/apps/pwabuilder/src/script/pages/qualification/app-token.ts
@@ -616,12 +616,17 @@ export class AppToken extends LitElement {
     this.heroBanners.uncovered = !covered;
   }
 
+  // if showAcceptButton is true we are coming from the accept t and c button
+  // if its false its just the link in the qualifications section
   showTandC(showAcceptButton: boolean){
     this.showTerms = true;
-    this.showTermsNoAccept = showAcceptButton;
-    if(showAcceptButton){
-      recordPWABuilderProcessStep("full_terms_and_conditions_clicked", AnalyticsBehavior.ProcessCheckpoint);
-    }
+    this.showTermsNoAccept = !showAcceptButton;
+
+    // if we are showing the accept button we are in the final t and c
+    // if not it must be from the qualifications box.
+    let location = showAcceptButton ? "final" : "qualification";
+    
+    recordPWABuilderProcessStep(`${location}_terms_and_conditions_clicked`, AnalyticsBehavior.ProcessCheckpoint);
     recordPWABuilderProcessStep("terms_and_conditions_modal_opened", AnalyticsBehavior.ProcessCheckpoint);
 
   }
@@ -916,7 +921,7 @@ export class AppToken extends LitElement {
           <li>Use the Store Token to create a Microsoft Store on Windows developer account within 30 calendar days of Microsoft sending you the token, using the same Microsoft Account you used to sign in here</li>
           <li>Plan to publish an app in the store this calendar year (prior to 12/31/2023 midnight Pacific Standard Time)</li>
         </ul>
-        <p class="FTC" @click=${() => this.showTandC(true)}>Full Terms and Conditions</p>
+        <p class="FTC" @click=${() => this.showTandC(false)}>Full Terms and Conditions</p>
       </div>` : html``}
       ${this.siteURL ?
         html`
@@ -944,7 +949,7 @@ export class AppToken extends LitElement {
               !this.isDenyList && !this.isPopularUrl ?
             html `
                 <div id="terms-and-conditions">
-                  <label><input type="checkbox" class="confirm-terms" @click=${() => this.showTandC(false)} /> By clicking this button, you accept the Terms of Service and our Privacy Policy.</label>
+                  <label><input type="checkbox" class="confirm-terms" @click=${() => this.showTandC(true)} /> By clicking this button, you accept the Terms of Service and our Privacy Policy.</label>
 
                   ${this.acceptedTerms ?
                     html`<sl-button class="primary" @click=${() => this.claimToken()} .loading="${this.claimTokenLoading}" .disabled="${this.claimTokenLoading}">View Token Code</sl-button>` :


### PR DESCRIPTION
If its coming from the qualifications panel expect: `qualifcation_terms_and_conditions_clicked`
If its the final terms they need to accept expect: `final_terms_and_conditions_clicked`

Either way, expect `terms_and_conditions_modal_opened` to keep a cumulative count