### PR TITLE
support jks in signing key file input #4312

### DIFF
--- a/apps/pwabuilder/src/script/components/android-form.ts
+++ b/apps/pwabuilder/src/script/components/android-form.ts
@@ -852,7 +852,7 @@ export class AndroidForm extends AppPackageFormBase {
             id="signing-key-file-input"
             @change="${(e: Event) =>
               this.androidSigningKeyUploaded(e.target)}"
-            accept=".keystore"
+            accept=".keystore, .jks"
             required
           />
         </div>


### PR DESCRIPTION
fixes #4312

## PR Type
- Bugfix

## Describe the current behavior?
.jks files are not supported on the custom signing key file input

## Describe the new behavior?
added signing support with .jks files

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [ ] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
