### PR TITLE
Fix CloudAPK image build broken by #6293: surgical Lint-jar remediation

### DIFF
--- a/apps/pwabuilder-google-play/Dockerfile
+++ b/apps/pwabuilder-google-play/Dockerfile
@@ -43,14 +43,18 @@ RUN echo export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-$(uname -m)/" >> /etc/jd
 
 FROM pre-base AS base
 
-# Install the Android SDK, then strip the Android Lint payload bundled inside
-# cmdline-tools. CloudAPK builds APK/AABs via Bubblewrap + Gradle and never runs
-# `lint`, so this tree is dead weight at runtime. It ships known-vulnerable
-# third-party jars (protobuf-java, jline-remote-telnet, commons-lang3, guava, ...)
-# that container scanners flag, and Google's cmdline-tools releases keep bundling
-# them, so a version bump alone doesn't clear the findings. Deleting the whole
-# external maven tree removes the current findings and prevents future recurrences
-# without affecting sdkmanager, platform-tools, build-tools, or the Gradle build.
+# Install the Android SDK, then remediate the vulnerable jars that ship inside the
+# Android Lint payload bundled in cmdline-tools. Container scanners keep flagging
+# these and Google's cmdline-tools releases keep bundling them, so a version bump
+# alone doesn't clear the findings.
+#   * lib/external/lint-psi bundles an old protobuf-java (2.6.1) and
+#     jline-remote-telnet (3.24.1) inside its Kotlin compiler. It is only used by
+#     `lint`, which CloudAPK (Bubblewrap + Gradle) never runs, so we delete it.
+#     sdkmanager keeps its own protobuf-java 3.25.5 elsewhere in lib/external.
+#   * commons-lang3 3.16.0 is referenced by sdkmanager's Class-Path manifest, so we
+#     overwrite it in place with the patched 3.18.0 (API-compatible). The 3.16.0
+#     filename is kept intentionally so every bundled *-classpath.jar manifest still
+#     resolves it; scanners read the jar's internal metadata and see 3.18.0.
 RUN wget --quiet -O sdk-tools.zip \
     "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS_VERSION}_latest.zip" && \
     mkdir -p "$ANDROID_HOME/cmdline-tools" && \
@@ -65,7 +69,9 @@ RUN wget --quiet -O sdk-tools.zip \
     echo yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;35.0.0" && \
     echo yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;34.0.0" && \
     echo yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses && \
-    rm -rf "$ANDROID_HOME/cmdline-tools/latest/lib/external"
+    rm -rf "$ANDROID_HOME/cmdline-tools/latest/lib/external/lint-psi" && \
+    wget --quiet -O "$ANDROID_HOME/cmdline-tools/latest/lib/external/org/apache/commons/commons-lang3/3.16.0/commons-lang3-3.16.0.jar" \
+    "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar"
 
 
 FROM base AS jenv-base


### PR DESCRIPTION
## Why this PR

#6293 merged the **whole-tree** `rm -rf cmdline-tools/latest/lib/external`, which **breaks the image build**: `sdkmanager` loads Guava from that tree, so wiping it throws `java.lang.NoClassDefFoundError: com/google/common/collect/Multimap` (seen in the base-image build). This PR replaces that with a **surgical** remediation that clears the same scanner findings *without* breaking sdkmanager.

The net change vs `main` is a single file (`apps/pwabuilder-google-play/Dockerfile`): the whole-tree `rm -rf .../lib/external` is swapped for the targeted steps below.

## The findings (all inside Google's bundled Android Lint payload)

| Package | Installed | Advisories |
|---|---|---|
| `com.google.protobuf:protobuf-java` | 2.6.1 | GHSA-wrvw-hg22-4m67, GHSA-h4h5-3hr4-j3g2, GHSA-735f-pc8j-v9w8 |
| `org.jline:jline-remote-telnet` | 3.24.1 | GHSA-47qp-hqvx-6r3f, GHSA-2r2c-cx56-8933 |
| `org.apache.commons:commons-lang3` | 3.16.0 | GHSA-j288-q9x7-2f5v |

## What this does

- **Delete only `lib/external/lint-psi`** — the lint-only Kotlin compiler that bundles the flagged `protobuf-java 2.6.1` and `jline-remote-telnet 3.24.1`. CloudAPK builds via Bubblewrap + Gradle and never runs `lint`. sdkmanager keeps its own `protobuf-java 3.25.5` (non-vulnerable) elsewhere in `lib/external`.
- **Overwrite the classpath `commons-lang3 3.16.0` jar in place with patched `3.18.0`** (API-compatible). sdkmanager references `commons-lang3` on its `Class-Path` manifest, so the file must stay; the `3.16.0` filename is kept intentionally so every bundled `*-classpath.jar` manifest still resolves it. The scanner is content-based (it detects the nested jar version), so it now reads `3.18.0`.

## Validation

Built locally to the `pre-minimal` stage (`--no-cache`), which runs `sdkmanager --licenses` and `--list` after remediation — both pass (whereas the whole-tree removal fails there). In-container checks:
- `sdkmanager --version`, `--list`, and a `platform-tools` install all exit 0.
- Built image contains **no** `kotlin-compiler-mvn.jar`, jline, or `protobuf-java 2.6.1`; only `protobuf-java 3.25.5` remains.
- `commons-lang3` jar internally reports `version=3.18.0`.

App/npm stages are unchanged; CI builds the full image and re-runs the container scan.

## Post-merge check

Confirm the six advisories clear on the next `cloudapk-prod` scan, and that a CloudAPK signed-package request still returns a ZIP containing `.apk` + `.aab`.

Supersedes the broken remediation merged in #6293.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 8cef0be9-405e-414c-8cbb-54bbe62b64e4