### PR TITLE
Fixes bug where model state wasn't updated due to input event not firing

### DIFF
--- a/apps/pwabuilder/src/script/components/publish-pane.ts
+++ b/apps/pwabuilder/src/script/components/publish-pane.ts
@@ -1102,13 +1102,15 @@ export class PublishPane extends LitElement {
         if (form) {
           const data = await getDataFromDB(this.objectStore, this.getFormKey());
           if (data) {
-            Array.from(form.elements).forEach((el: any) => {
+            (Array.from(form.elements) as HTMLInputElement[]).forEach(el => {
               if (el.id && data.hasOwnProperty(el.id)) {
                 if (el.type === "checkbox" || el.type === "radio") {
                   el.checked = data[el.id];
                 } else {
                   el.value = data[el.id];
                 }
+
+                el.dispatchEvent(new Event('input', { bubbles: true })); // Trigger input event to update its model
               }
             });
           }


### PR DESCRIPTION
Fixes an issue where if you set custom values in packaging form, e.g. you set PackageID to something non-default in the Android Form, then closed the form and opened it again, the values in the UI would be set to your new package ID, but the underlying model wouldn't be set to the new value. Thus, the actual Android package you generated would be set to the original value.

This PR fixes that bug.

## PR Type
Bugfix