### PR TITLE
Removes duplicate analytics code

### DIFF
--- a/apps/pwabuilder/index.html
+++ b/apps/pwabuilder/index.html
@@ -48,8 +48,6 @@
 <body>
   <app-index></app-index>
   <span id="pageTitle"></span> <!-- Add this line -->
-  <!-- for analytics -->
-  <script type="text/javascript" src="https://az416426.vo.msecnd.net/scripts/c/ms.analytics-web-2.min.js"></script>
   <script>
     navigator.serviceWorker.getRegistrations().then((registrations) => {
       for(const registration of registrations) {


### PR DESCRIPTION
Removes the duplicate analytics import code.

Home page will load analytics async and append to head. But we also had analytics script in the body, resulting in duplicate. This PR removes the analytics load in the body.

## PR Type
Bugfix