### PR TITLE
Job processing timeouts and better cleanup

### DIFF
--- a/apps/pwabuilder/Controllers/HealthController.cs
+++ b/apps/pwabuilder/Controllers/HealthController.cs
@@ -17,9 +17,10 @@ public class HealthController : ControllerBase
     }
 
     [HttpGet("check")]
-    public async Task<IActionResult> Check([FromServices] AnalysisJobProcessorHealthMonitor healthMonitor)
+    public async Task<IActionResult> Check([FromServices] AnalysisJobProcessorHealthMonitor healthMonitor, [FromServices] IPuppeteerService puppeteer)
     {
         var googlePlayPackageQueueLength = await healthMonitor.GetGooglePlayPackageQueueLength();
+        var openPageCount = await puppeteer.GetOpenPageCountAsync();
         var errorMessage = string.Empty;
         if (healthMonitor.JobProcessorStopped)
         {
@@ -28,6 +29,10 @@ public class HealthController : ControllerBase
         else if (healthMonitor.AnalysisQueueLength > 500)
         {
             errorMessage = $"There are {healthMonitor.AnalysisQueueLength} analysis jobs in the queue. This may indicate a severe problem with the AnalysisJobProcessor background service. Check the queue length and monitor it to ensure it's not growing too large.";
+        }
+        else if (openPageCount > 50)
+        {
+            errorMessage = $"There are {openPageCount} Puppeteer pages open. This indicates a page leak in the browser, which will degrade performance and may stall job processing.";
         }
         else if (healthMonitor.AnalysisQueueLength > 100)
         {
@@ -53,6 +58,9 @@ public class HealthController : ControllerBase
             healthMonitor.JobsCompletedInLastHourCount,
             healthMonitor.JobsStartedInLastHourCount,
             healthMonitor.RunningTime,
+            healthMonitor.CurrentJobDuration,
+            healthMonitor.CurrentJobAnalysisId,
+            OpenPageCount = openPageCount,
             GooglePlayPackageQueueLength = googlePlayPackageQueueLength,
             ErrorMessage = errorMessage,
         };

--- a/apps/pwabuilder/Services/AnalysisJobProcessor.cs
+++ b/apps/pwabuilder/Services/AnalysisJobProcessor.cs
@@ -109,7 +109,7 @@ public class AnalysisJobProcessor : IHostedService
     {
         try
         {
-            this.healthMonitor.MarkAnalysisAsStarted();
+            this.healthMonitor.MarkAnalysisAsStarted(job.AnalysisId);
 
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancelToken);
             timeoutCts.CancelAfter(TimeSpan.FromSeconds(JobTimeoutSeconds));
@@ -121,12 +121,14 @@ public class AnalysisJobProcessor : IHostedService
         catch (OperationCanceledException) when (!cancelToken.IsCancellationRequested)
         {
             // The job timed out, but the app itself isn't shutting down. Retry or fail.
+            this.healthMonitor.MarkAnalysisAsCompleted();
             var timeoutError = new TimeoutException($"Analysis job timed out after {JobTimeoutSeconds} seconds.");
             logger.LogError(timeoutError, "AnalysisJobProcessor: Job {jobId} for analysis {analysisId} timed out after {timeout} seconds. Attempting retry.", job.Id, job.AnalysisId, JobTimeoutSeconds);
             await RetryJobOrFail(job, timeoutError);
         }
         catch (Exception error)
         {
+            this.healthMonitor.MarkAnalysisAsCompleted();
             logger.LogError(error, "AnalysisJobProcessor: Exception while processing job {jobId} for analysis {analysisId}. Attempting retry.", job.Id, job.AnalysisId);
             await RetryJobOrFail(job, error);
         }

--- a/apps/pwabuilder/Services/AnalysisJobProcessor.cs
+++ b/apps/pwabuilder/Services/AnalysisJobProcessor.cs
@@ -8,6 +8,7 @@ namespace PWABuilder.Services;
 public class AnalysisJobProcessor : IHostedService
 {
     private const int MaxRetryCount = 3;
+    private const int JobTimeoutSeconds = 180;
     private readonly IAnalysisJobQueue queue;
     private readonly IAnalysisStore analysisStore;
     private CancellationTokenSource? abortToken;
@@ -109,9 +110,20 @@ public class AnalysisJobProcessor : IHostedService
         try
         {
             this.healthMonitor.MarkAnalysisAsStarted();
-            await ProcessJobAsync(job, cancelToken);
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancelToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(JobTimeoutSeconds));
+
+            await ProcessJobAsync(job, timeoutCts.Token);
             this.healthMonitor.MarkAnalysisAsCompleted();
             logger.LogInformation("AnalysisJobProcessor: Successfully processed job {jobId} for analysis {analysisId}.", job.Id, job.AnalysisId);
+        }
+        catch (OperationCanceledException) when (!cancelToken.IsCancellationRequested)
+        {
+            // The job timed out, but the app itself isn't shutting down. Retry or fail.
+            var timeoutError = new TimeoutException($"Analysis job timed out after {JobTimeoutSeconds} seconds.");
+            logger.LogError(timeoutError, "AnalysisJobProcessor: Job {jobId} for analysis {analysisId} timed out after {timeout} seconds. Attempting retry.", job.Id, job.AnalysisId, JobTimeoutSeconds);
+            await RetryJobOrFail(job, timeoutError);
         }
         catch (Exception error)
         {

--- a/apps/pwabuilder/Services/AnalysisJobProcessorHealthMonitor.cs
+++ b/apps/pwabuilder/Services/AnalysisJobProcessorHealthMonitor.cs
@@ -12,6 +12,8 @@ public class AnalysisJobProcessorHealthMonitor
     private readonly DateTimeOffset runningTime = DateTimeOffset.UtcNow;
     private readonly IRedisCache redis;
     private readonly IWebHostEnvironment env;
+    private DateTimeOffset? currentJobStartedAt;
+    private string? currentJobAnalysisId;
 
     public AnalysisJobProcessorHealthMonitor(IWebHostEnvironment env, IRedisCache redis)
     {
@@ -64,6 +66,18 @@ public class AnalysisJobProcessorHealthMonitor
     public TimeSpan RunningTime => DateTimeOffset.UtcNow - runningTime;
 
     /// <summary>
+    /// How long the current job has been running, or null if no job is in progress.
+    /// </summary>
+    public TimeSpan? CurrentJobDuration => currentJobStartedAt.HasValue
+        ? DateTimeOffset.UtcNow - currentJobStartedAt.Value
+        : null;
+
+    /// <summary>
+    /// The analysis ID of the current job being processed, or null if idle.
+    /// </summary>
+    public string? CurrentJobAnalysisId => currentJobAnalysisId;
+
+    /// <summary>
     /// Gets the current length of the Google Play package job queue from Redis.
     /// </summary>
     /// <returns></returns>
@@ -72,8 +86,10 @@ public class AnalysisJobProcessorHealthMonitor
     /// <summary>
     /// Records that an analysis job has been started.
     /// </summary>
-    public void MarkAnalysisAsStarted()
+    public void MarkAnalysisAsStarted(string? analysisId = null)
     {
+        currentJobStartedAt = DateTimeOffset.UtcNow;
+        currentJobAnalysisId = analysisId;
         startedJobTimestamps.Enqueue(DateTime.UtcNow);
         PruneStartedJobs();
     }
@@ -83,6 +99,8 @@ public class AnalysisJobProcessorHealthMonitor
     /// </summary>
     public void MarkAnalysisAsCompleted()
     {
+        currentJobStartedAt = null;
+        currentJobAnalysisId = null;
         completedJobTimestamps.Enqueue(DateTime.UtcNow);
         PruneCompletedJobs();
 

--- a/apps/pwabuilder/Services/IPuppeteerService.cs
+++ b/apps/pwabuilder/Services/IPuppeteerService.cs
@@ -21,4 +21,10 @@ public interface IPuppeteerService : IAsyncDisposable
     /// <param name="url">The URL to navigate to.</param>
     /// <returns></returns>
     Task<IPage?> TryNavigate(Uri url, ILogger logger);
+
+    /// <summary>
+    /// Gets the number of open pages in the browser.
+    /// </summary>
+    /// <returns>The number of open Chrome pages/tabs.</returns>
+    Task<int> GetOpenPageCountAsync();
 }

--- a/apps/pwabuilder/Services/PuppeteerService.cs
+++ b/apps/pwabuilder/Services/PuppeteerService.cs
@@ -132,7 +132,7 @@ namespace PWABuilder.Services
                     new NavigationOptions
                     {
                         Timeout = 30000,
-                        WaitUntil = [WaitUntilNavigation.DOMContentLoaded, WaitUntilNavigation.Load, /* WaitUntilNavigation.Networkidle2 - COMMENTED OUT: many PWAs have preload service worker scripts that preload all app assets. We don't want to wait for that. */],
+                        WaitUntil = [WaitUntilNavigation.DOMContentLoaded, WaitUntilNavigation.Load, /* Previously, we used WaitUntilNavigation.Networkidle2, but we found many PWAs have preload service worker scripts that preload all app assets. We don't want to wait for that. */],
                     }
                 );
 

--- a/apps/pwabuilder/Services/PuppeteerService.cs
+++ b/apps/pwabuilder/Services/PuppeteerService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using PuppeteerSharp;
 using PWABuilder.Common;
 
@@ -6,9 +5,13 @@ namespace PWABuilder.Services
 {
     public class PuppeteerService : IPuppeteerService
     {
+        private static readonly TimeSpan StalePageThreshold = TimeSpan.FromMinutes(10);
+        private static readonly int MaxOpenPages = 50;
+
         private readonly Task<IBrowser> reusableBrowser;
         private readonly ILogger<PuppeteerService> logger;
-        private readonly ConcurrentBag<PageReference> openPages = [];
+        private readonly Lock pagesLock = new();
+        private readonly List<PageReference> openPages = [];
 
         public PuppeteerService(Task<IBrowser> reusableBrowser, ILogger<PuppeteerService> logger)
         {
@@ -97,31 +100,51 @@ namespace PWABuilder.Services
 
             // Safety check: if we have too many pages open, something might be wrong
             var pages = await browser.PagesAsync();
-            if (pages.Length > 10) // Adjust threshold as needed
+            if (pages.Length > 10)
             {
                 logger.LogWarning("There are {pageCount} pages open in the Puppeteer browser. Possible page leak detected.", pages.Length);
             }
 
-            // Close any pages that have been opened for more than an hour.
             await TryCleanupOldPages();
 
+            // If we still have too many pages after cleanup, force-close the oldest tracked pages.
+            if (pages.Length > MaxOpenPages)
+            {
+                logger.LogWarning("Page count ({pageCount}) exceeds max ({maxPages}) after cleanup. Force-closing oldest pages.", pages.Length, MaxOpenPages);
+                await ForceCloseOldestPages(pages.Length - MaxOpenPages + 1);
+            }
+
             var page = await browser.NewPageAsync();
-            this.openPages.Add(new PageReference(page, site));
+            var pageRef = new PageReference(page, site);
+            lock (pagesLock)
+            {
+                openPages.Add(pageRef);
+            }
 
-            // Disable performance monitoring to avoid Protocol error (Performance.enable) issues
-            await page.SetCacheEnabledAsync(false);
+            try
+            {
+                // Disable performance monitoring to avoid Protocol error (Performance.enable) issues
+                await page.SetCacheEnabledAsync(false);
 
-            await page.SetUserAgentAsync(Constants.DesktopUserAgent);
-            await page.GoToAsync(
-                site.ToString(),
-                new NavigationOptions
-                {
-                    Timeout = 30000,
-                    WaitUntil = [WaitUntilNavigation.DOMContentLoaded, WaitUntilNavigation.Load, /* WaitUntilNavigation.Networkidle2 - COMMENTED OUT: many PWAs have preload service worker scripts that preload all app assets. We don't want to wait for that. */],
-                }
-            );
+                await page.SetUserAgentAsync(Constants.DesktopUserAgent);
+                await page.GoToAsync(
+                    site.ToString(),
+                    new NavigationOptions
+                    {
+                        Timeout = 30000,
+                        WaitUntil = [WaitUntilNavigation.DOMContentLoaded, WaitUntilNavigation.Load, /* WaitUntilNavigation.Networkidle2 - COMMENTED OUT: many PWAs have preload service worker scripts that preload all app assets. We don't want to wait for that. */],
+                    }
+                );
 
-            return page;
+                return page;
+            }
+            catch
+            {
+                // Navigation or setup failed — close the page to prevent leaking a Chrome tab.
+                RemovePageRef(pageRef);
+                await TryClosePageAsync(page, site);
+                throw;
+            }
         }
 
         public async Task<IPage?> TryNavigate(Uri site, ILogger logger)
@@ -143,44 +166,109 @@ namespace PWABuilder.Services
             await browser.DisposeAsync();
         }
 
+        /// <summary>
+        /// Removes a page reference from the tracking list.
+        /// </summary>
+        private void RemovePageRef(PageReference pageRef)
+        {
+            lock (pagesLock)
+            {
+                openPages.Remove(pageRef);
+            }
+        }
+
+        /// <summary>
+        /// Attempts to close a Puppeteer page, logging any errors.
+        /// </summary>
+        private async Task TryClosePageAsync(IPage page, Uri url)
+        {
+            try
+            {
+                if (!page.IsClosed)
+                {
+                    await page.CloseAsync();
+                }
+            }
+            catch (Exception closeError)
+            {
+                logger.LogWarning(closeError, "Error closing Puppeteer page for {url}.", url);
+            }
+        }
+
+        /// <summary>
+        /// Closes pages that have been open longer than <see cref="StalePageThreshold"/>.
+        /// </summary>
         private async Task TryCleanupOldPages()
         {
-            var hourAgo = DateTimeOffset.UtcNow.AddHours(-1);
-            foreach (var openPage in this.openPages)
+            var cutoff = DateTimeOffset.UtcNow - StalePageThreshold;
+
+            // Identify and remove stale entries under the lock, then close pages outside the lock.
+            List<PageReference> stalePages;
+            lock (pagesLock)
             {
-                if (openPage.CreatedAt < hourAgo)
+                stalePages = openPages.Where(p => p.CreatedAt < cutoff).ToList();
+                foreach (var stale in stalePages)
                 {
-                    logger.LogInformation("Closing stale Puppeteer page for {url} opened {time} ago.", openPage.Url, (DateTimeOffset.UtcNow - openPage.CreatedAt).ToString(@"hh\:mm"));
-                    openPage.Page.TryGetTarget(out var page);
-                    if (page != null)
-                    {
-                        openPages.TryTake(out var _);
-                        try
-                        {
-                            await page.CloseAsync();
-                        }
-                        catch (Exception closeError)
-                        {
-                            logger.LogWarning(closeError, "Error closing stale Puppeteer page for {url}.", openPage.Url);
-                        }
-                    }
+                    openPages.Remove(stale);
                 }
+            }
+
+            foreach (var stale in stalePages)
+            {
+                logger.LogInformation("Closing stale Puppeteer page for {url} opened {time} ago.", stale.Url, (DateTimeOffset.UtcNow - stale.CreatedAt).ToString(@"hh\:mm"));
+                await TryClosePageAsync(stale.Page, stale.Url);
+            }
+        }
+
+        /// <summary>
+        /// Force-closes the oldest tracked pages when the page count exceeds the maximum.
+        /// </summary>
+        private async Task ForceCloseOldestPages(int countToClose)
+        {
+            List<PageReference> toClose;
+            lock (pagesLock)
+            {
+                toClose = openPages
+                    .OrderBy(p => p.CreatedAt)
+                    .Take(countToClose)
+                    .ToList();
+                foreach (var page in toClose)
+                {
+                    openPages.Remove(page);
+                }
+            }
+
+            foreach (var pageRef in toClose)
+            {
+                logger.LogWarning("Force-closing Puppeteer page for {url} to stay within page limit.", pageRef.Url);
+                await TryClosePageAsync(pageRef.Page, pageRef.Url);
             }
         }
     }
 
     /// <summary>
-    /// An open page in Puppeteer. Uses a weak reference to allow for garbage collection. Used for cleaning up old pages that weren't properly disposed.
+    /// An open page in Puppeteer. Used for tracking and cleaning up pages that weren't properly closed.
     /// </summary>
-    public class PageReference
+    public sealed class PageReference
     {
-        public WeakReference<IPage> Page { get; }
+        /// <summary>
+        /// The Puppeteer page. Strong reference to ensure we can always close it.
+        /// </summary>
+        public IPage Page { get; }
+
+        /// <summary>
+        /// When the page was created.
+        /// </summary>
         public DateTimeOffset CreatedAt { get; }
+
+        /// <summary>
+        /// The URL the page was navigated to.
+        /// </summary>
         public Uri Url { get; }
 
         public PageReference(IPage page, Uri url)
         {
-            Page = new WeakReference<IPage>(page);
+            Page = page;
             CreatedAt = DateTimeOffset.UtcNow;
             Url = url;
         }

--- a/apps/pwabuilder/Services/PuppeteerService.cs
+++ b/apps/pwabuilder/Services/PuppeteerService.cs
@@ -166,6 +166,22 @@ namespace PWABuilder.Services
             await browser.DisposeAsync();
         }
 
+        /// <inheritdoc />
+        public async Task<int> GetOpenPageCountAsync()
+        {
+            try
+            {
+                var browser = await this.reusableBrowser;
+                var pages = await browser.PagesAsync();
+                return pages.Length;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Error getting open page count from Puppeteer browser.");
+                return -1;
+            }
+        }
+
         /// <summary>
         /// Removes a page reference from the tracking list.
         /// </summary>


### PR DESCRIPTION
Fixes #5930. On June 8th, we saw PWABuilder analysis queue maxed out, with new analyses getting timed out. 

Investigating the logs, we saw the analysis queue maxed out at 500 items. And 2 of our PWABuilder web instances were stuck. It appears they were stuck because there were over 1,000 opened Puppeteer pages still opened ☠️. We fixed the issue by restarting our PWABuilder web app.

This PR aims to fix the issue by strict cleanup of Puppeteer pages and forceful closing where necessary. It also adds a timeout to the analysis queue job processor so we don't get hung.

## PR Type
Bugfix

## Describe the current behavior?
There's no analysis job processing timeout, and some Puppeteer pages could remain opened for long periods of time.

## Describe the new behavior?
Analysis job processor has sane timeout. We zealously close Puppeteer pages.