### PR TITLE
AnalysisId and CreatedAt are included in stored package runs

### DIFF
--- a/apps/pwabuilder-microsoft-store/Models/PwaBuilderMsStorePackage.cs
+++ b/apps/pwabuilder-microsoft-store/Models/PwaBuilderMsStorePackage.cs
@@ -75,4 +75,21 @@ public class PwaBuilderMsStorePackage
     /// Version of the platform that generated the package.
     /// </summary>
     public string? PlatformIdVersion { get; set; }
+
+    /// <summary>
+    /// The timestamp when this document was created in CosmosDB.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// The optional ID of the PWABuilder analysis that was packaged for the Microsoft Store.
+    /// </summary>
+    public string? AnalysisId { get; set; }
+
+    /// <summary>
+    /// The time-to-live in seconds for this document in CosmosDB.
+    /// After this period elapses from the document's creation time, CosmosDB automatically deletes the document.
+    /// A value of -1 means the document never expires.
+    /// </summary>
+    public int Ttl { get; set; } = -1;
 }

--- a/apps/pwabuilder-microsoft-store/Models/WindowsAppPackageOptions.cs
+++ b/apps/pwabuilder-microsoft-store/Models/WindowsAppPackageOptions.cs
@@ -31,6 +31,11 @@ namespace PWABuilder.MicrosoftStore.Models
         public string Version { get; set; } = string.Empty;
 
         /// <summary>
+        /// The optional ID of the PWABuilder analysis that requested this app package generation.
+        /// </summary>
+        public string? AnalysisId { get; set; }
+
+        /// <summary>
         /// Whether the generated MSIX package will be signable. If false, the app won't be able to be submitted to the Store.
         /// </summary>
         public bool AllowSigning { get; set; }
@@ -273,7 +278,6 @@ namespace PWABuilder.MicrosoftStore.Models
                     {
                         errors.Add("TargetDeviceFamilies must contain only the following " + string.Join(", ", deviceFamilies));
                     }
-
                 }
             }
 

--- a/apps/pwabuilder-microsoft-store/Services/Analytics.cs
+++ b/apps/pwabuilder-microsoft-store/Services/Analytics.cs
@@ -58,7 +58,9 @@ namespace PWABuilder.MicrosoftStore
                 ErrorStack = error.StackTrace,
                 PackageId = packageOptions.PackageId,
                 PublisherDisplayName = packageOptions.Publisher?.DisplayName,
-                PublisherId = packageOptions.Publisher?.CommonName
+                PublisherId = packageOptions.Publisher?.CommonName,
+                AnalysisId = packageOptions.AnalysisId,
+                CreatedAt = DateTimeOffset.UtcNow
             };
             await TryRecordStorePackageCore(package, analyticsInfo);
         }
@@ -85,7 +87,9 @@ namespace PWABuilder.MicrosoftStore
                 ErrorStack = null,
                 PackageId = packageOptions.PackageId,
                 PublisherDisplayName = packageOptions.Publisher?.DisplayName,
-                PublisherId = packageOptions.Publisher?.CommonName
+                PublisherId = packageOptions.Publisher?.CommonName,
+                AnalysisId = packageOptions.AnalysisId,
+                CreatedAt = DateTimeOffset.UtcNow
             };
             await TryRecordStorePackageCore(package, analyticsInfo);
         }
@@ -94,6 +98,16 @@ namespace PWABuilder.MicrosoftStore
         {
             try
             {
+                // Packages stick around for 5 years for analytics purposes. If it's a test package, we expire in 1 year.
+                if (package.IsDevPackage)
+                {
+                    package.Ttl = (int)TimeSpan.FromDays(365).TotalSeconds;
+                }
+                else
+                {
+                    package.Ttl = (int)TimeSpan.FromDays(365 * 5).TotalSeconds;
+                }
+
                 SendAppInsightsEvent(package, analyticsInfo);
 
                 // Save to CosmosDB using the package's correlation ID as the partition key


### PR DESCRIPTION
Packaging a PWA for the Microsoft Store now includes analysis ID and creation date for analytics purposes.

## PR Type
Feature

## Describe the current behavior?
We currently don't associate a creation date or analysis ID when packaging for the Microsoft Store.

## Describe the new behavior?
We include creation date and PWABuilder analysis ID.