### PR TITLE
Refine image generator page layout

### DIFF
--- a/apps/pwabuilder/Frontend/src/locales/en_US.json
+++ b/apps/pwabuilder/Frontend/src/locales/en_US.json
@@ -277,6 +277,6 @@
         "transparent": "Transparent",
         "custom_color": "Custom color",
         "platforms": "Platforms",
-        "platforms_text": "Select the platforms to generate images for."
+        "platforms_text": "Select the app stores to generate images for."
     }
 }

--- a/apps/pwabuilder/Frontend/src/locales/en_US.json
+++ b/apps/pwabuilder/Frontend/src/locales/en_US.json
@@ -276,6 +276,7 @@
         "best_guess": "Best guess",
         "transparent": "Transparent",
         "custom_color": "Custom color",
+        "select_color": "Select a color",
         "platforms": "Platforms",
         "platforms_text": "Select the app stores to generate images for."
     }

--- a/apps/pwabuilder/Frontend/src/script/components/app-file-input.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/components/app-file-input.styles.ts
@@ -11,10 +11,6 @@ export const appFileInputStyles = css`
 		background-color: transparent;
 	}
 
-	wa-button::part(base) {
-		min-height: 44px;
-	}
-
 	${hidden}
 
 	${fastButtonCss}

--- a/apps/pwabuilder/Frontend/src/script/components/app-file-input.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/components/app-file-input.styles.ts
@@ -11,6 +11,10 @@ export const appFileInputStyles = css`
 		background-color: transparent;
 	}
 
+	wa-button::part(base) {
+		min-height: 44px;
+	}
+
 	${hidden}
 
 	${fastButtonCss}

--- a/apps/pwabuilder/Frontend/src/script/components/app-file-input.ts
+++ b/apps/pwabuilder/Frontend/src/script/components/app-file-input.ts
@@ -39,6 +39,7 @@ export class FileInput extends LitElement implements FileInputElement {
       <div>
         <wa-button
           variant="default"
+          size="s"
           @click=${this.clickModalInput}
         >
           ${this.buttonText}

--- a/apps/pwabuilder/Frontend/src/script/components/app-file-input.ts
+++ b/apps/pwabuilder/Frontend/src/script/components/app-file-input.ts
@@ -39,7 +39,6 @@ export class FileInput extends LitElement implements FileInputElement {
       <div>
         <wa-button
           variant="default"
-          size="small"
           @click=${this.clickModalInput}
         >
           ${this.buttonText}

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
@@ -20,7 +20,7 @@ export const imageGeneratorStyles = css`
 	}
 
 	p {
-		font-size: var(--font-size);
+		font-size: var(--body-font-size, 16px);
 	}
 
 	#image-generator-card {
@@ -128,14 +128,8 @@ export const imageGeneratorStyles = css`
 		color: var(--font-color);
 	}
 
-	wa-number-input#padding::part(base),
-	wa-number-input#padding::part(input),
-	wa-number-input#padding::part(stepper) {
-		min-height: 44px;
-	}
-
 	wa-number-input#padding::part(hint) {
-		font-size: var(--font-size);
+		font-size: var(--body-font-size, 16px);
 		font-weight: normal;
 		color: var(--secondary-font-color);
 	}
@@ -152,7 +146,7 @@ export const imageGeneratorStyles = css`
 
 	wa-radio::part(label),
 	wa-checkbox::part(label) {
-		font-size: var(--font-size);
+		font-size: var(--body-font-size, 16px);
 	}
 
 	.custom-color-block {
@@ -163,7 +157,7 @@ export const imageGeneratorStyles = css`
 	}
 
 	.custom-color-block label {
-		font-size: var(--font-size);
+		font-size: var(--body-font-size, 16px);
 		font-weight: var(--form-label-weight);
 	}
 

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
@@ -145,15 +145,14 @@ export const imageGeneratorStyles = css`
 		width: 100%;
 	}
 
-	wa-radio,
-	wa-checkbox {
-		min-height: 44px;
-	}
-
 	wa-radio::part(base),
 	wa-checkbox::part(base) {
 		align-items: center;
-		min-height: 44px;
+	}
+
+	wa-radio::part(label),
+	wa-checkbox::part(label) {
+		font-size: 0.75em;
 	}
 
 	.custom-color-block {

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
@@ -159,6 +159,10 @@ export const imageGeneratorStyles = css`
 		--grid-width: min(315px, calc(100vw - 48px));
 	}
 
+	.custom-color-block wa-color-picker::part(form-control-label) {
+		font-size: var(--body-font-size, 16px);
+	}
+
 	@media (max-width: 760px) {
 		.form-grid {
 			grid-template-columns: 1fr;

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
@@ -152,7 +152,7 @@ export const imageGeneratorStyles = css`
 
 	wa-radio::part(label),
 	wa-checkbox::part(label) {
-		font-size: 0.75em;
+		font-size: var(--font-size);
 	}
 
 	.custom-color-block {

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
@@ -145,7 +145,7 @@ export const imageGeneratorStyles = css`
 		width: 100%;
 	}
 
-	wa-radio::part(base),
+	wa-radio,
 	wa-checkbox::part(base) {
 		align-items: center;
 	}

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
@@ -3,7 +3,7 @@ import { css } from "lit";
 export const imageGeneratorStyles = css`
 	:host {
 		--loader-size: 1.8em;
-		--form-label-size: var(--body-font-size, 16px);
+		--form-label-size: 18px;
 		--form-label-weight: var(--font-bold, 700);
 		--divider-color: #e2e4ea;
 	}

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
@@ -3,20 +3,20 @@ import { css } from "lit";
 export const imageGeneratorStyles = css`
 	:host {
 		--loader-size: 1.8em;
-		--heading-font-size: var(--large-font-size, 1.5em);
-		--heading-font-weight: bold;
+		--form-label-size: var(--body-font-size, 16px);
+		--form-label-weight: var(--font-bold, 700);
+		--divider-color: #e2e4ea;
+	}
+
+	* {
+		box-sizing: border-box;
 	}
 
 	h1 {
-		font-size: var(--xlarge-font-size, 2em);
-		line-height: 48px;
+		font-size: clamp(2rem, 4vw, var(--header-font-size, 36px));
+		line-height: 1.15;
 		letter-spacing: -0.015em;
 		margin: 0;
-	}
-
-	h2 {
-		font-size: var(--heading-font-size);
-		font-weight: var(--heading-font-weight);
 	}
 
 	p {
@@ -24,20 +24,75 @@ export const imageGeneratorStyles = css`
 	}
 
 	#image-generator-card {
-		background: #ffffff;
-		padding: 16px;
+		background: var(--primary-background-color, #ffffff);
+		border-radius: var(--card-border-radius, 10px);
+		margin: 0 auto;
+		max-width: 1080px;
+		padding: clamp(24px, 4vw, 48px);
+		width: 100%;
+	}
+
+	.page-intro {
+		border-bottom: 1px solid var(--divider-color);
+		padding-bottom: 24px;
+	}
+
+	.page-intro p {
+		color: var(--secondary-font-color);
+		font-size: var(--body-font-size, 16px);
+		margin: 8px 0 0;
+		max-width: 680px;
 	}
 
 	.form {
 		display: flex;
 		flex-direction: column;
 		gap: 24px;
+		margin-top: 28px;
+	}
+
+	.form-grid {
+		display: grid;
+		gap: 32px;
+		grid-template-columns: minmax(0, 2fr) minmax(240px, 1fr);
 	}
 
 	.form-left {
 		display: flex;
 		flex-direction: column;
 		gap: 24px;
+	}
+
+	.form-right {
+		border-left: 1px solid var(--divider-color);
+		padding-left: 32px;
+	}
+
+	.form-group {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.form-label {
+		color: var(--font-color);
+		font-size: var(--form-label-size);
+		font-weight: var(--form-label-weight);
+		line-height: 1.35;
+	}
+
+	.form-help {
+		color: var(--secondary-font-color);
+		line-height: 1.45;
+		margin: 4px 0 12px;
+	}
+
+	.form-bottom {
+		border-top: 1px solid var(--divider-color);
+		padding-top: 24px;
+	}
+
+	wa-button::part(base) {
+		min-height: 44px;
 	}
 
 	#submit wa-button::part(base) {
@@ -51,41 +106,94 @@ export const imageGeneratorStyles = css`
 	}
 
 	.main {
-		padding: 32px;
+		min-height: calc(100vh - 72px);
+		padding: clamp(16px, 4vw, 40px);
 	}
 
-	.color-radio, .platform-list {
+	.platform-list {
 		display: flex;
 		flex-direction: column;
-		gap: 10px;
-	}
-
-	.color-section, .padding-section, .image-section, .platforms-section {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
+		gap: 12px;
 	}
 
 	wa-radio-group#colorOption::part(form-control-label) {
-		font-size: var(--heading-font-size);
-		font-weight: var(--heading-font-weight);
+		font-size: var(--form-label-size);
+		font-weight: var(--form-label-weight);
 		color: var(--font-color);
 	}
 
 	wa-number-input#padding::part(form-control-label) {
-		font-size: var(--heading-font-size);
-		font-weight: var(--heading-font-weight);
+		font-size: var(--form-label-size);
+		font-weight: var(--form-label-weight);
 		color: var(--font-color);
+	}
+
+	wa-number-input#padding::part(base),
+	wa-number-input#padding::part(input),
+	wa-number-input#padding::part(stepper) {
+		min-height: 44px;
 	}
 
 	wa-number-input#padding::part(hint) {
 		font-size: var(--font-size);
 		font-weight: normal;
-		color: var(--font-color);
+		color: var(--secondary-font-color);
 	}
 
 	#padding {
-		width: 30%;
-		min-width: 220px;
+		max-width: 360px;
+		width: 100%;
+	}
+
+	wa-radio,
+	wa-checkbox {
+		min-height: 44px;
+	}
+
+	wa-radio::part(base),
+	wa-checkbox::part(base) {
+		align-items: center;
+		min-height: 44px;
+	}
+
+	.custom-color-block {
+		align-items: center;
+		display: flex;
+		gap: 12px;
+		margin-top: 12px;
+	}
+
+	.custom-color-block label {
+		font-size: var(--font-size);
+		font-weight: var(--form-label-weight);
+	}
+
+	.custom-color-block input {
+		height: 44px;
+		width: 56px;
+	}
+
+	@media (max-width: 760px) {
+		.form-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.form-right {
+			border-left: 0;
+			border-top: 1px solid var(--divider-color);
+			padding-left: 0;
+			padding-top: 24px;
+		}
+	}
+
+	@media (max-width: 480px) {
+		#image-generator-card {
+			border-radius: 8px;
+			padding: 24px 20px;
+		}
+
+		.main {
+			padding: 12px;
+		}
 	}
 `;

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.styles.ts
@@ -152,18 +152,11 @@ export const imageGeneratorStyles = css`
 	.custom-color-block {
 		align-items: center;
 		display: flex;
-		gap: 12px;
 		margin-top: 12px;
 	}
 
-	.custom-color-block label {
-		font-size: var(--body-font-size, 16px);
-		font-weight: var(--form-label-weight);
-	}
-
-	.custom-color-block input {
-		height: 44px;
-		width: 56px;
+	.custom-color-block wa-color-picker {
+		--grid-width: min(315px, calc(100vw - 48px));
 	}
 
 	@media (max-width: 760px) {

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.ts
@@ -91,6 +91,7 @@ export class ImageGenerator extends LitElement {
                       id="padding"
                       name="padding"
                       label="${loc.padding}"
+                      size="s"
                       max="1"
                       min="0"
                       step="0.1"

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.ts
@@ -72,50 +72,56 @@ export class ImageGenerator extends LitElement {
         return html`
       <div>
         <app-header></app-header>
-        <main id="main" class="main background">
+        <div id="main" class="main background">
           <div id="image-generator-card">
-            <h1>${loc.image_generator}</h1>
-            <p>${loc.image_generator_text}</p>
+            <header class="page-intro">
+              <h1>${loc.image_generator}</h1>
+              <p>${loc.image_generator_text}</p>
+            </header>
             <form id="imageFileInputForm" enctype="multipart/form-data" class="form">
-              <section class="form-left">
-                <div class="image-section">
-                  <h2>${loc.input_image}</h2>
-                  <p>${loc.input_image_help}</p>
-                  <app-file-input accept="image/png, image/svg+xml, image/jpeg, image/webp, image/gif, image/tiff, image/bmp" @input-change="${this.handleInputChange}"></app-file-input>
+              <div class="form-grid">
+                <div class="form-left">
+                  <div class="form-group image-section" role="group" aria-labelledby="base-image-label">
+                    <div id="base-image-label" class="form-label">${loc.input_image}</div>
+                    <p class="form-help">${loc.input_image_help}</p>
+                    <app-file-input accept="image/png, image/svg+xml, image/jpeg, image/webp, image/gif, image/tiff, image/bmp" @input-change="${this.handleInputChange}"></app-file-input>
+                  </div>
+                  <div class="form-group padding-section">
+                    <wa-number-input
+                      id="padding"
+                      name="padding"
+                      label="${loc.padding}"
+                      max="1"
+                      min="0"
+                      step="0.1"
+                      value=${this.padding}
+                      hint="${loc.padding_text}"
+                      @change=${this.handlePaddingChange} required></wa-number-input>
+                  </div>
+                  <div class="form-group color-section">
+                    <wa-radio-group
+                      id="colorOption"
+                      name="colorOption"
+                      label="${loc.background_color}"
+                      .value=${this.colorOption}
+                      @change=${this.handleBackgroundRadioChange}>
+                      <wa-radio value="best guess">${loc.best_guess}</wa-radio>
+                      <wa-radio value="transparent">${loc.transparent}</wa-radio>
+                      <wa-radio value="custom">${loc.custom_color}</wa-radio>
+                    </wa-radio-group>
+                    ${this.renderColorPicker()}
+                  </div>
                 </div>
-                <div class="padding-section">
-                  <wa-number-input
-                    id="padding"
-                    name="padding"
-                    label="${loc.padding}"
-                    max="1"
-                    min="0"
-                    step="0.1"
-                    value=${this.padding}
-                    hint="${loc.padding_text}"
-                    @change=${this.handlePaddingChange} required></wa-number-input>
+                <div class="form-right">
+                  <div class="form-group platforms-section" role="group" aria-labelledby="platforms-label">
+                    <div id="platforms-label" class="form-label">${loc.platforms}</div>
+                    <p class="form-help">${loc.platforms_text}</p>
+                    <div class="platform-list">
+                      ${this.renderPlatformList()}
+                    </div>
+                  </div>
                 </div>
-                <div class="color-section">
-                  <wa-radio-group
-                    id="colorOption"
-                    name="colorOption"
-                    label="${loc.background_color}"
-                    .value=${this.colorOption}
-                    @change=${this.handleBackgroundRadioChange}>
-                    <wa-radio value="best guess">${loc.best_guess}</wa-radio>
-                    <wa-radio value="transparent">${loc.transparent}</wa-radio>
-                    <wa-radio value="custom">${loc.custom_color}</wa-radio>
-                  </wa-radio-group>
-                  ${this.renderColorPicker()}
-                </div>
-              </section>
-              <section class="form-right platforms-section">
-                <h2 id="platforms-heading">${loc.platforms}</h2>
-                <p>${loc.platforms_text}</p>
-                <div role="group" aria-labelledby="platforms-heading" class="platform-list">
-                  ${this.renderPlatformList()}
-                </div>
-              </section>
+              </div>
               <section id="submit" class="form-bottom">
                 <wa-button id="generateButton" variant="brand" ?disabled=${!this.generateEnabled || this.generating}
                   @click=${this.generateZip}
@@ -128,7 +134,7 @@ export class ImageGenerator extends LitElement {
               </section>
             </form>
           </div>
-        </main>
+        </div>
       </div>
     `;
     }

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.ts
@@ -162,7 +162,7 @@ export class ImageGenerator extends LitElement {
   <wa-color-picker
     id="theme-custom-color"
     name="color"
-    label="${localeStrings.values.custom}"
+    label="${loc.select_color}"
     format="hex"
     size="s"
     without-format-toggle

--- a/apps/pwabuilder/Frontend/src/script/pages/image-generator.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/image-generator.ts
@@ -6,9 +6,11 @@ import { localeStrings } from "../../locales";
 import "../components/app-header";
 import "../components/app-file-input";
 import { FileInputDetails, Lazy } from "../utils/interfaces";
+import type WaColorPicker from '@awesome.me/webawesome/dist/components/color-picker/color-picker.js';
 
 import { recordProcessStep, AnalyticsBehavior } from "../utils/analytics";
 import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/color-picker/color-picker.js';
 import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
 import '@awesome.me/webawesome/dist/components/radio/radio.js';
 import '@awesome.me/webawesome/dist/components/checkbox/checkbox.js';
@@ -157,9 +159,16 @@ export class ImageGenerator extends LitElement {
     renderColorPicker() {
         if (this.colorOption === "custom") {
             return html`<div class="custom-color-block">
-  <label for="theme-custom-color">${localeStrings.values.custom}</label>
-  <input type="color" id="theme-custom-color" name="color" .value=${this.color}
-    @change=${this.handleThemeColorInputChange} />
+  <wa-color-picker
+    id="theme-custom-color"
+    name="color"
+    label="${localeStrings.values.custom}"
+    format="hex"
+    size="s"
+    without-format-toggle
+    .value=${this.color}
+    @change=${this.handleThemeColorInputChange}>
+  </wa-color-picker>
 </div>`;
         }
 
@@ -206,8 +215,8 @@ export class ImageGenerator extends LitElement {
     }
 
     handleThemeColorInputChange(event: Event) {
-        const input = event.target as HTMLInputElement;
-        this.color = input.value;
+        const input = event.target as WaColorPicker;
+        this.color = input.value ?? this.color;
         this.checkGenerateEnabled();
     }
 


### PR DESCRIPTION
## Summary

- replace oversized form section headings with compact labels and helper text
- reorganize image settings into a responsive two-column layout
- tighten spacing and standardize interactive controls to 44px touch targets
- remove the nested main landmark while preserving the existing skip target

This is a visual-design follow-up to #6267.

## Validation

- `npm run build` in `apps/pwabuilder/Frontend`
- Spiderloop visual review accepted at 8/10