### PR TITLE
Fixes issue where analysis ID wasn't being propagated

### DIFF
--- a/apps/pwabuilder-google-play/services/packageJobQueue.ts
+++ b/apps/pwabuilder-google-play/services/packageJobQueue.ts
@@ -141,7 +141,7 @@ export class PackageJobQueue {
         return {
             id: id,
             pwaUrl: packageArgs.pwaUrl,
-            analysisId: null,
+            analysisId: packageArgs.analysisId ?? null,
             errors: [],
             logs: [],
             status: "Queued",

--- a/apps/pwabuilder/Frontend/src/script/pages/google-play-packaging-status.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/google-play-packaging-status.ts
@@ -4,15 +4,15 @@ import "../components/app-header";
 import { downloadGooglePlayPackageZip, enqueueGooglePlayPackageJob, getGooglePlayPackageJob } from "../services/publish/android-publish";
 import { GooglePlayPackageJob } from "../models/google-play-package-job";
 import { env } from "../utils/environment";
-import "@shoelace-style/shoelace/dist/components/textarea/textarea";
 import { googlePlayPackagingStatusStyles } from "./google-play-packaging-status.styles";
 import { AnalyticsBehavior, recordProcessStep } from "@pwabuilder/site-analytics";
 import { repeat } from "lit/directives/repeat.js";
-import "@shoelace-style/shoelace/dist/components/card/card";
-import "@shoelace-style/shoelace/dist/components/button/button";
+import "@shoelace-style/shoelace/dist/components/textarea/textarea.js";
+import "@shoelace-style/shoelace/dist/components/card/card.js";
+import "@shoelace-style/shoelace/dist/components/button/button.js";
+import "@shoelace-style/shoelace/dist/components/spinner/spinner.js";
+import "@shoelace-style/shoelace/dist/components/icon/icon.js";
 import { Router } from "@vaadin/router";
-import "@shoelace-style/shoelace/dist/components/spinner/spinner";
-import "@shoelace-style/shoelace/dist/components/icon/icon";
 import { packagingCompleted, packagingFailed } from "./app-report.api";
 
 /**


### PR DESCRIPTION
Fixes the analysis ID propagation in Google Play packaging service.

## PR Type
Bugfix

## Describe the current behavior?
`job.analysisId` is null at runtime.


## Describe the new behavior?
`job.analysisId` is populated.