### PR TITLE
Transparent new default for Windows Icon Backgrounds.

### DIFF
--- a/apps/pwabuilder/src/script/components/test-publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/test-publish-pane.ts
@@ -537,7 +537,7 @@ export class TestPublishPane extends LitElement {
           <div id="pp-frame-content">
             <div id="pp-frame-header">
               <h1>Download Test Package</h1>
-              <p>If you want to see what your app would look like in its current state, use the test package buttons below!</p>
+              <p>If you want to see what your app would look like in its current state, use the test package button below!</p>
             </div>
             <div id="store-cards">
               ${this.renderContentCards()}

--- a/apps/pwabuilder/src/script/components/windows-form.ts
+++ b/apps/pwabuilder/src/script/components/windows-form.ts
@@ -25,6 +25,7 @@ export class WindowsForm extends AppPackageFormBase {
   @state() packageOptions: WindowsPackageOptions = emptyWindowsPackageOptions();
   @state() activeLanguages: string[] = [];
   @state() activeLanguageCodes: string[] = [];
+  @state() userBackgroundColor: string = "";
 
   static get styles() {
     return [
@@ -202,7 +203,7 @@ export class WindowsForm extends AppPackageFormBase {
     if (manifestContext.isGenerated) {
       manifestContext = await fetchOrCreateManifest();
     }
-
+    
     this.packageOptions = createWindowsPackageOptionsFromManifest(
       manifestContext!.manifest
     );
@@ -210,7 +211,12 @@ export class WindowsForm extends AppPackageFormBase {
     this.packageOptions.targetDeviceFamilies = ['Desktop', 'Holographic'];
 
     this.customSelected = this.packageOptions.images?.backgroundColor != 'transparent';
-    this.initialBgColor = this.currentSelectedColor = (this.packageOptions.images?.backgroundColor as string);
+    this.currentSelectedColor = this.packageOptions.images?.backgroundColor!;
+    if(manifestContext?.manifest.background_color){
+      this.initialBgColor = manifestContext!.manifest.background_color;
+    } else {
+      this.initialBgColor = "#000000;"
+    }
   }
 
   toggleSettings(settingsToggleValue: 'basic' | 'advanced') {
@@ -327,7 +333,7 @@ export class WindowsForm extends AppPackageFormBase {
           <p class="sub-multi">Select your Windows icons background color</p>
           <sl-radio-group 
             id="icon-bg-radio-group" 
-            .value=${this.packageOptions!.images!.backgroundColor === 'transparent' ? 'transparent' : 'custom'}
+            .value=${'transparent'}
             @sl-change=${() => this.toggleIconBgRadios()}
           >
             <sl-radio class="color-radio" size="small" value="transparent">Transparent</sl-radio>
@@ -344,13 +350,17 @@ export class WindowsForm extends AppPackageFormBase {
   toggleIconBgRadios(){
     let input = (this.shadowRoot?.getElementById("icon-bg-radio-group") as any);
     let selected = input.value;
-    this.customSelected = selected !== 'transparent';
-    if(!this.customSelected){
+
+    // update values
+    if(this.customSelected){
       this.packageOptions.images!.backgroundColor = 'transparent';
     } else {
       this.packageOptions.images!.backgroundColor = this.initialBgColor;
       this.currentSelectedColor = this.initialBgColor;
     }
+
+    // switch flag which will trigger update
+    this.customSelected = selected !== 'transparent';
   }
 
   render() {
@@ -524,7 +534,7 @@ export class WindowsForm extends AppPackageFormBase {
                     'https://learn.microsoft.com/en-us/windows/apps/design/style/iconography/app-icon-design#color-contrast',
                   inputId: 'icon-bg-color-input',
                   type: 'color',
-                  value: this.packageOptions.images!.backgroundColor || 'transparent',
+                  value: this.packageOptions.images?.backgroundColor!,
                   placeholder: 'transparent',
                   inputHandler: (val: string) => this.packageOptions.images!.backgroundColor = val,
                 })}

--- a/apps/pwabuilder/src/script/services/publish/windows-publish.ts
+++ b/apps/pwabuilder/src/script/services/publish/windows-publish.ts
@@ -140,7 +140,7 @@ export function createWindowsPackageOptionsFromManifest(
     manifest: manifest,
     images: {
       baseImage: icon?.src || '',
-      backgroundColor: manifest.background_color || 'transparent',
+      backgroundColor: 'transparent',
       padding: 0.0,
     },
     resourceLanguage: languages,


### PR DESCRIPTION
fixes https://github.com/pwa-builder/PWABuilder/issues/4401
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
Manifest background color is default for icon background

## Describe the new behavior?
Transparent is default for icon background

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
This PR also disables the ability to generate screenshots as we feel generating base64 strings into peoples manifest is creating an inefficient system and people don't understand why its inefficient and trusting that PWABuilder is doing the right thing when it isn't. Part of the temporary solution described here https://github.com/pwa-builder/PWABuilder/issues/4550