### PR TITLE
clean up wording of vs code manifest creation popup

### DIFF
--- a/apps/pwabuilder-vscode/src/services/manifest/manifest-service.ts
+++ b/apps/pwabuilder-vscode/src/services/manifest/manifest-service.ts
@@ -18,7 +18,7 @@ export async function generateManifest(skipPrompts?: boolean) {
   }
   else {
     maniAnswer = await vscode.window.showInformationMessage(
-      "PWABuilder Studio will generate your Web Manifest, first, you will need to choose where to save your manifest.json file.",
+      "PWABuilder Studio will generate your Web Manifest. First, you will need to choose where to save your manifest.json file.",
       {
         title: "Ok",
       },


### PR DESCRIPTION
## PR Type
<!-- - Documentation content changes -->

## Describe the current behavior?
The popup is:       "PWABuilder Studio will generate your Web Manifest, first, you will need to choose where to save your manifest.json file.", which doesn't read very well.


## Describe the new behavior?
Clearer grammar

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
