### PR TITLE
Remove TypeScript compiler from runtime image

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -64,7 +64,12 @@ RUN npm run build
 WORKDIR /src/apps/pwabuilder/node-scripts
 RUN npm ci
 RUN npm run build
-RUN npm prune --omit=dev --ignore-scripts
+RUN npm prune --omit=dev --ignore-scripts \
+    && rm -rf node_modules/typescript node_modules/@typescript \
+    && rm -f node_modules/.bin/tsc \
+    && test ! -e node_modules/typescript \
+    && test ! -e node_modules/@typescript \
+    && test ! -e node_modules/.bin/tsc
 
 # Build backend
 WORKDIR /src/apps/pwabuilder


### PR DESCRIPTION
## Summary

- explicitly remove TypeScript and its platform-specific native compiler after building the Lighthouse scripts
- assert during the Docker build that no `typescript`, `@typescript`, or `tsc` artifact remains
- retain the production Lighthouse and Puppeteer dependencies

## Context

S360 reports GO-2026-4970 in `@typescript/typescript-linux-x64/lib/tsc` for image digest `sha256:54f90f05222966eb849f83748a8c21027370e717a4a4292d47388ed9b8ceadde`, deployed to both `pwabuilder` and `pwabuilder__11db`.

The existing `npm prune --omit=dev` does not remove TypeScript because npm classifies it as `devOptional`: TypeScript is a root development dependency and also an optional peer of the production dependency chain through Puppeteer and cosmiconfig. The compiler is build-only and should not be copied into the final image.

## Validation

- ran the node-scripts install and TypeScript build
- reproduced the production prune behavior
- removed the compiler artifacts and confirmed they are absent
- confirmed Lighthouse and Puppeteer remain as the production top-level dependencies