### PR TITLE
Fix: WidgetsSchema accepts JSON array (unblocks Widgets capability check)

### DIFF
--- a/apps/pwabuilder/Validations/Schema/WidgetsSchema.cs
+++ b/apps/pwabuilder/Validations/Schema/WidgetsSchema.cs
@@ -79,10 +79,18 @@ namespace PWABuilder.Validations.Schema
 			  }
 		}";
 
-        public static bool ValidateWidgetSchema(string jObject)
+        // The `widgets` member of the manifest is a JSON array, so we parse it as
+        // a JToken (which accepts both arrays and objects). The previous
+        // implementation called JObject.Parse, which throws for arrays with
+        // "Error reading JObject from JsonReader. Current JsonReader item is not
+        // an object: StartArray." That exception bubbled up to
+        // ManifestAnalyzer.AnalyzeAsync's try/catch and marked the Widgets
+        // capability as Skipped for every PWA that declared a valid widgets
+        // array, making the Widgets check unpassable.
+        public static bool ValidateWidgetSchema(string widgetsJson)
         {
-            var jSchema = JSchema.Parse(Schema);
-            return JObject.Parse(jObject).IsValid(jSchema);
+            var schema = JSchema.Parse(Schema);
+            return JToken.Parse(widgetsJson).IsValid(schema);
         }
     }
 }


### PR DESCRIPTION
## Summary

`WidgetsSchema.ValidateWidgetSchema` parses the `widgets` member of a Web App Manifest with `JObject.Parse`. Since `widgets` is a JSON **array** (as the schema itself declares with `type: 'array'`), `JObject.Parse` always throws:

```
Error reading JObject from JsonReader. Current JsonReader item is not an object: StartArray. Path '', line 1, position 1.
```

The exception bubbles up to `ManifestAnalyzer.AnalyzeAsync`'s try/catch and sets the Widgets capability to `Skipped` for **every** PWA that declares a valid `widgets` array. As a consequence, the Widgets check appears in the report card without a valid indicator and the manifest score is capped one point below the true maximum for anyone who ships widgets.

You can reproduce this against any PWA with widgets: for example, `https://www.pwabuilder.com/api/analyses?id=<recent-analysis-with-widgets>` will return `capabilities[Widgets].status = "Skipped"` with the exact error message above.

## Fix

Switch `JObject.Parse` to `JToken.Parse`, which accepts both arrays and objects. The schema already enforces the array shape via `'type': 'array', minItems: 1`, so behaviour when a developer accidentally provides a non-array is unchanged (returns `false` via schema validation rather than by throwing).

## Test plan

- [ ] Unit-level: `WidgetsSchema.ValidateWidgetSchema("[{\"name\":\"w\",\"description\":\"d\",\"tag\":\"t\",\"ms_ac_template\":\"/w.json\",\"screenshots\":[{\"src\":\"/s.png\",\"sizes\":\"600x400\",\"label\":\"l\"}]}]")` now returns `true` instead of throwing.
- [ ] Unit-level: passing a non-array (`"{}"`) still returns `false` (schema rejects it) instead of throwing.
- [ ] Integration: re-run any recent PWABuilder report where Widgets was `Skipped` due to the `StartArray` exception; the check should now pass and the manifest score should improve by 1 point.