### PR TITLE
[Accessibility] Errors are announced as the appear in the manifest editor

### DIFF
--- a/components/manifest-editor/src/components/manifest-icons-form.ts
+++ b/components/manifest-editor/src/components/manifest-icons-form.ts
@@ -320,6 +320,7 @@ export class ManifestIconsForm extends LitElement {
             p.innerText = error;
             p.style.color = "#eb5757";
             p.classList.add("error-message");
+            p.setAttribute('aria-live', 'polite');
             insertAfter(p, title!.parentNode!.parentNode);
             this.errorCount++;
           });

--- a/components/manifest-editor/src/components/manifest-info-form.ts
+++ b/components/manifest-editor/src/components/manifest-info-form.ts
@@ -328,6 +328,7 @@ export class ManifestInfoForm extends LitElement {
                 let p = document.createElement('p');
                 p.innerText = error;
                 p.style.color = "#eb5757";
+                p.setAttribute('aria-live', 'polite');
                 div.append(p);
                 this.errorMap[field]++;
               });
@@ -352,6 +353,7 @@ export class ManifestInfoForm extends LitElement {
                 let p = document.createElement('p');
                 p.innerText = error;
                 p.style.color = "#eb5757";
+                p.setAttribute('aria-live', 'polite');
                 div.append(p);
                 this.errorMap[field]++;
               });
@@ -379,6 +381,7 @@ export class ManifestInfoForm extends LitElement {
           let p = document.createElement('p');
           p.innerText = `${field} is required and is missing from your manifest.`;
           p.style.color = "#eb5757";
+          p.setAttribute('aria-live', 'polite');
           div.append(p);
           this.errorMap[field]++;
           insertAfter(div, input!.parentNode!.lastElementChild);
@@ -417,7 +420,6 @@ export class ManifestInfoForm extends LitElement {
       });
       this.dispatchEvent(manifestUpdated);
     }
-
   }
 
   async handleInputChange(event: InputEvent){
@@ -475,6 +477,7 @@ export class ManifestInfoForm extends LitElement {
           let p = document.createElement('p');
           p.innerText = error;
           p.style.color = "#eb5757";
+          p.setAttribute('aria-live', 'polite');
           div.append(p);
           this.errorMap[fieldName!]++;
         });

--- a/components/manifest-editor/src/components/manifest-platform-form.ts
+++ b/components/manifest-editor/src/components/manifest-platform-form.ts
@@ -416,6 +416,7 @@ export class ManifestPlatformForm extends LitElement {
               let p = document.createElement('p');
               p.innerText = error;
               p.style.color = "#eb5757";
+              p.setAttribute('aria-live', 'polite');
               div.append(p);
               this.errorMap[field]++;
             });
@@ -546,6 +547,7 @@ dispatchUpdateEvent(field: string, change: any, removal: boolean = false){
           let p = document.createElement('p');
           p.innerText = error;
           p.style.color = "#eb5757";
+          p.setAttribute('aria-live', 'polite');
           div.append(p);
           this.errorMap[fieldName!]++;
         });
@@ -806,6 +808,7 @@ dispatchUpdateEvent(field: string, change: any, removal: boolean = false){
           let p = document.createElement('p');
           p.innerText = error;
           p.style.color = "#eb5757";
+          p.setAttribute('aria-live', 'polite');
           div.append(p);
           this.errorMap[field]++;
         });

--- a/components/manifest-editor/src/components/manifest-screenshots-form.ts
+++ b/components/manifest-editor/src/components/manifest-screenshots-form.ts
@@ -273,11 +273,12 @@ export class ManifestScreenshotsForm extends LitElement {
         if(validation.errors){
           validation.errors.forEach((error: string) => {
             let p = document.createElement('p');
-          p.innerText = error;
-          p.style.color = "#eb5757";
-          p.classList.add("error-message");
-          insertAfter(p, title!.parentNode);
-          this.errorCount++;
+            p.innerText = error;
+            p.style.color = "#eb5757";
+            p.classList.add("error-message");
+            p.setAttribute('aria-live', 'polite');
+            insertAfter(p, title!.parentNode);
+            this.errorCount++;
           });
         }
 

--- a/components/manifest-editor/src/components/manifest-settings-form.ts
+++ b/components/manifest-editor/src/components/manifest-settings-form.ts
@@ -364,6 +364,7 @@ export class ManifestSettingsForm extends LitElement {
               let p = document.createElement('p');
               p.innerText = error;
               p.style.color = "#eb5757";
+              p.setAttribute('aria-live', 'polite');
               div.append(p);
               this.errorMap[field]++;
             });
@@ -470,6 +471,7 @@ export class ManifestSettingsForm extends LitElement {
           let p = document.createElement('p');
           p.innerText = error;
           p.style.color = "#eb5757";
+          p.setAttribute('aria-live', 'polite');
           div.append(p);
           this.errorMap[fieldName!]++;
         });
@@ -567,6 +569,7 @@ export class ManifestSettingsForm extends LitElement {
           let p = document.createElement('p');
           p.innerText = error;
           p.style.color = "#eb5757";
+          p.setAttribute('aria-live', 'polite');
           div.append(p);
           this.errorMap[field]++;
         });

--- a/components/manifest-editor/src/components/manifest-share-form.ts
+++ b/components/manifest-editor/src/components/manifest-share-form.ts
@@ -476,6 +476,7 @@ export class ManifestShareForm extends LitElement {
             p.innerText = error;
             p.style.color = "#eb5757";
             p.classList.add("error-message");
+            p.setAttribute('aria-live', 'polite');
             insertAfter(p, title!.parentNode!.parentNode);
             this.errorCount++;
           });


### PR DESCRIPTION
fixes [#4234](https://github.com/pwa-builder/PWABuilder/issues/4234)
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->
Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
If an error had appeared in the manifest editor, the screen reader wouldn't know

## Describe the new behavior?
Added aria live = polite to the error messages so they are announced if they appear after updating an input

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
