### PR TITLE
Regenerate package-lock.json for Bubblewrap 1.25.0

### DIFF
--- a/apps/pwabuilder-google-play/package-lock.json
+++ b/apps/pwabuilder-google-play/package-lock.json
@@ -14,7 +14,7 @@
                 "@azure/monitor-opentelemetry": "^1.18.2",
                 "@azure/storage-blob": "^12.29.0",
                 "@azure/storage-queue": "^12.29.0",
-                "@bubblewrap/core": "^1.24.1",
+                "@bubblewrap/core": "^1.25.0",
                 "@opentelemetry/api": "^1.9.0",
                 "@redis/client": "^5.10.0",
                 "@redis/entraid": "^5.10.0",
@@ -466,9 +466,9 @@
             }
         },
         "node_modules/@bubblewrap/core": {
-            "version": "1.24.1",
-            "resolved": "https://registry.npmjs.org/@bubblewrap/core/-/core-1.24.1.tgz",
-            "integrity": "sha512-onSyxG1pLk7OtV1zbro5jDo52bshDkSjqVUXYA8UOXXHgNq/+ooLGcEaIiS0qaxTUwwUXnFLZ5OT0E0gfA24aA==",
+            "version": "1.25.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bubblewrap/core/-/core-1.25.0.tgz",
+            "integrity": "sha1-iU+2zKENil6xugiI9tvg/QI37J0=",
             "license": "Apache-2.0",
             "dependencies": {
                 "@resvg/resvg-js": "^2.2.0",
@@ -478,9 +478,8 @@
                 "@types/inquirer": "^9.0.7",
                 "@types/lodash": "^4.17.14",
                 "@types/mime-types": "^2.1.0",
-                "@types/node": "^12.20.1",
+                "@types/node": "^18.11.0",
                 "@types/node-fetch": "^2.5.10",
-                "@types/tar": "^4.0.4",
                 "@types/valid-url": "^1.0.3",
                 "canvg": "4.0.3",
                 "color": "^3.1.3",
@@ -492,17 +491,21 @@
                 "lodash": "^4.17.21",
                 "mime-types": "^2.1.28",
                 "node-fetch": "^2.6.1",
-                "tar": "^6.1.0",
+                "tar": "^7.5.3",
                 "valid-url": "^1.0.9"
             },
             "engines": {
-                "node": ">=14.15.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@bubblewrap/core/node_modules/@types/node": {
-            "version": "12.20.55",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+            "version": "18.19.130",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-18.19.130.tgz",
+            "integrity": "sha1-2kxjJHk6ed77emLLo5R+xa3QDVk=",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@bubblewrap/core/node_modules/node-fetch": {
             "version": "2.6.12",
@@ -3336,15 +3339,6 @@
             "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.1.tgz",
             "integrity": "sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw=="
         },
-        "node_modules/@types/minipass": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-3.3.5.tgz",
-            "integrity": "sha512-M2BLHQdEmDmH671h0GIlOQQJrgezd1vNqq7PVj1VOsHZ2uQQb4iPiQIl0SlMdhxZPUsLIfEklmeEHXg8DJRewA==",
-            "deprecated": "This is a stub types definition. minipass provides its own type definitions, so you do not need this installed.",
-            "dependencies": {
-                "minipass": "*"
-            }
-        },
         "node_modules/@types/mysql": {
             "version": "2.15.27",
             "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
@@ -3447,15 +3441,6 @@
             "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
             "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
             "dev": true
-        },
-        "node_modules/@types/tar": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.5.tgz",
-            "integrity": "sha512-cgwPhNEabHaZcYIy5xeMtux2EmYBitfqEceBUi2t5+ETy4dW6kswt6WX4+HqLeiiKOo42EXbGiDmVJ2x+vi37Q==",
-            "dependencies": {
-                "@types/minipass": "*",
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/through": {
             "version": "0.0.33",
@@ -8424,6 +8409,12 @@
                 "@typescript/typescript-win32-arm64": "7.0.2",
                 "@typescript/typescript-win32-x64": "7.0.2"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha1-vNU5iT0AtW6WT9JlekhmsiGmVhc=",
+            "license": "MIT"
         },
         "node_modules/unicorn-magic": {
             "version": "0.3.0",


### PR DESCRIPTION
## Summary
The private npm feed has now synced `@bubblewrap/core@1.25.0`, so this regenerates `apps/pwabuilder-google-play/package-lock.json` to bring it in sync with `package.json` (`^1.25.0`).

## Why
PR #6209 bumped `package.json` to `^1.25.0` but could not update the lock file because the internal feed had not yet published 1.25.0. That left `main` failing to build with:

> npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync.

This PR regenerates the lock file (now resolving `@bubblewrap/core@1.25.0` from the feed) and restores a green `npm ci` build. Verified locally with `npm ci --dry-run` succeeding.

## Changes
- `apps/pwabuilder-google-play/package-lock.json` — resolve `@bubblewrap/core` to `1.25.0` and sync its transitive dependency tree.