### PR TITLE
Analyses expire at 14 days, or longer if packaged for stores

### DIFF
--- a/apps/pwabuilder/Controllers/AnalysesController.cs
+++ b/apps/pwabuilder/Controllers/AnalysesController.cs
@@ -127,7 +127,7 @@ public class AnalysesController : ControllerBase
         }
 
         analysis.AppStorePackages.Add(appStorePackage);
-        await this.analysisStore.SaveAsync(analysis);
+        await this.analysisStore.SaveAsync(analysis, expiration: TimeSpan.FromDays(365));
         return NoContent();
     }
 }

--- a/apps/pwabuilder/Services/AnalysisStore.cs
+++ b/apps/pwabuilder/Services/AnalysisStore.cs
@@ -23,8 +23,10 @@ public interface IAnalysisStore
     /// Saves an analysis.
     /// </summary>
     /// <param name="analysis">The analysis to save.</param>
+    /// <param name="expiration">Optional expiration timespan for the analysis. If not provided, a default expiration will be used based on the implementation.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>A task.</returns>
-    Task SaveAsync(Analysis analysis);
+    Task SaveAsync(Analysis analysis, TimeSpan? expiration = null, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -42,7 +44,7 @@ public sealed class InMemoryAnalysisStore : IAnalysisStore
     }
 
     /// <inheritdoc/>
-    public Task SaveAsync(Analysis analysis)
+    public Task SaveAsync(Analysis analysis, TimeSpan? expiration = null, CancellationToken cancellationToken = default)
     {
         analysis.LastModifiedAt = DateTimeOffset.UtcNow;
         analyses[analysis.Id] = analysis;
@@ -55,8 +57,7 @@ public sealed class InMemoryAnalysisStore : IAnalysisStore
 /// </summary>
 public sealed class CosmosAnalysisStore : IAnalysisStore
 {
-    // 13 months expressed as 395 days.
-    private static readonly int AnalysisTtlInSeconds = (int)TimeSpan.FromDays(365).TotalSeconds;
+    private static readonly int DefaultExpirationInSeconds = (int)TimeSpan.FromDays(14).TotalSeconds;
 
     private readonly ILogger<CosmosAnalysisStore> logger;
     private readonly Task<Container> containerTask;
@@ -94,15 +95,15 @@ public sealed class CosmosAnalysisStore : IAnalysisStore
     }
 
     /// <inheritdoc/>
-    public async Task SaveAsync(Analysis analysis)
+    public async Task SaveAsync(Analysis analysis, TimeSpan? expiration = null, CancellationToken cancellationToken = default)
     {
         try
         {
             var container = await containerTask;
             analysis.LastModifiedAt = DateTimeOffset.UtcNow;
 
-            var document = AnalysisCosmosDocument.Create(analysis, AnalysisTtlInSeconds);
-            await container.UpsertItemAsync(document, new PartitionKey(document.Id));
+            var document = AnalysisCosmosDocument.Create(analysis, expiration.HasValue ? (int)expiration.Value.TotalSeconds : DefaultExpirationInSeconds);
+            await container.UpsertItemAsync(document, new PartitionKey(document.Id), cancellationToken: cancellationToken);
             logger.LogInformation("Saved analysis {id} to Cosmos DB.", analysis.Id);
         }
         catch (Exception ex)


### PR DESCRIPTION
Analyses expire after 14 days by default, longer if packaged for app stores. This is intended to reduce the number of analyses we store.

## PR Type
Feature

## Describe the current behavior?
Currently, analyses are set to expire in 365 days.

## Describe the new behavior?
This PR changes the behavior so that if an analysis isn't packaged for app stores, we expire the analysis after 14 days.