### PR TITLE
[SITE] remove giveaway references from the report card page

### DIFF
--- a/apps/pwabuilder/src/script/components/publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/publish-pane.ts
@@ -1004,19 +1004,6 @@ export class PublishPane extends LitElement {
               ${platform.factoids.map((fact: string) => html`<li>${fact}</li>`)}
             </ul>
           </div>
-          ${ platform.title === "Windows" && this.tokensCampaign ? html`
-              <button id="windows-package-token-banner" @click=${() => this.goToTokenPage()}>
-                <div id="token-banner-windows-icon">
-                  <img src="/assets/microsoft_store_icon_white.png" alt="Windows">
-                </div>
-                <div id="token-banner-text">
-                  <p>
-                    Check to see if you qualify for a free Microsoft Store account <img src="/assets/white-arrow.png" alt="arrow" />
-                  </p>
-                </div>
-              </button>
-            ` : html``
-          }
         </div>`
     );
   }
@@ -1130,9 +1117,9 @@ export class PublishPane extends LitElement {
     return html`
       <sl-dialog
         class=${classMap({noX: this.preventClosing, dialog: true})}
-        @sl-show=${() => document.body.style.height = "100vh"} 
-        @sl-hide=${(e: any) => this.hideDialog(e)} 
-        @sl-request-close=${(e:any) => this.handleRequestClose(e)} 
+        @sl-show=${() => document.body.style.height = "100vh"}
+        @sl-hide=${(e: any) => this.hideDialog(e)}
+        @sl-request-close=${(e:any) => this.handleRequestClose(e)}
         noHeader>
         <div id="pp-frame-wrapper">
           <div id="pp-frame-content">

--- a/apps/pwabuilder/src/script/components/todo-list-item.ts
+++ b/apps/pwabuilder/src/script/components/todo-list-item.ts
@@ -22,7 +22,6 @@ export class TodoItem extends LitElement {
   @property({ type: String }) displayString: string = "";
 
   @state() clickable: boolean = false;
-  @state() giveaway: boolean = false;
   @state() isOpen: boolean = false;
 
   static get styles() {
@@ -111,10 +110,6 @@ export class TodoItem extends LitElement {
           }
       }
 
-      .giveaway img { 
-        height: 21px;
-      }
-
       .arrow {
         width: 16px;
       }
@@ -145,11 +140,6 @@ export class TodoItem extends LitElement {
   }
 
   decideClasses(){
-    // token giveaway toggle
-    this.giveaway = false;
-    if(this.field === "giveaway"){
-      this.giveaway = true;
-    }
 
     if(this.status === "retest" || this.field.startsWith("Open")){
       this.clickable = true;
@@ -157,8 +147,8 @@ export class TodoItem extends LitElement {
       this.clickable = false;
     }
 
-    return {iwrapper: true, clickable: this.clickable, giveaway: this.giveaway}
-  } 
+    return {iwrapper: true, clickable: this.clickable}
+  }
 
   bubbleEvent(){
     if(manifest_fields[this.field]){
@@ -206,21 +196,14 @@ export class TodoItem extends LitElement {
     switch(this.status){
       case "required":
         return html`<img src=${stop_src} alt="yield result icon"/>`
-    
+
       case "retest":
         return html`<img src=${retest_src} style="color: black" alt="retest site icon"/>`
-
-      case "giveaway":
-        return html`<img src=${giveaway_src}  alt="giveaway site icon"/>`
     }
 
     return html`<img src=${yield_src} alt="yield result icon"/>`
   }
 
-  goToGiveaway(){
-    let event = new CustomEvent('giveawayEvent', {});
-    this.dispatchEvent(event);
-  }
 
   render() {
     return html`
@@ -228,30 +211,12 @@ export class TodoItem extends LitElement {
         <div class="left">
           ${this.decideIcon()}
           <p>${this.fix}</p>
-
-          ${this.giveaway ? 
-            html`
-              <span
-                class="arrow_anchor"
-                @click=${() => this.goToGiveaway()}
-              >
-                <p class="arrow_link">Check Now</p>
-                <img
-                  class="arrow"
-                  src="/assets/new/arrow.svg"
-                  alt="arrow"
-                />
-              </span>
-            ` :
-            html``
-          }
-          
         </div>
 
-        ${manifest_fields[this.field] ? 
+        ${manifest_fields[this.field] ?
           html`
             <manifest-info-card .field=${this.field} @trigger-hover=${(e: CustomEvent) => this.triggerHoverState(e)}></manifest-info-card>
-          ` 
+          `
           : html``}
       </div>
     `;
@@ -261,4 +226,3 @@ export class TodoItem extends LitElement {
 const yield_src = "/assets/new/yield.svg";
 const stop_src = "/assets/new/stop.svg";
 const retest_src = "/assets/new/retest-black.svg";
-const giveaway_src = "/assets/new/msft_store_giveaway.svg";

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -1834,19 +1834,6 @@ export class AppReport extends LitElement {
     this.todoItems = [];
     if (findersResults.manifestTodos.length){
       this.todoItems.push(...findersResults.manifestTodos)
-
-      // adding todo for token giveaway item if theres at least a manifest
-      if(!this.createdManifest && this.tokensCampaign){
-        this.todoItems.push(
-          {
-            "card": "giveaway",
-            "field": "giveaway",
-            "fix": `Your PWA may qualify for a free Microsoft Store developer account.`,
-            "status": "giveaway",
-            "displayString": `Your PWA may qualify for a free Microsoft Store developer account`
-          }
-        );
-      }
     }
     else {
       this.todoItems.push(...await this.testManifest());
@@ -1909,19 +1896,6 @@ export class AppReport extends LitElement {
     } else {
       manifest = {};
       todos.push({"card": "mani-details", "field": "Open Manifest Modal", "fix": "Edit and download your created manifest (Manifest not found before detection tests timed out)", "status": "required"});
-    }
-
-    // adding todo for token giveaway item if theres at least a manifest
-    if(!this.createdManifest && this.tokensCampaign){
-      this.todoItems.push(
-        {
-          "card": "giveaway",
-          "field": "giveaway",
-          "fix": `Your PWA may qualify for a free Microsoft Store developer account.`,
-          "status": "giveaway",
-          "displayString": `Your PWA may qualify for a free Microsoft Store developer account`
-        }
-      );
     }
 
     if(this.manifestRequiredCounter > 0){
@@ -2399,10 +2373,9 @@ export class AppReport extends LitElement {
     const rank: { [key: string]: number } = {
       "retest": 0,
       "required": 1,
-      "giveaway": 2,
-      "highly recommended": 3,
-      "recommended": 4,
-      "optional": 5
+      "highly recommended": 2,
+      "recommended": 3,
+      "optional": 4
     };
     this.todoItems.sort((a, b) => {
       if (rank[a.status] < rank[b.status]) {
@@ -2511,16 +2484,6 @@ export class AppReport extends LitElement {
       this.openTooltips = [];
     }
 
-  }
-
-  goToGiveawayPage(){
-    recordPWABuilderProcessStep("free_token_check_now_clicked", AnalyticsBehavior.ProcessCheckpoint);
-    let a: HTMLAnchorElement = document.createElement("a");
-    a.target = "_blank";
-    a.href = `${window.location.protocol}//${window.location.host}/freeToken?site=${this.siteURL}`;
-    a.rel = "noopener";
-
-    a.click();
   }
 
   closeTooltipOnScroll() {
@@ -2691,7 +2654,7 @@ export class AppReport extends LitElement {
                         @todo-clicked=${(e: CustomEvent) => this.animateItem(e)}
                         @open-manifest-editor=${(e: CustomEvent) => this.openManifestEditorModal(e.detail.field, e.detail.tab)}
                         @trigger-hover=${(e: CustomEvent) => this.handleShowingTooltip(e)}
-                        @giveawayEvent=${() => this.goToGiveawayPage()}>
+                      >
 
                       </todo-item>`
                   ) : html`<span class="loader"></span>`}
@@ -2699,11 +2662,11 @@ export class AppReport extends LitElement {
             ${(this.todoItems.length > this.pageSize) ?
               html`
               <div id="pagination-actions">
-                <button 
-                  class="pagination-buttons" 
-                  name="action-items-previous-page-button" 
+                <button
+                  class="pagination-buttons"
+                  name="action-items-previous-page-button"
                   aria-label="Previous page button for action items list"
-                  type="button"  
+                  type="button"
                   @click=${() => this.switchPage(false)}
                   ><sl-icon class="pageToggles" name="chevron-left"></sl-icon>
                 </button>
@@ -2717,12 +2680,12 @@ export class AppReport extends LitElement {
                         <img src="/assets/new/inactive_dot.svg" alt="inactive dot" />
                       `)}
                 </div>
-                <button 
-                  class="pagination-buttons" 
-                  name="action-items-next-page-button" 
+                <button
+                  class="pagination-buttons"
+                  name="action-items-next-page-button"
                   aria-label="Next page button for action items list"
                   aria-live="polite"
-                  type="button" 
+                  type="button"
                   @click=${() => this.switchPage(true)}><sl-icon class="pageToggles" name="chevron-right"></sl-icon>
                 </button>
               </div>` : html``}


### PR DESCRIPTION
Removes the todo item and the banner on the Windows store card pushing users to the giveaway page.