### PR TITLE
Fixed issue of github link not showing text when tabbed over

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -125,6 +125,14 @@
           navigator.serviceWorker.register('sw.js')
         }
     </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+        const githubCorner = document.querySelector('.github-corner');
+        if (githubCorner) {
+            githubCorner.setAttribute('title', 'View source on GitHub');
+        }
+        });
+    </script>
     
 
 </body>


### PR DESCRIPTION
fixes #4256
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Before:
![image](https://github.com/pwa-builder/PWABuilder/assets/51131738/ab64842e-1fa1-44f2-bfd1-c90397a43102)


## Describe the new behavior?
Tooltip shows on hover (cant show screenshot bc it goes away)

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
