### PR TITLE
Packaging jobs older than 30 minutes are discarded from the queue

### DIFF
--- a/apps/pwabuilder-google-play/services/packageJobProcessor.ts
+++ b/apps/pwabuilder-google-play/services/packageJobProcessor.ts
@@ -4,7 +4,7 @@ import { PackageCreationProgress } from "../models/packageCreationProgress.js";
 import { PackageJobLogger } from "../models/packageJobLogger.js";
 import { blobStorage } from "./azureStorageBlobService.js";
 import { redisService } from "./redisService.js";
-import { azureQueue } from "./azureQueueService.js";
+import { azureQueue, AzureQueueService } from "./azureQueueService.js";
 import { packageJobQueue } from "./packageJobQueue.js";
 
 /**
@@ -16,6 +16,7 @@ export class PackageJobProcessor {
 
     private readonly jobCheckIntervalMs = 2000;
     private readonly maxRetryCount = 2;
+    private readonly maxJobAgeMs = 60000 * 30; // 30 minutes
 
     /**
      * Begins the background job processor that periodically checks for Google Play packaging jobs and processes them.
@@ -43,8 +44,17 @@ export class PackageJobProcessor {
         try {
             job = await packageJobQueue.dequeue();
             if (job) {
-                jobLogger = new PackageJobLogger(job);
-                await this.processJob(job, jobLogger);
+                // Skip stale jobs — users won't be waiting for results after 15 minutes.
+                // Discarding these prevents the queue from staying backed up with dead work.
+                if (this.isJobStale(job)) {
+                    console.info(`Discarding stale job ${job.id} (created ${job.createdAt}). Job exceeded max age of ${this.maxJobAgeMs / 60000} minutes.`);
+                    job.errors.push(`Discarding job due to exceeding max age of ${this.maxJobAgeMs / 60000} minutes.`);
+                    job.status = "Failed";
+                    await redisService.save(job.id, job);
+                } else {
+                    jobLogger = new PackageJobLogger(job);
+                    await this.processJob(job, jobLogger);
+                }
             }
         } catch (jobError) {
             hadError = true;
@@ -82,6 +92,14 @@ export class PackageJobProcessor {
     }
 
     private async retryJobOrMarkAsFailed(job: GooglePlayPackageJob, jobError: any, logger: PackageJobLogger): Promise<void> {
+        // Don't retry stale jobs — the user has already moved on
+        if (this.isJobStale(job)) {
+            logger.error(`Job expired after ${this.maxJobAgeMs / 60000} minutes. Marking as failed without retry.`, jobError);
+            job.status = "Failed";
+            await redisService.save(job.id, job);
+            return;
+        }
+
         if (job.retryCount < this.maxRetryCount) {
             job.retryCount++;
             logger.info("Retrying job", { attempt: job.retryCount + 1, maxAttempts: this.maxRetryCount + 1 });
@@ -93,6 +111,15 @@ export class PackageJobProcessor {
             job.status = "Failed";
             await redisService.save(job.id, job);
         }
+    }
+
+    /**
+     * Checks if a job has exceeded the maximum allowed age.
+     * Stale jobs are discarded because the user is no longer waiting for results.
+     */
+    private isJobStale(job: GooglePlayPackageJob): boolean {
+        const createdAt = new Date(job.createdAt).getTime();
+        return Date.now() - createdAt > this.maxJobAgeMs;
     }
 
     async jobProgressed(e: PackageCreationProgress, job: GooglePlayPackageJob, logger: PackageJobLogger) {

--- a/apps/pwabuilder/Frontend/src/script/pages/google-play-packaging-status.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/google-play-packaging-status.ts
@@ -26,7 +26,7 @@ export class GooglePlayPackagingStatus extends LitElement {
     @state() job: GooglePlayPackageJob | null = null;
     @state() isRetrying = false;
     private readonly pollIntervalMs = 3000; // Poll the job every 3 seconds
-    private readonly maxWaitTimeMs = 15 * 60 * 1000; // Max wait time of 15 minutes
+    private readonly maxWaitTimeMs = 30 * 60 * 1000; // Max wait time of 30 minutes
     private jobTimeoutHandle = 0;
     private hasRecordedCompletion = false;
     private hasRecordedFailure = false;


### PR DESCRIPTION
This updates PWABuilder's Google Play platform to discard packaging jobs from the queue if they've been waiting longer than 30 minutes. This will help reduce the impact when PWABuilder's Google Play packager gets overloaded.

## PR Type
Feature

## Describe the current behavior?
Currently, PWABuilder blocks new Google Play package jobs if the queue has more than 50 jobs in it.

## Describe the new behavior?
PWABuilder's Google Play platform will skip processing a packaging job if it's been waiting for more than 30 minutes.