### PR TITLE
Disable App URI handler for double-hyphen URLs

### DIFF
--- a/apps/pwabuilder/Frontend/src/script/services/publish/windows-publish.ts
+++ b/apps/pwabuilder/Frontend/src/script/services/publish/windows-publish.ts
@@ -147,7 +147,7 @@ export function createWindowsPackageOptionsFromManifest(
         },
         resourceLanguage: languages,
         enableWebAppWidgets: Object.keys(manifest).includes("widgets"),
-        extensions: "appurihandler",
+        extensions: pwaURL.includes('--') ? undefined : 'appurihandler',
     };
 
     return options;

--- a/apps/pwabuilder/Frontend/tests/packaging.spec.ts
+++ b/apps/pwabuilder/Frontend/tests/packaging.spec.ts
@@ -390,6 +390,71 @@ test('Ensure Windows package dialog initially focuses the Package ID field', asy
       internalInputFocused: internalInput === packageIdInput?.shadowRoot?.activeElement
     };
   });
+
   expect(focusState).not.toBeNull();
   expect(focusState?.packageIdFocused || focusState?.internalInputFocused).toBe(true);
+});
+
+test('App URI Handler is disabled by default for URLs containing double hyphens', async ({ page }) => {
+  const appUriHandlerEnabled = await page.evaluate(async () => {
+    const siteUrl = 'https://studio--studio-2987697784-ae82f.us-central1.hosted.app';
+    const manifestContext = {
+      siteUrl,
+      manifestUrl: `${siteUrl}/manifest.webmanifest`,
+      manifest: {
+        dir: 'auto',
+        display: 'standalone',
+        name: 'Example App',
+        short_name: 'Example',
+        start_url: '/',
+        scope: '/',
+        lang: 'en',
+        description: 'Example description',
+        theme_color: '#000000',
+        background_color: '#ffffff',
+        icons: [],
+        screenshots: []
+      },
+      initialManifest: {
+        dir: 'auto',
+        display: 'standalone',
+        name: 'Example App',
+        short_name: 'Example',
+        start_url: '/',
+        scope: '/',
+        lang: 'en',
+        description: 'Example description',
+        theme_color: '#000000',
+        background_color: '#ffffff',
+        icons: [],
+        screenshots: []
+      },
+      isGenerated: false,
+      isEdited: false
+    };
+
+    sessionStorage.setItem('current_url', siteUrl);
+    sessionStorage.setItem('PWABuilderManifest', JSON.stringify(manifestContext));
+    await import('/src/script/components/windows-form.ts');
+    await customElements.whenDefined('windows-form');
+
+    document.body.innerHTML = '<windows-form></windows-form>';
+    const windowsForm = document.querySelector('windows-form') as HTMLElement & {
+      updateComplete: Promise<void>;
+      shadowRoot: ShadowRoot;
+    } | null;
+
+    if (!windowsForm) {
+      return null;
+    }
+
+    await windowsForm.updateComplete;
+    const checkbox = windowsForm.shadowRoot?.querySelector('#app-uri-handler-checkbox') as {
+      checked: boolean;
+    } | null;
+
+    return checkbox?.checked ?? null;
+  });
+
+  expect(appUriHandlerEnabled).toBe(false);
 });


### PR DESCRIPTION
fixes #[issue number]
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## Describe the current behavior?

Windows packages enable the App URI Handler by default for every PWA. URLs whose host contains a double hyphen produce an AppxManifest that fails Windows SDK schema validation.


## Describe the new behavior?

The Windows package form leaves App URI Handler unchecked by default when the PWA URL contains `--`. Other URLs retain the existing enabled default, and users can still opt in manually. A browser regression test covers the reported hostname.


## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information

Automated frontend validation could not run locally because the corporate npm feed did not contain the locked `ip-address@10.4.0` artifact. The public npm registry is blocked by corporate policy.