### PR TITLE
Add PWABuilder bot documentation

### DIFF
--- a/docs/builder/pwabuilder-bot.md
+++ b/docs/builder/pwabuilder-bot.md
@@ -1,0 +1,27 @@
+# PWABuilder bot
+
+PWABuilder is a developer tool that fetches a web app at the URL supplied by a user. It analyzes the app against progressive web app criteria and can package the app for submission to app stores.
+
+## How the bot works
+
+The PWABuilder bot:
+
+* visits a web app only when a user explicitly directs PWABuilder to analyze that URL
+* fetches the web app and the resources needed to evaluate its progressive web app capabilities
+* analyzes the app for progressive web app criteria, including its web app manifest and service worker
+* uses the analysis to help the user prepare and package the app for app stores
+
+## What the bot does not do
+
+The PWABuilder bot:
+
+* does not crawl a web app without a user's express directive
+* does not crawl a web app on an ongoing or scheduled basis
+* does not revisit a web app unless a user explicitly directs PWABuilder to analyze it again
+* does not use data from a web app to train AI models
+
+PWABuilder's access is user-initiated and limited to the analysis or packaging task requested by that user.
+
+## Questions
+
+For questions about the PWABuilder bot, [open an issue in the PWABuilder GitHub repository](https://github.com/pwa-builder/pwabuilder/issues).

--- a/docs/src/menuData.ts
+++ b/docs/src/menuData.ts
@@ -109,6 +109,12 @@ export const parentMenuData: ParentMenu = {
           includeOnHomePage: false
         },
         {
+          pageTitle: "PWABuilder bot",
+          menuTitle: "PWABuilder bot",
+          path: "/builder/pwabuilder-bot",
+          includeOnHomePage: false
+        },
+        {
           pageTitle: "PWABuilder - Using PWABuilder Features",
           menuTitle: "Using PWABuilder Features",
           path: "/builder/using-pwabuilder-features ",


### PR DESCRIPTION
Issue: N/A

## PR Type

- Documentation content changes

## Describe the current behavior?

PWABuilder does not have a public documentation page describing its user-initiated bot behavior, crawl limitations, or AI training policy. This information is needed for listing PWABuilder in Cloudflare's known bot database.

## Describe the new behavior?

Adds a navigable **PWABuilder bot** documentation page explaining how PWABuilder fetches and analyzes user-submitted web apps for PWA criteria and app-store packaging. The page clarifies that crawling occurs only on explicit user instruction, is not ongoing, and does not provide web app data for AI model training. It also directs questions to the PWABuilder GitHub Issues page.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information

The docs package setup/build completes successfully.