### PR TITLE
Halt analysis on base64 manifest and prevent Cosmos 413

### DIFF
--- a/apps/pwabuilder/Frontend/src/script/pages/app-report.styles.ts
+++ b/apps/pwabuilder/Frontend/src/script/pages/app-report.styles.ts
@@ -1498,7 +1498,7 @@ export const appReportStyles = css`
 
 		&::part(header) {
 			background-image: url('/assets/new/mani-dead.webp');
-			background-size: contain;
+			background-size: cover;
 			background-repeat: no-repeat;
 			@media (max-width: 535px) {
 				background-position-x: center;

--- a/apps/pwabuilder/Services/AnalysisJobProcessor.cs
+++ b/apps/pwabuilder/Services/AnalysisJobProcessor.cs
@@ -188,6 +188,19 @@ public class AnalysisJobProcessor : IHostedService
         analysis.ProcessCapabilities(manifestCapabilities);
         await analysisStore.SaveAsync(analysis);
 
+        // Step 3.5: if the manifest contains inline base64-encoded images, halt analysis immediately.
+        // Such manifests can't be published to app stores and their large inline images bloat the pipeline
+        // (slow service worker/offline checks, oversized documents that fail to persist), so we stop here with
+        // the base64 error surfaced rather than running the remaining checks for several minutes.
+        if (HaltIfManifestHasBase64Images(analysis, cancelTokenSrc))
+        {
+            analysis.Duration = DateTimeOffset.UtcNow.Subtract(analysis.CreatedAt);
+            analysisLogger.FlushLogs();
+            logger.LogWarning("Halted analysis {id} for {url} after {duration} seconds because the manifest contains inline base64-encoded images. Remaining checks were skipped.", analysis.Id, job.Url, analysis.Duration?.TotalSeconds);
+            await analysisStore.SaveAsync(analysis);
+            return;
+        }
+
         // Step 4: find the service worker.
         analysis.ServiceWorker = await serviceWorkerDetectionTask;
         await analysisStore.SaveAsync(analysis);
@@ -236,6 +249,31 @@ public class AnalysisJobProcessor : IHostedService
         }
 
         return servedHtmlCapability.Status;
+    }
+
+    /// <summary>
+    /// Checks whether the detected manifest contains inline base64-encoded images. If so, the analysis is halted:
+    /// the cancellation token is triggered to stop in-flight detection, any remaining in-progress checks are
+    /// skipped, and the analysis is marked as completed so the base64 error is surfaced to the user without
+    /// waiting on the slower service worker and offline checks.
+    /// </summary>
+    /// <param name="analysis">The analysis.</param>
+    /// <param name="cancelTokenSrc">The cancellation token source used to abort remaining work.</param>
+    /// <returns><c>true</c> if the manifest had base64-encoded images and analysis was halted; otherwise <c>false</c>.</returns>
+    private static bool HaltIfManifestHasBase64Images(Analysis analysis, CancellationTokenSource cancelTokenSrc)
+    {
+        if (analysis.WebManifest?.HasBase64EncodedImages is not true)
+        {
+            return false;
+        }
+
+        cancelTokenSrc.Cancel();
+        analysis.Status = AnalysisStatus.Completed;
+        analysis.Capabilities
+            .Where(capability => capability.Status == PwaCapabilityCheckStatus.InProgress)
+            .ToList()
+            .ForEach(capability => capability.Status = PwaCapabilityCheckStatus.Skipped);
+        return true;
     }
 
     // private async Task<LighthouseReport?> TryRunLighthouseAudit(AnalysisJob job, AnalysisLogger logger, CancellationToken cancelToken)

--- a/apps/pwabuilder/Services/AnalysisLogger.cs
+++ b/apps/pwabuilder/Services/AnalysisLogger.cs
@@ -9,6 +9,13 @@ namespace PWABuilder.Services;
 /// </summary>
 public class AnalysisLogger : ILogger
 {
+    /// <summary>
+    /// Maximum length of a single log entry stored on the analysis. Entries longer than this are truncated so a single
+    /// oversized value (for example, a manifest served from a multi-megabyte inline <c>data:</c> URI, or a large HTML/stack
+    /// trace dump) can't bloat <see cref="Analysis.Logs"/> and cause the analysis document to exceed Cosmos DB's size limit.
+    /// </summary>
+    private const int MaxLogMessageLength = 4096;
+
     private readonly ConcurrentQueue<string> logs = new();
     private readonly Analysis analysis;
     private readonly ILogger serviceLogger;
@@ -45,6 +52,12 @@ public class AnalysisLogger : ILogger
             {
                 message += $" | StackTrace: {exception.StackTrace}";
             }
+        }
+
+        // Truncate overly long entries so a single huge value can't bloat the analysis document beyond Cosmos DB's size limit.
+        if (message.Length > MaxLogMessageLength)
+        {
+            message = message[..MaxLogMessageLength] + $"…[truncated {message.Length - MaxLogMessageLength} chars]";
         }
 
         logs.Enqueue(message);

--- a/apps/pwabuilder/Services/ManifestDetector.cs
+++ b/apps/pwabuilder/Services/ManifestDetector.cs
@@ -189,6 +189,18 @@ public class ManifestDetector
             logger.LogWarning("Detected inline base64-encoded images in a web manifest for host {manifestHost}. Images in a manifest must be external URLs.", manifestUrl.Host);
         }
 
+        // A manifest can be served from an inline data: URI (for example, a base64-encoded manifest injected into the page at
+        // runtime). Such URLs can be many megabytes, which bloats the stored analysis and causes Cosmos to reject the document
+        // with a 413. We can neither store nor meaningfully display a multi-megabyte URL, so replace it with a compact placeholder
+        // and treat it like the base64 image case: flag it so analysis surfaces the error and halts instead of persisting the value.
+        var storedManifestUrl = manifestUrl;
+        if (string.Equals(manifestUrl.Scheme, "data", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogWarning("A web manifest was served from an inline data: URI. Replacing the manifest URL with a placeholder to avoid storing megabytes of inline base64 data.");
+            storedManifestUrl = OmittedManifestUrl;
+            hasBase64EncodedImages = true;
+        }
+
         // We can't have more than 2.5m characters in the manifest (roughly 10MB)
         // This is to prevent very large manifests that encode the entire images inside the manifest.
         if (sanitizedManifestJson.Length > 2_500_000)
@@ -218,7 +230,7 @@ public class ManifestDetector
 
         return new ManifestDetection
         {
-            Url = manifestUrl,
+            Url = storedManifestUrl,
             Manifest = manifest,
             ManifestRaw = sanitizedManifestJson,
             HasBase64EncodedImages = hasBase64EncodedImages
@@ -253,6 +265,12 @@ public class ManifestDetector
     /// The placeholder value that replaces inline base64-encoded image data URLs stripped from a manifest.
     /// </summary>
     private const string Base64ImagePlaceholder = "data:[omitted-by-pwabuilder]";
+
+    /// <summary>
+    /// The placeholder manifest URL stored when the real manifest was served from an oversized inline <c>data:</c> URI.
+    /// Storing the original multi-megabyte data URI would bloat the analysis document and cause Cosmos to reject it (413).
+    /// </summary>
+    private static readonly Uri OmittedManifestUrl = new(Base64ImagePlaceholder);
 
     /// <summary>
     /// Matches inline base64-encoded image data URLs such as <c>data:image/png;base64,AAAA...</c>.


### PR DESCRIPTION
## Summary

Follow-up to #6309. When a web manifest contains inline base64-encoded images — or the manifest itself is served from a large `data:` URI injected at runtime — analysis would run the full pipeline for **several minutes** and then fail with a Cosmos DB `RequestEntityTooLarge (413)` because the oversized value was persisted. This PR makes analysis halt immediately and stops the oversized data from ever reaching Cosmos.

## Changes

- **Halt immediately on base64** (`AnalysisJobProcessor`): after the manifest is analyzed, if base64 images are detected the analysis is marked `Completed`, remaining in-progress checks are `Skipped`, and the in-flight service worker / offline detection is cancelled. The base64 error surfaces right away instead of after minutes of unnecessary work. Mirrors the existing `FailIfNotServedHtml` fast-exit pattern.
- **Replace inline `data:` manifest URLs** (`ManifestDetector`): a manifest served from a `data:` URI can be many megabytes. We now store a compact placeholder (`data:[omitted-by-pwabuilder]`) instead of the raw URL and flag it as base64 so it triggers the same halt + error path, rather than persisting the huge value.
- **Cap analysis log entry length** (`AnalysisLogger`): each log entry is truncated to 4096 chars so a single oversized value (e.g. a logged multi-MB `data:` URL, or a large HTML/stack dump) can't bloat `Analysis.Logs` past the Cosmos document size limit. General safety net for the second channel that was leaking the data URI into the stored document.
- **CSS tweak** (`app-report.styles.ts`): the `.analysis-error-dialog` header background uses `background-size: cover` instead of `contain`.

## Root cause

For sites like `https://maxout120.netlify.app/`, the manifest link is injected at runtime as a `data:application/json;base64,...` URI whose payload embeds base64 images. Image sanitization from #6309 shrank the manifest *content*, but the giant value still reached Cosmos through two channels: `WebManifest.Url` and `Analysis.Logs` (the detector logs the full manifest URL). Both are now handled at the source, and the analysis halts before running the slow steps.

## Verification

Ran locally against `maxout120.netlify.app`:

- `status = Completed` in **3.4s** (previously minutes → timeout/413)
- `webManifest.url = data:[omitted-by-pwabuilder]` (giant `data:` URI no longer stored)
- `hasBase64EncodedImages = True`, `ImagesAreNotBase64Encoded = Failed` (error surfaced)
- Service worker / offline / icon-fetch checks = `Skipped` (halted early, no redundant action items)
- Backend builds clean (0 warnings / 0 errors)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>