### PR TITLE
fix unexpected close dialog when a tooltip is open and escape key is pressed #4262

### DIFF
--- a/apps/pwabuilder/src/script/components/manifest-editor-frame.ts
+++ b/apps/pwabuilder/src/script/components/manifest-editor-frame.ts
@@ -24,6 +24,7 @@ export class ManifestEditorFrame extends LitElement {
   @state() manifest: Manifest = {};
   @state() manifestURL: string = '';
   @state() baseURL: string = '';
+  @state() tooltipOpen: boolean = false;
 
   static get styles() {
     return [
@@ -244,12 +245,24 @@ export class ManifestEditorFrame extends LitElement {
 
   // hides modal
   async hideDialog(e: any){
-    let dialog: any = this.shadowRoot!.querySelector(".dialog");
+    const dialog: any = this.shadowRoot!.querySelector(".dialog");
     if(e.target === dialog){
       await dialog!.hide();
       recordPWABuilderProcessStep("manifest_editor_closed", AnalyticsBehavior.ProcessCheckpoint);
       document.body.style.height = "unset";
     }
+  }
+
+  async openDialog(){
+    document.body.style.height = "100vh"
+    const dialog = this.shadowRoot!.querySelector(".dialog");
+
+    dialog?.removeEventListener('sl-request-close', () => {});
+    dialog?.addEventListener('sl-request-close', (event: any) => {
+      if (event.detail.source === 'keyboard' && this.tooltipOpen) {
+          event.preventDefault();
+      }
+    }, { once: true });
   }
 
   /* Next functions are for analytics */
@@ -290,7 +303,7 @@ export class ManifestEditorFrame extends LitElement {
 
   render() {
     return html`
-      <sl-dialog class="dialog" @sl-show=${() => document.body.style.height = "100vh"} @sl-hide=${(e: any) => this.hideDialog(e)} noHeader>
+      <sl-dialog class="dialog" @sl-show=${() => this.openDialog()} @sl-hide=${(e: any) => this.hideDialog(e)} noHeader>
         <div id="frame-wrapper">
           <div id="frame-content">
             <div id="frame-header">
@@ -310,6 +323,7 @@ export class ManifestEditorFrame extends LitElement {
               @generateScreenshotsAttempted=${(e: CustomEvent) => this.handleImageGeneration(e, "screenshots")}
               @uploadIcons=${() => this.handleUploadIcon()}
               @generateIconsAttempted=${(e: CustomEvent) => this.handleImageGeneration(e, "icons")}
+              @trigger-hover=${(e: CustomEvent) => this.tooltipOpen = e.detail.entering}
             ></pwa-manifest-editor>
             
           </div>


### PR DESCRIPTION
fixes #4262 
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->
When the manifest modal is opened, it has icons that open a tooltip to give more detail about the field to be filled. If escape is pressed when a tooltip is open, it closes the modal along with the tooltip. When the intention would be that only the tooltip is closed.

## Describe the new behavior?
When there is a tooltip open in the manifest dialog, and the escape key is pressed, it just closes the tooltip, and in case there is no tooltip open, it closes the dialog as expected.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
