### PR TITLE
Fix icons validation #4945

### DIFF
--- a/apps/pwabuilder/src/script/utils/icons.ts
+++ b/apps/pwabuilder/src/script/utils/icons.ts
@@ -281,8 +281,9 @@ export class IconInfo {
 
   private getMimeTypeByExtension(): ImageFormat | null {
     const srcLower = this.icon.src?.toLowerCase() || '';
+    const srcParsed = srcLower.split('?')[0].split('#')[0];
     const extension = IconInfo.formats
-      .find(f => f.exts.some(ext => srcLower.endsWith(`.${ext}`)));
+      .find(f => f.exts.some(ext => srcParsed.endsWith(`.${ext}`)));
     return extension ?? null;
   }
 


### PR DESCRIPTION
## fixes 
- #4945

## PR Type
- Bugfix 

## Describe the current behavior?
Icons with src that have query parameters do not pass icon validation.

## Describe the new behavior?
Icons with query parameters or fragments are validated correctly

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
