### PR TITLE
Quick Fix: make Code Editor read only

### DIFF
--- a/components/code-editor/src/code-editor.ts
+++ b/components/code-editor/src/code-editor.ts
@@ -7,8 +7,6 @@ import { getEditorState, emitter } from './utils/codemirror';
 import { resizeObserver } from './utils/events';
 import { Lazy, CodeEditorEvents, CodeEditorSyncEvent, increment } from './utils/helpers';
 
-//import { AnalyticsBehavior, recordPWABuilderProcessStep } from '../../../apps/pwabuilder/src/script/utils/analytics';
-
 @customElement('code-editor')
 export class CodeEditor extends LitElement {
   @property({

--- a/components/manifest-editor/src/components/manifest-code-form.ts
+++ b/components/manifest-editor/src/components/manifest-code-form.ts
@@ -53,7 +53,7 @@ export class ManifestCodeForm extends LitElement {
   render() {
     return html`
       <div id="code-holder">
-        <code-editor .startText=${prettyString(this.manifest)} .readOnly=${false}></code-editor>
+        <code-editor .startText=${prettyString(this.manifest)} .readOnly=${true}></code-editor>
       </div>
       ${this.showCopyToast ? html`<app-toast>Manifest Copied to Clipboard</app-toast>` : html``}
     `;


### PR DESCRIPTION
Reduce confusion by making code editor read only.