### PR TITLE
Update the app store publishing docs

### DIFF
--- a/docs/builder/app-store.md
+++ b/docs/builder/app-store.md
@@ -68,12 +68,12 @@ To solve this you can run `pod repo update`, and then `pod update` if you alread
    
 5. Click `Product` > `Build` in Xcode to build your project.
 
-6. With the project opened in Xcode, click ▶️ to test your PWA in an iPhone simulator. You may also choose other iOS simulators to try our your app on those devices.
+6. With the project opened in Xcode, click ▶️ to test your PWA in an iPhone simulator. You may also choose other iOS simulators to try out your app on those devices.
 
 ## Adjusting Capabilities
 
-Under xcode `Signing & Capabilities` tab, check and disable all capabilites your app don't needed.
-Use only those that are actually involved in your application. This is important for passing publishing verification.  
+Select the `Project Navigator` tab. Select your application. Under the `Signing & Capabilities` tab, check and disable all capabilites your app does not needed.
+Use only those that are actually involved in your application. This is important for passing publishing verification.
 
 <div class="docs-image">
      <img src="/assets/builder/ios/signing-and-capabilities.jpg" alt="XCode Signing and Capabilities tab" width=500>
@@ -141,9 +141,9 @@ Next, you will need to use the Keychain Acess application to create a Certificat
 
 3. Enter your email address and your name. You may leave `CA Email Address` empty.
 
-5. Choose the `Saved to disk` option and select `Continue`.
+4. Choose the `Saved to disk` option and select `Continue`.
 
-6. You'll be prompted to save a `.certSigningRequest` file to disk.
+5. You'll be prompted to save a `.certSigningRequest` file to disk.
 
 #### 4. Create a Certificate
 
@@ -181,7 +181,7 @@ Next, you can use the certificate you created to create a Provisioning Profile:
 
 2. Select `Profiles` and select the `+` symbol to add a new profile.
 
-3. On the next page, select `App Store` under `Distribution` and click `Continue`.
+3. On the next page, select `App Store Connect` under `Distribution` and click `Continue`.
 
 4. You will be prompted to select an app ID, choose the Bundle ID you created in Step 2 and click `Continue`.
 
@@ -227,7 +227,7 @@ First, you'll need to **sign in to Xcode**:
 
 1. Click `Xcode` in the top menu bar.
 
-2. Click `Preferences`.
+2. Click `Settings`.
 
 3. Navigate to the `Accounts` panel.
 


### PR DESCRIPTION
There are a couple of typos along with some inaccurate and outdated information in the file `docs/builder/app-store.md`.

I discovered these while publishing my [PWA](https://www.wordgains.com) to the App Store. The instructions were still incredibly useful! Thank you!

Hope this helps.

List of fixes:
1. `try our your app` -> `try out your app`
2. `Signing & Capabilities` tab is not under xcode -> It is under`Project Navigator` where you select your application.
3. a numbered list had a skipped number
4. `App Store` is now called `App Store Connect` under `Distribution` in step `6. Create a Provisioning Profile`
5. `Preferences` is now called `Settings` on Mac

closes: #4968