### PR TITLE
Store and load store package form inputs #4609

### DIFF
--- a/apps/pwabuilder/src/script/utils/indexedDB.ts
+++ b/apps/pwabuilder/src/script/utils/indexedDB.ts
@@ -1,0 +1,47 @@
+async function getDB(objectStore: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open('pwa-db', 1);
+    request.onupgradeneeded = () => {
+      try {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(objectStore)) {
+          db.createObjectStore(objectStore);
+        }
+      } catch (err) {
+        reject(new Error('Failed to upgrade IndexedDB: ' + (err as Error).message));
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(new Error('Failed to open IndexedDB: ' + request.error));
+  });
+}
+
+export async function setDataInDB(objectStore: string, key: string, data: any) {
+  try {
+    const db = await getDB(objectStore);
+    return new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(objectStore, 'readwrite');
+      tx.objectStore(objectStore).put(data, key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(new Error(`Failed to save data to ${objectStore}: ` + tx.error));
+    });
+  } catch (err) {
+    console.error('setFormDataInDB error:', err);
+    throw err;
+  }
+}
+
+export async function getDataFromDB(objectStore: string, key: string): Promise<any | undefined> {
+  try {
+    const db = await getDB(objectStore);
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(objectStore, 'readonly');
+      const req = tx.objectStore(objectStore).get(key);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(new Error(`Failed to load data from ${objectStore}: ` + req.error));
+    });
+  } catch (err) {
+    console.error('getFormDataFromDB error:', err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## fixes 
- #4609

## PR Type
- Feature

## Describe the current behavior?
Some store package form inputs have to be manually input, thus needing to take note of previous values in case of new version packaging.

## Describe the new behavior?
All of the form inputs are stored with the indexedDB API, loading the inputs of previously edited forms. Save occurs on form back, form panel close and submit.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
