### PR TITLE
fix(security): patch container vulns for js-yaml and propagator-jaeger

### DIFF
--- a/apps/pwabuilder-google-play/package-lock.json
+++ b/apps/pwabuilder-google-play/package-lock.json
@@ -2437,27 +2437,12 @@
             }
         },
         "node_modules/@opentelemetry/propagator-jaeger": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.8.0.tgz",
-            "integrity": "sha512-Xnz9zZvvQzUw+9DrOn0MomR7BxFCkA2pcfXBQuHC28ndJpSbjLs7knzYb05kw5SyCjSsEWombkZMgGcJSk8JVg==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.10.0.tgz",
+            "integrity": "sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "2.8.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
-            "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/semantic-conventions": "^1.29.0"
+                "@opentelemetry/core": "2.10.0"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"

--- a/apps/pwabuilder-google-play/package.json
+++ b/apps/pwabuilder-google-play/package.json
@@ -70,6 +70,7 @@
         "async": ">=3.2.2",
         "file-type": "21.3.4",
         "minimatch": ">=3.0.2",
-        "tar": ">=7.5.20"
+        "tar": ">=7.5.20",
+        "@opentelemetry/propagator-jaeger": ">=2.9.0"
     }
 }

--- a/apps/pwabuilder/node-scripts/package-lock.json
+++ b/apps/pwabuilder/node-scripts/package-lock.json
@@ -1980,9 +1980,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Fixes corporate security-reported container vulnerabilities in the **pwabuilder** and **cloudapk** container images (vulns-5 batch).

| Container | Package | From | To | Advisory |
|-----------|---------|------|----|----------|
| pwabuilder (`node-scripts`) | `js-yaml` | 4.2.0 | 4.3.1 | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (req ≥ 4.3.0) |
| cloudapk (`pwabuilder-google-play`) | `@opentelemetry/propagator-jaeger` | 2.8.0 | 2.10.0 | [GHSA-45rx-2jwx-cxfr](https://github.com/open-telemetry/opentelemetry-js/security/advisories/GHSA-45rx-2jwx-cxfr) (req ≥ 2.9.0) |

## Changes

- **`js-yaml`** is a transitive dependency pulled in via `^4.1.0`, so a lockfile update was sufficient to move it to 4.3.1.
- **`@opentelemetry/propagator-jaeger`** was pinned to `2.8.0` exactly by `@opentelemetry/sdk-node`, so a plain `npm update` couldn't move it. Added a `>=2.9.0` entry to the existing `overrides` block in `apps/pwabuilder-google-play/package.json` (following the repo's established override pattern). It resolves to 2.10.0; its `@opentelemetry/core@2.10.0` dependency hoists to the already-present top-level entry.

## Verification

- Both lockfiles validated as well-formed JSON.
- `resolved` URLs kept on `registry.npmjs.org` for consistency with the rest of the lockfiles; npm substitutes the configured registry (Microsoft delayed proxy) at install time and gates on `integrity`.
- **Integrity hashes verified**: recomputed sha1 of each downloaded tarball matches the registry's published `shasum` (authentic content), and the `sha512` integrity written into the lockfiles matches a fresh recomputation — so `npm ci` validates cleanly.
- Both target versions are >3 weeks old, clearing the 7-day security-mirror delay, so they're already available on the Microsoft npm proxy.