### PR TITLE
[CLI] Small analytics update to CLI

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pwabuilder/cli",
-  "version": "0.0.16",
+  "version": "0.0.18",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/apps/cli/src/analytics/usage-analytics.ts
+++ b/apps/cli/src/analytics/usage-analytics.ts
@@ -12,6 +12,10 @@ export interface CreateEventData {
   template: string
 }
 
+export interface MessageShowEventData {
+  label: string
+}
+
 export interface PWABuilderData {
   user: {
     id: string
@@ -121,23 +125,37 @@ function spawnAnalyticsProcess(event: string, properties?: any) {
   child.unref();
 }
 
+function getThisPackageVersion(): string {
+  return require("../../package.json").version;
+}
+
+function appendPackageVersionToEventData(eventData: object): object {
+  var versionAppendedEventData: object = eventData;
+  versionAppendedEventData['version'] = getThisPackageVersion();
+  return versionAppendedEventData;
+}
+
 function resolveNodeSpawnArgs(event: string, properties?: any): string [] {
   const scriptPath: string = path.resolve(__dirname, 'track-events.js')
   return properties ? [scriptPath, event, JSON.stringify(properties)] : [scriptPath, event];
 }
 
 export function trackErrorWrapper(_error: Error): void {
-  spawnAnalyticsProcess('error', {error: _error});
+  spawnAnalyticsProcess('error', {error: _error, version: getThisPackageVersion()});
 }
 
 export function trackCreateEventWrapper(createEventData: CreateEventData): void {
-  spawnAnalyticsProcess('create', createEventData);
+  spawnAnalyticsProcess('create', appendPackageVersionToEventData(createEventData));
 }
 
 export function trackBuildEventWrapper(): void {
-  spawnAnalyticsProcess('build');
+  spawnAnalyticsProcess('build', {version: getThisPackageVersion()});
 }
 
 export function trackStartEventWrapper(): void {
-  spawnAnalyticsProcess('start');
+  spawnAnalyticsProcess('start', {version: getThisPackageVersion()});
+}
+
+export function trackMessageShowEventWrapper(messageShowEventData: MessageShowEventData): void {
+  spawnAnalyticsProcess('messageShow', appendPackageVersionToEventData(messageShowEventData));
 }

--- a/apps/cli/src/util/campaignUtil.ts
+++ b/apps/cli/src/util/campaignUtil.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import * as fs from 'fs';
 import { doesFileExist } from '../util/fileUtil';
-import { PWABuilderData, createUserDataAndWrite } from '../analytics/usage-analytics';
+import { PWABuilderData, createUserDataAndWrite, trackMessageShowEventWrapper } from '../analytics/usage-analytics';
 import { outputMessage } from './util';
 import { formatCodeSnippet, formatEmphasis, formatEmphasisStrong } from './textUtil';
 import * as prompts from "@clack/prompts";
@@ -63,7 +63,8 @@ function handleShowCampaign(userData: PWABuilderData, campaign: Campaign) {
         outputMessage(campaign.displayText);
         campaign.displayed = true;
         userDataWithCampaign.campaignMap[campaign.name] = campaign;
-        rewritePWABuilderDataFile(userDataWithCampaign)
+        trackMessageShowEventWrapper({label: campaign.name});
+        rewritePWABuilderDataFile(userDataWithCampaign);
     }
 }
 


### PR DESCRIPTION
Changes:
- Track `MessageShow` event with `label` attribute for campaign tracking (like for whisper)
- appended the `version` property to all analytics events to keep track of CLI versioning