### PR TITLE
fix(libraries): Update tooltip description for share_target.extra-step

### DIFF
--- a/libraries/manifest-information/src/index.ts
+++ b/libraries/manifest-information/src/index.ts
@@ -599,7 +599,7 @@ export const manifest_fields: { [field: string]: infoPanel } = {
   },
   "share_target.extra-step": {
     description: [
-      `When a user selects your app in the system's share dialog, your PWA is launched, and a HTTP request is made to the provided URL. You will need to add this scriot to your SW.`,
+      `When a user selects your app in the system's share dialog, your PWA is launched, and a HTTP request is made to the provided URL. You will need to add this script to your SW.`,
     ],
     purpose: null,
     example: null,


### PR DESCRIPTION
Fix a typo in the tooltip content present in the description for share_target.extra-step.

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
- Documentation content changes
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
This pull request will fix a typo in the tooltip content for handling receiving share data in your code within Share Target present within the Edit your manifest modal. The typo is present in the last sentence of the tooltip content, which currently reads:

> You will need to add this scriot to your SW.


## Describe the new behavior?
This PR will correct the typo to:

> You will need to add this script to your SW.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
