### PR TITLE
add suitable icon validation in manifest tests #4445

### DIFF
--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -39,6 +39,7 @@ import { manifest_fields } from '@pwabuilder/manifest-information';
 import { SlDropdown } from '@shoelace-style/shoelace';
 import { processManifest, processSecurity, processServiceWorker } from './app-report.helper';
 import { Report, ReportAudit, FindWebManifest, FindServiceWorker, AuditServiceWorker } from './app-report.api';
+import { findBestAppIcon } from '../utils/icons';
 
 const valid_src = "/assets/new/valid.svg";
 const yield_src = "/assets/new/yield.svg";
@@ -2191,8 +2192,12 @@ export class AppReport extends LitElement {
       todos.push({"card": "mani-details", "field": "Open Manifest Modal", "fix": "Edit and download your created manifest (Manifest not found before detection tests timed out)", "status": "missing"});
     }
 
-    manifest = JSON.parse(sessionStorage.getItem("PWABuilderManifest")!).manifest;
+    manifest = getManifestContext().manifest;
     this.validationResults = await validateManifest(manifest, true);
+
+    const icon = findBestAppIcon(manifest.icons);
+    this.validationResults.push({infoString: "Icons are used to create packages for different stores and must meet certain formatting requirements.", displayString: "Manifest has suitable icons", category: 'required', member: 'suitable-icons', valid: !!icon, errorString: "Can't find a suitable icon to use for the package stores. Ensure your manifest has a square, large (512x512 or better) PNG icon; Check if the proposed any or maskable is set. And if the format of the image matches the mimetype.", testRequired: true, quickFix: true});
+
 
     //  This just makes it so that the valid things are first
     // and the invalid things show after.


### PR DESCRIPTION
fixes #4445
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
For certain pages where the icon configuration has inconsistencies in the manifest. It passes certain sets of tests but fails in the validations executed in the views to generate the packages for the stores.

We leave a [link](https://www.pwabuilder.com/reportcard?site=https://southworks.github.io/paeonia-pwa-app-demo/) to the report of a test page where we play with the configuration of the manifest and we can replicate different scenarios.

## Describe the new behavior?
We standardized the tests to include the same icon validations that the stores package generation executes when validating the manifest and in case of inconsistencies it blocks the “Package for Stores” button. Where also appears in the Actions Items the detailed error. And in the manifest details a specific check of “Manifest has suitable icons” in addition to simply validate if it has icons.

A validation was also added to check that the file extension matches the mimetype if provided.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
