### PR TITLE
Fix: Persist referrer value in sessionStorage across URLs

### DIFF
--- a/apps/pwabuilder/src/script/pages/app-home.ts
+++ b/apps/pwabuilder/src/script/pages/app-home.ts
@@ -419,8 +419,12 @@ export class AppHome extends LitElement {
   }
 
   async firstUpdated() {
-    // Resetting for a new url
+    // Resetting for a new url, keep referrer value
+    const referrer = sessionStorage.getItem('ref');
     sessionStorage.clear();
+    if(referrer){
+      sessionStorage.setItem('ref', referrer);
+    }
     resetInitialManifest();
 
     const search = new URLSearchParams(location.search);
@@ -528,7 +532,7 @@ export class AppHome extends LitElement {
             </h1>
             <section id="content-grid" slot="grid-container">
               <div class="intro-grid-item">
-                <div class="grid-item-header">  
+                <div class="grid-item-header">
                   <a @click=${() => recordPWABuilderProcessStep("top.PWAStarter_clicked", AnalyticsBehavior.ProcessCheckpoint)} href="https://docs.pwabuilder.com/#/starter/quick-start" target="_blank" rel="noopener" aria-label="Start a new pwa, will open in separate tab">Start a new PWA</a>
                   <img src="/assets/new/arrow.svg" alt="arrow"/>
 
@@ -539,7 +543,7 @@ export class AppHome extends LitElement {
               </div>
 
               <div class="intro-grid-item">
-                <div class="grid-item-header">  
+                <div class="grid-item-header">
                   <a @click=${() => recordPWABuilderProcessStep("home.top.PWAStudio_clicked", AnalyticsBehavior.ProcessCheckpoint)} href="https://aka.ms/install-pwa-studio" target="_blank" rel="noopener" aria-label="Use dev tools, will open a separate tab">Use dev tools</a>
                   <img src="/assets/new/arrow.svg" alt="arrow"/>
                 </div>

--- a/apps/pwabuilder/src/script/pages/app-home.ts
+++ b/apps/pwabuilder/src/script/pages/app-home.ts
@@ -422,7 +422,7 @@ export class AppHome extends LitElement {
     // Resetting for a new url, keep referrer value
     const referrer = sessionStorage.getItem('ref');
     sessionStorage.clear();
-    if(referrer){
+    if( referrer ) {
       sessionStorage.setItem('ref', referrer);
     }
     resetInitialManifest();


### PR DESCRIPTION
Referrer value was being reset when revisiting homepage, it will now persist.