### PR TITLE
[SITE] #4573: Added campaign referrer tracking to PWABuilder front end

### DIFF
--- a/apps/pwabuilder/src/app-index.ts
+++ b/apps/pwabuilder/src/app-index.ts
@@ -97,7 +97,6 @@ export class AppIndex extends LitElement {
     window.addEventListener('vaadin-router-location-changed', ev => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
 
-
       recordPageView(
         ev.detail.location.pathname, // path
         ev.detail.location.route?.component // page name

--- a/apps/pwabuilder/src/app-index.ts
+++ b/apps/pwabuilder/src/app-index.ts
@@ -126,33 +126,19 @@ export class AppIndex extends LitElement {
     // Remove leading slash if present
     this.pageName = pathname.replace(/^\//, '');
 
-    const pages: string[] = [
-      "reportcard",
-      "freetoken",
-      "congratulations",
-      "portals",
-      "imagegenerator"
-    ]
-
-    // safety in case we type a string above without lowercase for comparison
-    const lowercasePages: string[] = pages.map(page => page.toLowerCase());
-
-    // Detect the current page and set the title
-    const path = this.pageName.toLocaleLowerCase();
-    if (path.toLowerCase().includes(lowercasePages[0])) {
-      this.setPageTitle('Report Card');
-    } else if (path.toLowerCase().includes(lowercasePages[1])) {
-      this.setPageTitle('Free Token');
-    } else if (path.toLowerCase().includes(lowercasePages[2])) {
-      this.setPageTitle('Congratulations');
-    } else if (path.toLowerCase().includes(lowercasePages[3])) {
-      this.setPageTitle('Portals');
-    } else if (path.toLowerCase().includes(lowercasePages[4])) {
-      this.setPageTitle('Image Generator');
-    } else {
-      this.setPageTitle('Home'); // Default title
+    type PageMap = {
+      [key: string]: string
     }
 
+    const pages: PageMap = {
+      'reportcard': 'Report Card',
+      'freetoken': 'Free Token',
+      'congratulations': 'Congratulations',
+      'portals': 'Portals',
+      'imagegenerator': 'Image Generator'
+    }
+
+    this.setPageTitle(pages[this.pageName.toLocaleLowerCase()] || 'Home');
   }
 
    // Function to set the page title dynamically

--- a/apps/pwabuilder/src/app-index.ts
+++ b/apps/pwabuilder/src/app-index.ts
@@ -9,7 +9,7 @@ import './script/components/app-header';
 import './script/components/app-button';
 //import './script/components/cookie-banner';
 import './script/components/discord-box';
-import { recordPageView } from './script/utils/analytics';
+import { recordPageView, storeQueryParam } from './script/utils/analytics';
 
 @customElement('app-index')
 export class AppIndex extends LitElement {
@@ -92,8 +92,11 @@ export class AppIndex extends LitElement {
   constructor() {
     super();
 
+    storeQueryParam('ref');
+
     window.addEventListener('vaadin-router-location-changed', ev => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
+
 
       recordPageView(
         ev.detail.location.pathname, // path
@@ -115,7 +118,7 @@ export class AppIndex extends LitElement {
   }
 
   handlePageChange = () => {
-    
+
     var urlObj = new URL(location.href);
 
     // Get the pathname (page name)

--- a/apps/pwabuilder/src/script/pages/app-report.api.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.api.ts
@@ -71,10 +71,11 @@ export type AuditServiceWorkerResult = {
 export async function Report(
 	url: string
   ): Promise<ReportAudit> {
+	const referrer = sessionStorage.getItem('ref');
 	const fetchReport = await fetch(
 		`${
 			env.api
-		}/Report?site=${encodeURIComponent(url)}&desktop=true`,
+		}/Report?site=${encodeURIComponent(url)}&desktop=true${referrer ? '&ref=' + encodeURIComponent(referrer) : ''}`,
 		{
 			headers: new Headers(getHeaders())
 		}

--- a/apps/pwabuilder/src/script/services/publish/android-publish.ts
+++ b/apps/pwabuilder/src/script/services/publish/android-publish.ts
@@ -20,7 +20,8 @@ export async function generateAndroidPackage(androidOptions: AndroidPackageOptio
 
   let headers = {...getHeaders(), 'content-type': 'application/json' };
 
-  const generateAppUrl = `${env.androidPackageGeneratorUrl}/generateAppPackage`;
+  const referrer = sessionStorage.getItem('ref');
+  const generateAppUrl = `${env.androidPackageGeneratorUrl}/generateAppPackage${referrer ? '?ref=' + encodeURIComponent(referrer) : ''}`;
   const response = await fetch(generateAppUrl, {
     method: 'POST',
     body: JSON.stringify(androidOptions),

--- a/apps/pwabuilder/src/script/services/publish/ios-publish.ts
+++ b/apps/pwabuilder/src/script/services/publish/ios-publish.ts
@@ -27,7 +27,6 @@ export async function generateIOSPackage(
   });
 
   if (!createPackageResponse.ok) {
-
     const responseText = await createPackageResponse.text();
 
     let err = new Error(

--- a/apps/pwabuilder/src/script/services/publish/ios-publish.ts
+++ b/apps/pwabuilder/src/script/services/publish/ios-publish.ts
@@ -18,7 +18,8 @@ export async function generateIOSPackage(
 
   let headers = {...getHeaders(), 'content-type': 'application/json' };
 
-  const createPackageUrl = `${env.iosPackageGeneratorUrl}`;
+  const referrer = sessionStorage.getItem('ref');
+  const createPackageUrl = `${env.iosPackageGeneratorUrl}${referrer ? '?ref=' + encodeURIComponent(referrer) : ''}`;
   const createPackageResponse = await fetch(createPackageUrl, {
     method: 'POST',
     body: JSON.stringify(options),
@@ -26,7 +27,7 @@ export async function generateIOSPackage(
   });
 
   if (!createPackageResponse.ok) {
-    
+
     const responseText = await createPackageResponse.text();
 
     let err = new Error(

--- a/apps/pwabuilder/src/script/services/publish/oculus-publish.ts
+++ b/apps/pwabuilder/src/script/services/publish/oculus-publish.ts
@@ -36,7 +36,6 @@ export async function generateOculusPackage(
     Object.defineProperty(createPackageResponse, "stack_trace", {value: responseText});
     //@ts-ignore
     err.response = createPackageResponse;
-
     throw err;
   }
 

--- a/apps/pwabuilder/src/script/services/publish/oculus-publish.ts
+++ b/apps/pwabuilder/src/script/services/publish/oculus-publish.ts
@@ -27,7 +27,6 @@ export async function generateOculusPackage(
   });
 
   if (!createPackageResponse.ok) {
-
     const responseText = await createPackageResponse.text();
 
     let err = new Error(

--- a/apps/pwabuilder/src/script/services/publish/oculus-publish.ts
+++ b/apps/pwabuilder/src/script/services/publish/oculus-publish.ts
@@ -34,7 +34,6 @@ export async function generateOculusPackage(
       `Error generating Oculus package.\nStatus code: ${createPackageResponse.status}\nError: ${createPackageResponse.statusText}\nDetails: ${responseText}`
     );
 
-
     Object.defineProperty(createPackageResponse, "stack_trace", {value: responseText});
     //@ts-ignore
     err.response = createPackageResponse;

--- a/apps/pwabuilder/src/script/services/publish/oculus-publish.ts
+++ b/apps/pwabuilder/src/script/services/publish/oculus-publish.ts
@@ -18,7 +18,8 @@ export async function generateOculusPackage(
 
   let headers = {...getHeaders(), 'content-type': 'application/json' };
 
-  const createPackageUrl = `${env.oculusPackageGeneratorUrl}`;
+  const referrer = sessionStorage.getItem('ref');
+  const createPackageUrl = `${env.oculusPackageGeneratorUrl}${referrer ? '?ref=' + encodeURIComponent(referrer) : ''}`;
   const createPackageResponse = await fetch(createPackageUrl, {
     method: 'POST',
     body: JSON.stringify(options),
@@ -26,18 +27,18 @@ export async function generateOculusPackage(
   });
 
   if (!createPackageResponse.ok) {
-    
+
     const responseText = await createPackageResponse.text();
 
     let err = new Error(
       `Error generating Oculus package.\nStatus code: ${createPackageResponse.status}\nError: ${createPackageResponse.statusText}\nDetails: ${responseText}`
     );
-    
+
 
     Object.defineProperty(createPackageResponse, "stack_trace", {value: responseText});
     //@ts-ignore
     err.response = createPackageResponse;
-    
+
     throw err;
   }
 

--- a/apps/pwabuilder/src/script/services/publish/windows-publish.ts
+++ b/apps/pwabuilder/src/script/services/publish/windows-publish.ts
@@ -23,7 +23,7 @@ export async function generateWindowsPackage(
   // sets en-us as the default fallback
   if(!windowsOptions.resourceLanguage || windowsOptions.resourceLanguage.length === 0){
     windowsOptions.resourceLanguage = 'en-us';
-  } 
+  }
   // the api expects a comma separated string instead of a list, so we do it this way
   else {
     if(typeof(windowsOptions.resourceLanguage) != "string"){
@@ -41,19 +41,18 @@ export async function generateWindowsPackage(
 
   let headers = {...getHeaders(), 'content-type': 'application/json' };
 
-  //console.info('Before fetching windows package');
-  const response = await fetch(`${env.windowsPackageGeneratorUrl}`, {
+  const referrer = sessionStorage.getItem('ref');
+  const response = await fetch(`${env.windowsPackageGeneratorUrl}${referrer ? '?ref=' + encodeURIComponent(referrer) : ''}`, {
     method: 'POST',
     body: JSON.stringify(windowsOptions),
     headers: new Headers(headers),
   });
-  //console.info('After fetching windows package', response);
+
   if (response.status === 200) {
     const data = await response.blob();
 
     //set generated flag
     hasGeneratedWindowsPackage = true;
-    //console.info('After fetching windows package', data);
     return data;
   } else {
     const responseText = await response.text();
@@ -64,7 +63,7 @@ export async function generateWindowsPackage(
       //@ts-ignore
       err.response = response;
     throw err;
-    
+
   }
 }
 

--- a/apps/pwabuilder/src/script/utils/analytics.ts
+++ b/apps/pwabuilder/src/script/utils/analytics.ts
@@ -5,7 +5,7 @@ import { env } from "./environment";
 
 export function recordPageView(uri: string, name?: string, properties?: any) {
   if (env.isProduction) {
-    analytics.recordPageView(uri, name, properties);
+    analytics.recordPageView(uri, name, appendReferrerProperty(properties));
   }
 }
 
@@ -31,7 +31,7 @@ export function recordPWABuilderProcessStep(
       }
 
       let processLabel = pageName + "." + processStep
-      
+
       recordProcessStep(scn, processLabel, stepType, additionalInfo);
     }
 }
@@ -42,12 +42,27 @@ export function recordProcessStep(
   stepType: analytics.AnalyticsBehavior.ProcessCheckpoint | analytics.AnalyticsBehavior.StartProcess | analytics.AnalyticsBehavior.ProcessCheckpoint | analytics.AnalyticsBehavior.CancelProcess | analytics.AnalyticsBehavior.CompleteProcess,
   additionalInfo?: {}) {
     if (env.isProduction) {
-      analytics.recordProcessStep(processName, processStep, stepType, additionalInfo);
+      analytics.recordProcessStep(processName, processStep, stepType, appendReferrerProperty(additionalInfo));
     }
 }
 
 export function recordPageAction(actionName: string, type: analytics.AnalyticsActionType, behavior: analytics.AnalyticsBehavior, properties?: { [key: string]: string | number | boolean | string[] | number[] | boolean[] | object }) {
   if (env.isProduction) {
-    analytics.recordPageAction(actionName, type, behavior, properties);
+    analytics.recordPageAction(actionName, type, behavior, appendReferrerProperty(properties));
   }
+}
+
+export function storeQueryParam(key: string): void {
+  const value = (new URLSearchParams(window.location.search)).get(key);
+  if(value) {
+    sessionStorage.setItem(key, value);
+  }
+}
+
+function appendReferrerProperty(properties: any): any {
+  const referrer = sessionStorage.getItem('ref');
+  if (referrer) {
+    properties.referrer = referrer;
+  }
+  return properties;
 }


### PR DESCRIPTION
fixes #4573 

Main Change:

On first visit to site, we now check for a `ref` query param and then store it in sessionStorage.
When making any calls to analytics or back end, check if we have stored a referrer value, and include it if we have.

Included changes:
- simplify page title setting logic

Marked as `DO-NOT-MERGE` as I still need to test some things and make sure back end PRs are merged first.