### PR TITLE
Update brace-expansion to address container vulnerability

### DIFF
--- a/apps/pwabuilder-google-play/package-lock.json
+++ b/apps/pwabuilder-google-play/package-lock.json
@@ -4407,15 +4407,15 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {


### PR DESCRIPTION
N/A — reported by the production container vulnerability scan; no linked GitHub issue.

## PR Type

- Bugfix

## Describe the current behavior?

The CloudAPK production dependency tree resolves `brace-expansion@5.0.7` through `archiver -> readdir-glob -> minimatch`. The deployed image is consequently reported for CVE-2026-14257 / GHSA-mh99-v99m-4gvg. The two reported alerts reference the same image digest and vulnerability.

## Describe the new behavior?

The generated lockfile now resolves `brace-expansion@5.0.9`. This clears CVE-2026-14257 while also avoiding the follow-up advisory affecting version 5.0.8. No direct dependency or base-image change is introduced.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). No UI behavior is changed.

## Additional Information

Validated with:

- `npm ci --omit=dev --ignore-scripts`
- `npm ls brace-expansion --all` resolving `brace-expansion@5.0.9`
- `npm audit --omit=dev`, which no longer reports `brace-expansion`
- `git diff --check`

The package audit still reports six unrelated pre-existing vulnerabilities (three moderate and three high).