### PR TITLE
fix(typo): `handle_links` error message

### DIFF
--- a/libraries/manifest-validation/src/mani-tests.ts
+++ b/libraries/manifest-validation/src/mani-tests.ts
@@ -57,7 +57,7 @@ export const maniTests: Array<Validation> = [
         member: "handle_links",
         defaultValue: "auto",
         docsLink: "https://docs.pwabuilder.com/#/builder/manifest?id=handle_links-string",
-        errorString: "handle_links should be either auto, preferred or not-proferred",
+        errorString: "handle_links should be either auto, preferred or not-preferred",
         quickFix: true,
         test: (value: string) => {
             if (value && typeof value === "string") {


### PR DESCRIPTION
## PR Type
Bugfix


## Describe the current behavior?
Typo in `todo-item` that suggests "not-proferred [sic]" as an option for `handle_links`.

## Describe the new behavior
Fixes typo to match [spec](https://github.com/WICG/pwa-url-handler/blob/main/handle_links/explainer.md)