### PR TITLE
fix: playwright tests

### DIFF
--- a/apps/pwabuilder/playwright.config.ts
+++ b/apps/pwabuilder/playwright.config.ts
@@ -12,7 +12,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './tests',
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: (process.env.CI ? 30 : 50) * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/apps/pwabuilder/playwright.config.ts
+++ b/apps/pwabuilder/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: process.env.CI ? 'https://preview.pwabuilder.com': 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/apps/pwabuilder/tests/basic.spec.ts
+++ b/apps/pwabuilder/tests/basic.spec.ts
@@ -1,10 +1,8 @@
 import { test, expect } from '@playwright/test';
 
-const url = 'https://preview.pwabuilder.com/';
-
 // before each test
 test.beforeEach(async ({ page }) => {
-    await page.goto(url);
+    await page.goto('/');
 });
 
 test('ensure application loads home page', async ({ page }) => {

--- a/apps/pwabuilder/tests/packaging.spec.ts
+++ b/apps/pwabuilder/tests/packaging.spec.ts
@@ -2,11 +2,10 @@ import { test, expect, Page } from '@playwright/test';
 
 let currentPage: Page | undefined;
 
-const url = 'https://preview.pwabuilder.com/';
 // before each test
 test.beforeEach(async ({ page }) => {
   currentPage = page;
-  await page.goto(url);
+  await page.goto('/');
 });
 
 // only run this test once
@@ -49,15 +48,12 @@ test('Ensure demo app can be packaged for Windows', async ({ page }) => {
 
   await expect(generateButton).toBeVisible();
 
-  // wait on request to https://pwabuilder-windows-docker.azurewebsites.net/msix/generatezip to finish
-  const pageRequest = page.waitForRequest(
-    'https://pwabuilder-windows-docker.azurewebsites.net/msix/generatezip'
-  );
+  // wait on request to finish
+  const pageRequest = page.waitForRequest('https://pwabuilder-windows-docker-dev.azurewebsites.net/msix/generatezip');
   await generateButton.click();
   const request = await pageRequest;
 
-  // wait for response to https://pwabuilder-windows-docker.azurewebsites.net/msix/generatezip to finish
-
+  // wait for response to finish
   const response = await request.response();
 
   if (response) {

--- a/apps/pwabuilder/tests/report-card.spec.ts
+++ b/apps/pwabuilder/tests/report-card.spec.ts
@@ -2,11 +2,10 @@ import { test, expect, Page } from '@playwright/test';
 
 let currentPage: Page | undefined;
 
-const url = 'https://preview.pwabuilder.com';
 // before each test
 test.beforeEach(async ({ page }) => {
     currentPage = page;
-    await page.goto(url);
+    await page.goto('/');
 });
 
 


### PR DESCRIPTION
## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes 
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
The existing `npm run tests` is using a hardcoded URL mapped to https://preview.pwabuilder.com/reportcard?site=https://webboard.app which isn't working (outdated env variable) and also doesn't help validate **localhost**.


## Describe the new behavior?
Keep existing setup for CI, and allow localhost sanity check run for devs.

![image](https://github.com/user-attachments/assets/dfe6f953-9a50-4061-a1fa-aaa35c28e16e)


## PR Checklist

- [X] Test: run `npm run test` and ensure that all tests pass
- [X] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [X] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
