### PR TITLE
Fix CloudAPK and PWABuilder container vulnerabilities

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -62,11 +62,9 @@ RUN npm run build
 
 # Build lighthouse custom audits
 WORKDIR /src/apps/pwabuilder/node-scripts
-RUN npm install
+RUN npm ci
 RUN npm run build
-
-# Force fix any NPM vulnerabilities
-RUN npm audit fix --force
+RUN npm prune --omit=dev --ignore-scripts
 
 # Build backend
 WORKDIR /src/apps/pwabuilder
@@ -105,10 +103,8 @@ COPY --from=publish /app/publish .
 ENV ASPNETCORE_DETAILEDERRORS=true
 ENV Logging__LogLevel__Default=Information
 
-# Copy Node.js binary and npm
+# Copy the Node.js runtime and Lighthouse scripts
 COPY --from=build /usr/bin/node /usr/bin/node
-COPY --from=build /usr/bin/npm /usr/bin/npm
-COPY --from=build /usr/lib/node_modules /usr/lib/node_modules
 COPY --from=build /src/apps/pwabuilder/node-scripts /app/node-scripts
 # Node path
 ENV NODE_BIN=/usr/bin/node

--- a/apps/pwabuilder-google-play/Dockerfile
+++ b/apps/pwabuilder-google-play/Dockerfile
@@ -1,7 +1,7 @@
 # ─── PRELIMINAR: Ubuntu base con Android/Java toolchain ───────────────────────
 FROM --platform=linux/amd64 ubuntu:24.04  AS ubuntu
 
-ARG ANDROID_SDK_TOOLS_VERSION="11076708"
+ARG ANDROID_SDK_TOOLS_VERSION="15641748"
 ARG NODE_VERSION="24.x"
 ARG JENV_RELEASE="0.5.6"
 
@@ -34,10 +34,9 @@ RUN echo export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-$(uname -m)/" >> /etc/jd
     echo . /etc/jdk.env >> /etc/bash.bashrc && echo . /etc.jdk.env >> /etc/profile && \
     apt-get update -qq && \
     apt-get install -qq --no-install-recommends \
-    apt-utils locales unzip curl git git-lfs build-essential openjdk-11-jdk openjdk-17-jdk \
-    wget zip zipalign ruby-full python3-pip tzdata && \
+    apt-utils locales unzip curl git build-essential openjdk-11-jdk openjdk-17-jdk \
+    wget zip zipalign ruby-full tzdata && \
     locale-gen $LANG && \
-    git lfs install && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     rm -rf /var/lib/apt/lists/*
 

--- a/apps/pwabuilder-google-play/Dockerfile
+++ b/apps/pwabuilder-google-play/Dockerfile
@@ -82,6 +82,8 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - && \
     rm -rf /var/lib/apt/lists/*
 
 FROM node-final AS builder
+ARG NPM_CONFIG_REGISTRY=https://registry.npmjs.org/
+ARG NPM_CONFIG_REPLACE_REGISTRY_HOST=always
 WORKDIR /app
 
 COPY package*.json tsconfig.json ./

--- a/apps/pwabuilder-google-play/package-lock.json
+++ b/apps/pwabuilder-google-play/package-lock.json
@@ -25,6 +25,7 @@
                 "dotenv": "^16.6.1",
                 "escape-html": "^1.0.3",
                 "express": "^4.22.2",
+                "file-type": "21.3.4",
                 "fs-extra": "^11.3.3",
                 "node-fetch": "^3.3.2",
                 "password-generator": "^2.3.2",
@@ -463,6 +464,16 @@
             },
             "engines": {
                 "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@borewit/text-codec": {
+            "version": "0.2.2",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+            "integrity": "sha1-dQJfc1wJg7OocWaIBKVzh+Nkk3U=",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/@bubblewrap/core": {
@@ -3090,10 +3101,50 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@tokenizer/inflate": {
+            "version": "0.4.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+            "integrity": "sha1-+mzbg2YVGzzIQmv5dVweoDovugg=",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "token-types": "^6.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@tokenizer/inflate/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@tokenizer/inflate/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+            "license": "MIT"
+        },
         "node_modules/@tokenizer/token": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha1-/pipP+eJJH6ZjHXnTpx8YyF6onY=",
             "license": "MIT"
         },
         "node_modules/@tsconfig/node10": {
@@ -5427,17 +5478,18 @@
             }
         },
         "node_modules/file-type": {
-            "version": "16.5.4",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-            "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+            "version": "21.3.4",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/file-type/-/file-type-21.3.4.tgz",
+            "integrity": "sha1-4/kC+u6OxKoVKQn8kCp6d/nAZyU=",
             "license": "MIT",
             "dependencies": {
-                "readable-web-to-node-stream": "^3.0.0",
-                "strtok3": "^6.2.4",
-                "token-types": "^4.1.1"
+                "@tokenizer/inflate": "^0.4.1",
+                "strtok3": "^10.3.4",
+                "token-types": "^6.1.1",
+                "uint8array-extras": "^1.4.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -7111,19 +7163,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/peek-readable": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-            "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
         "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -7433,62 +7472,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/readable-web-to-node-stream": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
-            "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
-            "license": "MIT",
-            "dependencies": {
-                "readable-stream": "^4.7.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
-        "node_modules/readable-web-to-node-stream/node_modules/buffer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
-        "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-            "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-            "license": "MIT",
-            "dependencies": {
-                "abort-controller": "^3.0.0",
-                "buffer": "^6.0.3",
-                "events": "^3.3.0",
-                "process": "^0.11.10",
-                "string_decoder": "^1.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/readdir-glob": {
@@ -8015,16 +7998,15 @@
             "license": "MIT"
         },
         "node_modules/strtok3": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-            "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+            "version": "10.3.5",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strtok3/-/strtok3-10.3.5.tgz",
+            "integrity": "sha1-chMoXaDcPewPyM5d9Li3pzPxQ2A=",
             "license": "MIT",
             "dependencies": {
-                "@tokenizer/token": "^0.3.0",
-                "peek-readable": "^4.1.0"
+                "@tokenizer/token": "^0.3.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "type": "github",
@@ -8166,16 +8148,17 @@
             }
         },
         "node_modules/token-types": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-            "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+            "version": "6.1.2",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/token-types/-/token-types-6.1.2.tgz",
+            "integrity": "sha1-GND9WbmW1CH5+DkU1hAcIBvQgSk=",
             "license": "MIT",
             "dependencies": {
+                "@borewit/text-codec": "^0.2.1",
                 "@tokenizer/token": "^0.3.0",
                 "ieee754": "^1.2.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14.16"
             },
             "funding": {
                 "type": "github",
@@ -8408,6 +8391,18 @@
                 "@typescript/typescript-sunos-x64": "7.0.2",
                 "@typescript/typescript-win32-arm64": "7.0.2",
                 "@typescript/typescript-win32-x64": "7.0.2"
+            }
+        },
+        "node_modules/uint8array-extras": {
+            "version": "1.5.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+            "integrity": "sha1-ENKoUhPeOtowT+ocRU9jXHODnoY=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/undici-types": {

--- a/apps/pwabuilder-google-play/package.json
+++ b/apps/pwabuilder-google-play/package.json
@@ -8,6 +8,7 @@
         "start": "node ./server.js",
         "postinstall": "tsc",
         "dev": "cross-env NODE_ENV=development node --inspect=5858 --loader ts-node/esm ./server.ts",
+        "prebuild": "node ./scripts/patch-jimp-file-type.mjs",
         "build": "tsc --noEmitOnError",
         "docker:build": "npm run build && docker build -t cloud-apk .",
         "docker:run": "docker run -p 5779:5858 -e NODE_ENV=development cloud-apk"
@@ -38,6 +39,7 @@
         "dotenv": "^16.6.1",
         "escape-html": "^1.0.3",
         "express": "^4.22.2",
+        "file-type": "21.3.4",
         "fs-extra": "^11.3.3",
         "node-fetch": "^3.3.2",
         "password-generator": "^2.3.2",
@@ -66,6 +68,7 @@
         "qs": ">=6.3.2",
         "path-parse": ">=1.0.7",
         "async": ">=3.2.2",
+        "file-type": "21.3.4",
         "minimatch": ">=3.0.2",
         "tar": ">=7.5.20"
     }

--- a/apps/pwabuilder-google-play/scripts/patch-jimp-file-type.mjs
+++ b/apps/pwabuilder-google-play/scripts/patch-jimp-file-type.mjs
@@ -1,0 +1,43 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+const patches = [
+  {
+    path: 'node_modules/@jimp/core/dist/utils/image-bitmap.js',
+    replacements: [
+      [
+        'var _fileType = _interopRequireDefault(require("file-type"));',
+        '// file-type is loaded dynamically because current releases are ESM-only.',
+      ],
+      [
+        'const fileTypeFromBuffer = await _fileType.default.fromBuffer(buffer);',
+        'const fileTypeFromBuffer = await (await import("file-type")).fileTypeFromBuffer(buffer);',
+      ],
+    ],
+  },
+  {
+    path: 'node_modules/@jimp/core/es/utils/image-bitmap.js',
+    replacements: [
+      ['import FileType from "file-type";', 'import { fileTypeFromBuffer } from "file-type";'],
+      [
+        'const fileTypeFromBuffer = await FileType.fromBuffer(buffer);',
+        'const fileType = await fileTypeFromBuffer(buffer);',
+      ],
+      ['if (fileTypeFromBuffer) {', 'if (fileType) {'],
+      ['return fileTypeFromBuffer.mime;', 'return fileType.mime;'],
+    ],
+  },
+];
+
+for (const patch of patches) {
+  let source = await readFile(patch.path, 'utf8');
+
+  for (const [before, after] of patch.replacements) {
+    if (source.includes(before)) {
+      source = source.replace(before, after);
+    } else if (!source.includes(after)) {
+      throw new Error(`Expected Jimp source was not found in ${patch.path}`);
+    }
+  }
+
+  await writeFile(patch.path, source);
+}

--- a/apps/pwabuilder-google-play/scripts/patch-jimp-file-type.mjs
+++ b/apps/pwabuilder-google-play/scripts/patch-jimp-file-type.mjs
@@ -1,5 +1,11 @@
 import { readFile, writeFile } from 'node:fs/promises';
 
+// Bubblewrap 1.25.0 depends on Jimp 0.22, which imports the vulnerable
+// file-type 16 CommonJS API. We override file-type with the patched ESM-only
+// release and adapt Jimp's installed wrappers to its named export.
+//
+// Remove this script, the prebuild hook, and the file-type override once
+// @bubblewrap/core upgrades to Jimp 1.x (or otherwise supports file-type 21+).
 const patches = [
   {
     path: 'node_modules/@jimp/core/dist/utils/image-bitmap.js',


### PR DESCRIPTION
## Summary

- upgrade CloudAPK to Android command-line tools 22.0, removing vulnerable protobuf, Guava, Commons, and JLine artifacts
- remove unused `git-lfs` and `python3-pip` packages from the CloudAPK image
- update `file-type` to 21.3.4 and add a documented compatibility patch for Bubblewrap's Jimp dependency
- allow container builds to select an approved npm registry mirror while retaining npmjs as the default
- prune PWABuilder's Lighthouse dependencies and stop shipping npm/global npm modules in the runtime image

## Validation

- built the complete CloudAPK Docker image with Android command-line tools 22.0
- ran the image locally and submitted a signed Webboard package request using production-shaped JSON
- confirmed the request returned HTTP 200 and a ZIP containing both `Webboard.apk` and `Webboard.aab`
- smoke-tested PNG detection through the patched Jimp dependency
- built and production-pruned PWABuilder node scripts
- confirmed the CloudAPK lockfile resolves only `file-type@21.3.4`