### PR TITLE
[Accessibility] Removed close button from portals modal

### DIFF
--- a/apps/pwabuilder/src/script/components/publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/publish-pane.ts
@@ -19,6 +19,7 @@ import './ios-form';
 import './oculus-form';
 import { AppPackageFormBase } from './app-package-form-base';
 import { PackageOptions } from '../utils/interfaces';
+import { classMap } from 'lit/directives/class-map.js';
 
 @customElement('publish-pane')
 export class PublishPane extends LitElement {
@@ -41,8 +42,8 @@ export class PublishPane extends LitElement {
   @state() downloadFileName: string | null = null;
   @state() feedbackMessages: TemplateResult[] = [];
 
-  @property() preventClosing = false;
-  @property() tokensCampaign = false;
+  @property({type: Boolean}) preventClosing = false;
+  @property({type: Boolean}) tokensCampaign = false;
 
   @state() storeMap: any = {
   "Windows":
@@ -368,6 +369,10 @@ export class PublishPane extends LitElement {
       #form-area[data-store="Android"] {
         padding-top: 0;
         flex-direction: column;
+      }
+
+      .noX::part(close-button) {
+        display: none;
       }
 
       .dialog::part(body){
@@ -1123,7 +1128,12 @@ export class PublishPane extends LitElement {
 
   render() {
     return html`
-      <sl-dialog class="dialog" @sl-show=${() => document.body.style.height = "100vh"} @sl-hide=${(e: any) => this.hideDialog(e)} @sl-request-close=${(e:any) => this.handleRequestClose(e)} noHeader>
+      <sl-dialog
+        class=${classMap({noX: this.preventClosing, dialog: true})}
+        @sl-show=${() => document.body.style.height = "100vh"} 
+        @sl-hide=${(e: any) => this.hideDialog(e)} 
+        @sl-request-close=${(e:any) => this.handleRequestClose(e)} 
+        noHeader>
         <div id="pp-frame-wrapper">
           <div id="pp-frame-content">
           ${this.cardsOrForm ?


### PR DESCRIPTION
fixes https://github.com/pwa-builder/PWABuilder/issues/4238
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
X button on portals pop up even tho you can't X it out 

## Describe the new behavior?
Removed the X

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
