### PR TITLE
docs(manifest): correct web app origin association

### DIFF
--- a/docs/builder/manifest.md
+++ b/docs/builder/manifest.md
@@ -490,16 +490,15 @@ In the second example below, if `navigate-existing` is unavailable it will fallb
   ]
 ```
 
-In order to allow for your app to intercept links, you must specify `web-app-origin-association.json` that must be located at `https://<associated origin>/.well-known/web-app-origin-association.json`.
+In order to allow for your app to intercept links, you must specify `web-app-origin-association` that must be located at `https://<associated origin>/.well-known/web-app-origin-association`.
 
 ```json
 {
-  "web_apps": {
-     "https://docs.pwabuilder.com/": {
-       "scope": "/",
-       "authorize": ["intercept-links"]
-     }
-  }
+  "web_apps": [
+    {
+      "web_app_identity": "https://docs.pwabuilder.com/"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
Update the example to what is specified in https://github.com/WICG/manifest-incubations/blob/gh-pages/scope_extensions-explainer.md

## PR Type

Documentation content changes

## Describe the current behavior?
The example seems incorrect.


## Describe the new behavior?
The example is changed to what is explained in the specification.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
n/a