### PR TITLE
fix service worker registration timeout #4553

### DIFF
--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -2274,14 +2274,11 @@ export class AppReport extends LitElement {
         const prevResult = reducerServiceWorkerResult[value.member!];
 
         //Validate if the service worker result has changed for some reason
-        if (value.member == 'has_service_worker' && prevResult && prevResult.result != value.result) {
+        if (value.member == 'has_service_worker' && prevResult && prevResult.result && !value.result ) {
           this.showServiceWorkerWarningBanner = true;
+          return prevResult;
         }
 
-        //Should we merge the results?
-        if (prevResult) {
-          return {...value, ...prevResult};
-        }
         return value;
       });
 

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -2110,8 +2110,6 @@ export class AppReport extends LitElement {
     this.filteredTodoItems = this.allTodoItems;
 
     FindServiceWorker(url).then( async (result) => {
-      console.log('#########FIND SERVICE WORKER', result);
-      console.log('#########PREV DATA REPORT AUDIT', this.reportAudit?.audits?.serviceWorker);
         if (result?.content?.url && !this.reportAudit?.audits?.serviceWorker?.score) {
           await AuditServiceWorker(result.content.url).then( async (result) => {
             console.log("content:", result.content);
@@ -2273,7 +2271,7 @@ export class AppReport extends LitElement {
       },{});
 
       this.serviceWorkerResults = serviceWorkerResults.map((value) => {
-        const prevResult = reducerServiceWorkerResult[value.member];
+        const prevResult = reducerServiceWorkerResult[value.member!];
 
         //Validate if the service worker result has changed for some reason
         if (value.member == 'has_service_worker' && prevResult && prevResult.result != value.result) {

--- a/apps/pwabuilder/src/script/utils/interfaces.ts
+++ b/apps/pwabuilder/src/script/utils/interfaces.ts
@@ -161,6 +161,7 @@ export interface TestResult {
   infoString: string;
   result: boolean;
   category: string;
+  member: string;
 }
 
 export interface OrganizedResults {

--- a/apps/pwabuilder/src/script/utils/interfaces.ts
+++ b/apps/pwabuilder/src/script/utils/interfaces.ts
@@ -161,7 +161,7 @@ export interface TestResult {
   infoString: string;
   result: boolean;
   category: string;
-  member: string;
+  member?: string;
 }
 
 export interface OrganizedResults {


### PR DESCRIPTION
fixes #4553 
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
When a page has the service worker resource but does not register it properly on the page, the `AuditServiceWorker` request works properly but the page's `Report` request returns that there is no service worker, this generates a race condition and mismatch where it first appears that the page has a service worker and then (with the second request) updates the status to show that no service worker was found.

## Describe the new behavior?
A warning banner notifies that a mismatch has been found, possibly pointing to an incorrect registration of the service worker.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
