### PR TITLE
[Site] fall back for no manifest

### DIFF
--- a/apps/pwabuilder/src/script/components/todo-list-item.ts
+++ b/apps/pwabuilder/src/script/components/todo-list-item.ts
@@ -111,7 +111,7 @@ export class TodoItem extends LitElement {
           }
       }
 
-      .giveaway img { 
+      .giveaway img {
         height: 21px;
       }
 
@@ -158,7 +158,7 @@ export class TodoItem extends LitElement {
     }
 
     return {iwrapper: true, clickable: this.clickable, giveaway: this.giveaway}
-  } 
+  }
 
   bubbleEvent(){
     if(manifest_fields[this.field]){
@@ -205,8 +205,9 @@ export class TodoItem extends LitElement {
   decideIcon(){
     switch(this.status){
       case "required":
+      case "missing":
         return html`<img src=${stop_src} alt="yield result icon"/>`
-    
+
       case "retest":
         return html`<img src=${retest_src} style="color: black" alt="retest site icon"/>`
 
@@ -229,7 +230,7 @@ export class TodoItem extends LitElement {
           ${this.decideIcon()}
           <p>${this.fix}</p>
 
-          ${this.giveaway ? 
+          ${this.giveaway ?
             html`
               <span
                 class="arrow_anchor"
@@ -245,13 +246,13 @@ export class TodoItem extends LitElement {
             ` :
             html``
           }
-          
+
         </div>
 
-        ${manifest_fields[this.field] ? 
+        ${manifest_fields[this.field] ?
           html`
             <manifest-info-card .field=${this.field} @trigger-hover=${(e: CustomEvent) => this.triggerHoverState(e)}></manifest-info-card>
-          ` 
+          `
           : html``}
       </div>
     `;

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -1870,46 +1870,49 @@ export class AppReport extends LitElement {
     let manifest;
     let todos: unknown[] = [];
 
-    if(!this.createdManifest){
-      manifest = JSON.parse(sessionStorage.getItem("PWABuilderManifest")!).manifest;
-      this.validationResults = await validateManifest(manifest, true);
-
-      //  This just makes it so that the valid things are first
-      // and the invalid things show after.
-      this.validationResults.sort((a, b) => {
-        if(a.valid && !b.valid){
-          return 1;
-        } else if(b.valid && !a.valid){
-          return -1;
-        } else {
-          return a.member.localeCompare(b.member);
-        }
-      });
-      this.manifestTotalScore = this.validationResults.length;
-      this.manifestValidCounter = 0;
-      this.manifestRequiredCounter = 0;
-
-      this.validationResults.forEach((test: Validation) => {
-        if(test.valid){
-          this.manifestValidCounter++;
-        } else {
-          let status ="";
-          if(test.category === "required" || test.testRequired){
-            status = "required";
-            this.manifestRequiredCounter++;
-          } else if(test.category === "recommended"){
-            status = "recommended";
-            this.manifestRecCounter++;
-          } else {
-            status = "optional";
-          }
-          todos.push({"card": "mani-details", "field": test.member, "displayString": test.displayString ?? "", "fix": test.errorString, "status": status});
-        }
-      });
-    } else {
+    if(this.createdManifest) {
       manifest = {};
-      todos.push({"card": "mani-details", "field": "Open Manifest Modal", "fix": "Edit and download your created manifest (Manifest not found before detection tests timed out)", "status": "required"});
+      todos.push({"card": "mani-details", "field": "Open Manifest Modal", "fix": "Edit and download your created manifest (Manifest not found before detection tests timed out)", "status": "missing"});
     }
+
+
+    manifest = JSON.parse(sessionStorage.getItem("PWABuilderManifest")!).manifest;
+    this.validationResults = await validateManifest(manifest, true);
+
+    //  This just makes it so that the valid things are first
+    // and the invalid things show after.
+    this.validationResults.sort((a, b) => {
+      if(a.valid && !b.valid){
+        return 1;
+      } else if(b.valid && !a.valid){
+        return -1;
+      } else {
+        return a.member.localeCompare(b.member);
+      }
+    });
+    this.manifestTotalScore = this.validationResults.length;
+    this.manifestValidCounter = 0;
+    this.manifestRequiredCounter = 0;
+
+    this.validationResults.forEach((test: Validation) => {
+      if(test.valid){
+        this.manifestValidCounter++;
+      } else {
+        let status ="";
+        if(test.category === "required" || test.testRequired){
+          status = "required";
+          this.manifestRequiredCounter++;
+        } else if(test.category === "recommended"){
+          status = "recommended";
+          this.manifestRecCounter++;
+        } else {
+          status = "optional";
+        }
+        todos.push({"card": "mani-details", "field": test.member, "displayString": test.displayString ?? "", "fix": test.errorString, "status": status});
+      }
+    });
+
+
 
     // adding todo for token giveaway item if theres at least a manifest
     if(!this.createdManifest && this.tokensCampaign){
@@ -2398,11 +2401,12 @@ export class AppReport extends LitElement {
   sortTodos(){
     const rank: { [key: string]: number } = {
       "retest": 0,
-      "required": 1,
-      "giveaway": 2,
-      "highly recommended": 3,
-      "recommended": 4,
-      "optional": 5
+      "missing": 1,
+      "required": 2,
+      "giveaway": 3,
+      "highly recommended": 4,
+      "recommended": 5,
+      "optional": 6
     };
     this.todoItems.sort((a, b) => {
       if (rank[a.status] < rank[b.status]) {
@@ -2699,11 +2703,11 @@ export class AppReport extends LitElement {
             ${(this.todoItems.length > this.pageSize) ?
               html`
               <div id="pagination-actions">
-                <button 
-                  class="pagination-buttons" 
-                  name="action-items-previous-page-button" 
+                <button
+                  class="pagination-buttons"
+                  name="action-items-previous-page-button"
                   aria-label="Previous page button for action items list"
-                  type="button"  
+                  type="button"
                   @click=${() => this.switchPage(false)}
                   ><sl-icon class="pageToggles" name="chevron-left"></sl-icon>
                 </button>
@@ -2717,12 +2721,12 @@ export class AppReport extends LitElement {
                         <img src="/assets/new/inactive_dot.svg" alt="inactive dot" />
                       `)}
                 </div>
-                <button 
-                  class="pagination-buttons" 
-                  name="action-items-next-page-button" 
+                <button
+                  class="pagination-buttons"
+                  name="action-items-next-page-button"
                   aria-label="Next page button for action items list"
                   aria-live="polite"
-                  type="button" 
+                  type="button"
                   @click=${() => this.switchPage(true)}><sl-icon class="pageToggles" name="chevron-right"></sl-icon>
                 </button>
               </div>` : html``}


### PR DESCRIPTION
fixes #4363
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
We had an if statement that blocked the validation tests from running on created manifests and since we populate the data using the results from those tests, it was empty
![image](https://github.com/pwa-builder/PWABuilder/assets/51131738/890cf082-2956-4b67-8806-ee9419f0b51f)

## Describe the new behavior?
Unblock the tests and make sure they know its created and they need to update it 
![image](https://github.com/pwa-builder/PWABuilder/assets/51131738/2e9c4867-56fc-49af-b12e-c80ed07440e2)

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
