### PR TITLE
validate manifest images exist #4669

### DIFF
--- a/apps/pwabuilder/src/script/pages/app-report.api.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.api.ts
@@ -1,3 +1,4 @@
+import { Validation } from '@pwabuilder/manifest-validation';
 import { env } from '../utils/environment';
 import { getHeaders } from '../utils/platformTrackingHeaders';
 
@@ -27,6 +28,9 @@ export type ReportAudit = {
 		splashScreen: { score: boolean },
 		themedOmnibox: { score: boolean },
 		viewport: { score: boolean }
+		images: {
+			score: boolean, details: { iconsValidation?: Validation, screenshotsValidation?: Validation }
+		}
 	},
 	artifacts: {
 		webAppManifest: {

--- a/apps/pwabuilder/src/script/pages/app-report.helper.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.helper.ts
@@ -1,4 +1,4 @@
-import { Manifest } from '@pwabuilder/manifest-validation';
+import { Manifest, Validation } from '@pwabuilder/manifest-validation';
 import { ManifestContext, TestResult } from '../utils/interfaces';
 import { createManifestContextFromEmpty } from '../services/manifest';
 import { ReportAudit } from './app-report.api';
@@ -105,4 +105,17 @@ export function processServiceWorker(serviceWorker?: ReportAudit['audits']['serv
 	];
 
 	return organizedResults;
-  }
+}
+
+export function processImages(
+	audits?: ReportAudit['audits']
+): Array<Validation> {
+	const iconsValidation = audits?.images?.details?.iconsValidation;
+	const screenshotValidation = audits?.images?.details?.screenshotsValidation;
+
+	const results = [iconsValidation, screenshotValidation].filter(
+		(v): v is Validation => v !== undefined
+	);
+
+	return results;
+}

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -133,8 +133,8 @@ export class AppReport extends LitElement {
   @state() showSecurityWarningBanner: boolean = false;
   @state() securityIssues: string[] = [];
 
-  @state() showIconsWarningBanner: boolean = false;
-  @state() showScreenshotsWarningBanner: boolean = false;
+  @state() showIconsErrorBanner: boolean = false;
+  @state() showScreenshotsErrorBanner: boolean = false;
 
   @state() showServiceWorkerWarningBanner: boolean = false;
 
@@ -2190,7 +2190,7 @@ export class AppReport extends LitElement {
     this.allTodoItems.push(...await this.testImages(processImages(this.reportAudit?.audits)));
 
     this.filteredTodoItems = this.allTodoItems;
-    this.canPackage = this.canPackageList[0] && this.canPackageList[1] && this.canPackageList[2];
+    this.canPackage = this.canPackageList[0] && this.canPackageList[1] && this.canPackageList[2] && this.canPackageList[3];
 
     this.runningTests = false;
     this.requestUpdate();
@@ -2398,13 +2398,15 @@ export class AppReport extends LitElement {
     imagesValidation.forEach((result: Validation) => {
       if (!result.valid) {
         if (result.member === "icons") {
-          this.showIconsWarningBanner = true;
+          this.showIconsErrorBanner = true;
         } else if (result.member === "screenshots") {
-          this.showScreenshotsWarningBanner = true;
+          this.showScreenshotsErrorBanner = true;
         }
-        todos.push({ "card": "mani-details", "field": result.member, "fix": result.errorString, "status": "recommended" });
+        todos.push({ "card": "mani-details", "field": result.member, "fix": result.errorString, "status": "required" });
       }
     });
+
+    this.canPackageList[3] = !(this.showSecurityErrorBanner || this.showScreenshotsErrorBanner);
 
     //save security tests in session storage
     sessionStorage.setItem('image_tests', JSON.stringify(imagesValidation));
@@ -3179,15 +3181,15 @@ export class AppReport extends LitElement {
             null
           }
 
-              ${this.showIconsWarningBanner ?
+              ${this.showIconsErrorBanner ?
             html`
-                  <div class="feedback-holder type-warning">
-                    <img src="/assets/new/yield.svg" alt="invalid result icon" />
+                  <div class="feedback-holder type-error">
+                  <img src="/assets/new/stop.svg" alt="invalid result icon" />
                     <div class="error-info">
                       <p class="error-title">Manifest icons could not be fetched</p>
-                      <p class="error-desc">PWABuilder has done a basic analysis of the manifest images and found issues. Check out the documentation linked below to learn more.</p>
+                      <p class="error-desc">PWABuilder has done a basic analysis of the manifest images and has identified required actions before you can package. Check out the documentation linked below to learn more.</p>
                       <div class="error-actions">
-                        <a href="https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/core-concepts/04" target="_blank" rel="noopener">Security Documentation</a>
+                        <a href="https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/core-concepts/03" target="_blank" rel="noopener">Manifest Documentation</a>
                       </div>
                     </div>
                   </div>
@@ -3195,15 +3197,15 @@ export class AppReport extends LitElement {
             null
           }
 
-              ${this.showScreenshotsWarningBanner ?
+              ${this.showScreenshotsErrorBanner ?
             html`
-                  <div class="feedback-holder type-warning">
-                    <img src="/assets/new/yield.svg" alt="invalid result icon" />
+                  <div class="feedback-holder type-error">
+                  <img src="/assets/new/stop.svg" alt="invalid result icon" />
                     <div class="error-info">
                       <p class="error-title">Manifest screenshots could not be fetched</p>
-                      <p class="error-desc">PWABuilder has done a basic analysis of the manifest images and found issues. Check out the documentation linked below to learn more.</p>
+                      <p class="error-desc">PWABuilder has done a basic analysis of the manifest images and has identified required actions before you can package. Check out the documentation linked below to learn more.</p>
                       <div class="error-actions">
-                        <a href="https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/core-concepts/04" target="_blank" rel="noopener">Security Documentation</a>
+                        <a href="https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/core-concepts/03" target="_blank" rel="noopener">Manifest Documentation</a>
                       </div>
                     </div>
                   </div>

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -45,7 +45,7 @@ import { AnalyticsBehavior, recordPWABuilderProcessStep } from '../utils/analyti
 import Color from "../../../node_modules/colorjs.io/dist/color";
 import { manifest_fields } from '@pwabuilder/manifest-information';
 import '@shoelace-style/shoelace/dist/components/dropdown/dropdown.js';
-import { processManifest, processSecurity, processServiceWorker } from './app-report.helper';
+import { processImages, processManifest, processSecurity, processServiceWorker } from './app-report.helper';
 import { Report, ReportAudit, FindWebManifest, FindServiceWorker, AuditServiceWorker } from './app-report.api';
 import { findBestAppIcon } from '../utils/icons';
 import SlDropdown from '@shoelace-style/shoelace/dist/components/dropdown/dropdown.js';
@@ -70,9 +70,9 @@ export class AppReport extends LitElement {
     iconURL: '/assets/new/icon_placeholder.png',
     iconAlt: 'Your sites logo'
   };
-  @property({ type: Object }) CardStyles = { backgroundColor: '#ffffff', color: '#292c3a'};
-  @property({ type: Object }) BorderStyles = { borderTop: '1px solid #00000033'};
-  @property({ type: Object }) LastEditedStyles = { color: '#000000b3'};
+  @property({ type: Object }) CardStyles = { backgroundColor: '#ffffff', color: '#292c3a' };
+  @property({ type: Object }) BorderStyles = { borderTop: '1px solid #00000033' };
+  @property({ type: Object }) LastEditedStyles = { color: '#000000b3' };
   @property() manifestCard = {};
   @property() serviceWorkerCard = {};
   @property() securityCard = {};
@@ -132,6 +132,9 @@ export class AppReport extends LitElement {
   @state() showSecurityErrorBanner: boolean = false;
   @state() showSecurityWarningBanner: boolean = false;
   @state() securityIssues: string[] = [];
+
+  @state() showIconsWarningBanner: boolean = false;
+  @state() showScreenshotsWarningBanner: boolean = false;
 
   @state() showServiceWorkerWarningBanner: boolean = false;
 
@@ -2184,6 +2187,8 @@ export class AppReport extends LitElement {
     // TODO: move installability score to different place
     this.allTodoItems.push(...await this.testServiceWorker(processServiceWorker(this.reportAudit?.audits?.serviceWorker, this.reportAudit!.audits!.offlineSupport))),
     this.allTodoItems.push(...await this.testSecurity(processSecurity(this.reportAudit?.audits)));
+    this.allTodoItems.push(...await this.testImages(processImages(this.reportAudit?.audits)));
+
     this.filteredTodoItems = this.allTodoItems;
     this.canPackage = this.canPackageList[0] && this.canPackageList[1] && this.canPackageList[2];
 
@@ -2383,6 +2388,26 @@ export class AppReport extends LitElement {
 
     //save security tests in session storage
     sessionStorage.setItem('security_tests', JSON.stringify(securityTests));
+    this.requestUpdate();
+    return todos;
+  }
+
+  async testImages(imagesValidation: Validation[]) {
+    let todos: unknown[] = [];
+
+    imagesValidation.forEach((result: Validation) => {
+      if (!result.valid) {
+        if (result.member === "icons") {
+          this.showIconsWarningBanner = true;
+        } else if (result.member === "screenshots") {
+          this.showScreenshotsWarningBanner = true;
+        }
+        todos.push({ "card": "mani-details", "field": result.member, "fix": result.errorString, "status": "recommended" });
+      }
+    });
+
+    //save security tests in session storage
+    sessionStorage.setItem('image_tests', JSON.stringify(imagesValidation));
     this.requestUpdate();
     return todos;
   }
@@ -3151,6 +3176,38 @@ export class AppReport extends LitElement {
                 </div>
               </div>
             ` :
+            null
+          }
+
+              ${this.showIconsWarningBanner ?
+            html`
+                  <div class="feedback-holder type-warning">
+                    <img src="/assets/new/yield.svg" alt="invalid result icon" />
+                    <div class="error-info">
+                      <p class="error-title">Manifest icons could not be fetched</p>
+                      <p class="error-desc">PWABuilder has done a basic analysis of your HTTPS setup and has identified required actions before you can package. Check out the documentation linked below to learn more.</p>
+                      <div class="error-actions">
+                        <a href="https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/core-concepts/04" target="_blank" rel="noopener">Security Documentation</a>
+                      </div>
+                    </div>
+                  </div>
+                ` :
+            null
+          }
+
+              ${this.showScreenshotsWarningBanner ?
+            html`
+                  <div class="feedback-holder type-warning">
+                    <img src="/assets/new/yield.svg" alt="invalid result icon" />
+                    <div class="error-info">
+                      <p class="error-title">Manifest screenshots could not be fetched</p>
+                      <p class="error-desc">PWABuilder has done a basic analysis of your HTTPS setup and has identified required actions before you can package. Check out the documentation linked below to learn more.</p>
+                      <div class="error-actions">
+                        <a href="https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/core-concepts/04" target="_blank" rel="noopener">Security Documentation</a>
+                      </div>
+                    </div>
+                  </div>
+                ` :
             null
           }
 

--- a/apps/pwabuilder/src/script/pages/app-report.ts
+++ b/apps/pwabuilder/src/script/pages/app-report.ts
@@ -3185,7 +3185,7 @@ export class AppReport extends LitElement {
                     <img src="/assets/new/yield.svg" alt="invalid result icon" />
                     <div class="error-info">
                       <p class="error-title">Manifest icons could not be fetched</p>
-                      <p class="error-desc">PWABuilder has done a basic analysis of your HTTPS setup and has identified required actions before you can package. Check out the documentation linked below to learn more.</p>
+                      <p class="error-desc">PWABuilder has done a basic analysis of the manifest images and found issues. Check out the documentation linked below to learn more.</p>
                       <div class="error-actions">
                         <a href="https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/core-concepts/04" target="_blank" rel="noopener">Security Documentation</a>
                       </div>
@@ -3201,7 +3201,7 @@ export class AppReport extends LitElement {
                     <img src="/assets/new/yield.svg" alt="invalid result icon" />
                     <div class="error-info">
                       <p class="error-title">Manifest screenshots could not be fetched</p>
-                      <p class="error-desc">PWABuilder has done a basic analysis of your HTTPS setup and has identified required actions before you can package. Check out the documentation linked below to learn more.</p>
+                      <p class="error-desc">PWABuilder has done a basic analysis of the manifest images and found issues. Check out the documentation linked below to learn more.</p>
                       <div class="error-actions">
                         <a href="https://microsoft.github.io/win-student-devs/#/30DaysOfPWA/core-concepts/04" target="_blank" rel="noopener">Security Documentation</a>
                       </div>


### PR DESCRIPTION
## fixes 
- #4669 

## PR Type
- Feature

## Describe the current behavior?
Images described in the manifest are not validated, thus they could not actually exist


## Describe the new behavior?
/Report tries to fetch (HEAD request with a fallback GET request) images described in the manifest and display package blocking error if they could not
![image](https://github.com/user-attachments/assets/77e6d395-a928-487e-aa65-0de2f0a7d0db)




## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
