### PR TITLE
[FIX] #4584: Dismiss feedback messages when modal is closed

### DIFF
--- a/apps/pwabuilder/src/script/components/publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/publish-pane.ts
@@ -955,6 +955,7 @@ export class PublishPane extends LitElement {
     if(e.target === dialog){
       this.blob = undefined;
       this.generating = false;
+      this.feedbackMessages = [];
       await dialog!.hide();
       recordPWABuilderProcessStep("publish_pane_closed", AnalyticsBehavior.ProcessCheckpoint);
       document.body.style.height = "unset";
@@ -1049,7 +1050,7 @@ export class PublishPane extends LitElement {
         class=${classMap({noX: this.preventClosing, dialog: true})}
         @sl-hide=${(e: any) => this.hideDialog(e)}
         @sl-request-close=${(e:any) => this.handleRequestClose(e)}
-        noHeader 
+        noHeader
       >
         <div id="pp-frame-wrapper">
           <div id="pp-frame-content">


### PR DESCRIPTION
fixes #4584 

Feedback messages were persisting when package modal was closed, added a line to clear them out.