### PR TITLE
feat(): generate changelogs for staging and prod builds

### DIFF
--- a/.github/workflows/pwabuilder-main.yml
+++ b/.github/workflows/pwabuilder-main.yml
@@ -67,6 +67,17 @@ jobs:
           skip_app_build: true # Skip building the app using the default build commands for the specified app framework - optional
           output_location: "" # Built app content directory - optional
 
+  generate_release:
+    runs-on: ubuntu-latest
+    name: Generate Release including changelog
+    steps:
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.CHANGELOG_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: false
+          title: "Production Build"
+
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/pwabuilder-preview.yml
+++ b/.github/workflows/pwabuilder-preview.yml
@@ -66,6 +66,17 @@ jobs:
           skip_app_build: true # Skip building the app using the default build commands for the specified app framework - optional
           output_location: "" # Built app content directory - optional
 
+  generate_release:
+    runs-on: ubuntu-latest
+    name: Generate Release including changelog
+    steps:
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.CHANGELOG_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Staging Build"
+
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'


### PR DESCRIPTION
fixes #4433 
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the new behavior?
Changelogs generated, along with a "release" tag here on Github, for both staging and prod builds. Changelogs are generated based on commits of course, staging builds are marked as a pre-release and prod builds are simply marked as a release. 

## PR Checklist

- [ x] Test: run `npm run test` and ensure that all tests pass
- [xx ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
