### PR TITLE
Add durable queued Windows packaging

### DIFF
--- a/.github/workflows/deploy-msstore-to-preview.yml
+++ b/.github/workflows/deploy-msstore-to-preview.yml
@@ -4,11 +4,13 @@ on:
   push:
     paths:
       - "apps/pwabuilder-microsoft-store/**"
+      - "apps/pwabuilder-microsoft-store.Tests/**"
       - ".github/workflows/deploy-msstore-to-preview.yml"
     branches: ["main"]
   pull_request:
     paths:
       - "apps/pwabuilder-microsoft-store/**"
+      - "apps/pwabuilder-microsoft-store.Tests/**"
       - ".github/workflows/deploy-msstore-to-preview.yml"
     branches: [main]
   workflow_dispatch:
@@ -24,6 +26,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: "true"
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+      - name: Test Windows packaging and durable jobs
+        run: dotnet test apps/pwabuilder-microsoft-store.Tests/PWABuilder.MicrosoftStore.Tests.csproj --configuration Release --verbosity minimal
       - uses: microsoft/variable-substitution@v1
         with:
           files: "./apps/pwabuilder-microsoft-store/appsettings.Production.json"

--- a/apps/pwabuilder-microsoft-store.Tests/PackagingPipelineTests.cs
+++ b/apps/pwabuilder-microsoft-store.Tests/PackagingPipelineTests.cs
@@ -358,14 +358,19 @@ public sealed class PackagingPipelineTests
     {
         /// <inheritdoc/>
         public string ApplicationName { get; set; } = "PackagingTests";
+
         /// <inheritdoc/>
         public string EnvironmentName { get; set; } = "Development";
+
         /// <inheritdoc/>
         public string ContentRootPath { get; set; } = root;
+
         /// <inheritdoc/>
         public string WebRootPath { get; set; } = root;
+
         /// <inheritdoc/>
         public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+
         /// <inheritdoc/>
         public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
     }
@@ -373,8 +378,11 @@ public sealed class PackagingPipelineTests
     private sealed class PipelineFixture : IDisposable
     {
         private readonly ServiceProvider provider;
+
         private readonly HttpClient http;
+
         private readonly ZombieProcessKiller killer;
+
         private readonly TelemetryConfiguration telemetry;
 
         /// <summary>
@@ -427,31 +435,69 @@ public sealed class PackagingPipelineTests
             };
         }
 
-        /// <summary>Gets the owned artifact root.</summary>
+        /// <summary>
+        /// Gets the owned artifact root.
+        /// </summary>
         public string Root { get; }
-        /// <summary>Gets the build settings.</summary>
+
+        /// <summary>
+        /// Gets the build settings.
+        /// </summary>
         public AppSettings Settings { get; }
-        /// <summary>Gets the disposable build scope.</summary>
+
+        /// <summary>
+        /// Gets the disposable build scope.
+        /// </summary>
         public IServiceScope Scope { get; }
-        /// <summary>Gets the scoped temporary-file owner.</summary>
+
+        /// <summary>
+        /// Gets the scoped temporary-file owner.
+        /// </summary>
         public TempDirectory Temp { get; }
-        /// <summary>Gets the locally captured telemetry.</summary>
+
+        /// <summary>
+        /// Gets the locally captured telemetry.
+        /// </summary>
         public TelemetryChannel Channel { get; }
-        /// <summary>Gets the package entry point.</summary>
+
+        /// <summary>
+        /// Gets the package entry point.
+        /// </summary>
         public WindowsAppPackageCreator Creator { get; }
-        /// <summary>Gets the package options.</summary>
+
+        /// <summary>
+        /// Gets the package options.
+        /// </summary>
         public WindowsAppPackageOptions PackageOptions { get; }
-        /// <summary>Gets the SDK packager.</summary>
+
+        /// <summary>
+        /// Gets the SDK packager.
+        /// </summary>
         public MakeAppxWrapper MakeAppx { get; }
-        /// <summary>Gets the SDK resource generator.</summary>
+
+        /// <summary>
+        /// Gets the SDK resource generator.
+        /// </summary>
         public MakePriWrapper MakePri { get; }
-        /// <summary>Gets the classic package generator.</summary>
+
+        /// <summary>
+        /// Gets the classic package generator.
+        /// </summary>
         public ClassicWindowsPackageCreator Classic { get; }
-        /// <summary>Gets the EdgeHTML package generator.</summary>
+
+        /// <summary>
+        /// Gets the EdgeHTML package generator.
+        /// </summary>
         public SpartanWindowsPackageCreator Spartan { get; }
-        /// <summary>Gets the modern package generator.</summary>
+
+        /// <summary>
+        /// Gets the modern package generator.
+        /// </summary>
         public ModernWindowsPackageCreator Modern { get; }
-        /// <summary>Gets the native PWABuilder tool.</summary>
+
+        /// <summary>
+        /// Gets the native PWABuilder tool.
+        /// </summary>
         public PwaBuilderWrapper PwaBuilder { get; }
 
         /// <inheritdoc/>

--- a/apps/pwabuilder-microsoft-store.Tests/PackagingPipelineTests.cs
+++ b/apps/pwabuilder-microsoft-store.Tests/PackagingPipelineTests.cs
@@ -1,0 +1,469 @@
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using PWABuilder.MicrosoftStore.Models;
+using PWABuilder.MicrosoftStore.Services;
+using System.Net;
+using System.IO.Compression;
+using System.Reflection;
+using System.Text.Json;
+using Xunit;
+
+namespace PWABuilder.MicrosoftStore.Tests;
+
+/// <summary>
+/// Tests package-file lifetime, archive compatibility, telemetry, and pipeline cancellation without native SDK tools.
+/// </summary>
+public sealed class PackagingPipelineTests
+{
+    /// <summary>
+    /// Verifies manifest download cancellation is neither wrapped nor treated as fallback.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Find_WhenHttpCanceled_PreservesCancellation(bool explicitManifestUrl)
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var handler = new CancelingHandler(cancellation.Token);
+        using var http = new HttpClient(handler);
+        using var temp = new TempDirectory(Settings(), NullLogger<TempDirectory>.Instance);
+        var finder = new WebManifestFinder(new HttpFactory(http), NullLogger<WebManifestFinder>.Instance, temp);
+        var options = new WindowsAppPackageOptions
+        {
+            Url = new Uri("https://example.com"),
+            ManifestUrl = explicitManifestUrl ? new Uri("https://example.com/manifest.json") : null
+        };
+        var error = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => finder.Find(options));
+        Assert.Equal(cancellation.Token, error.CancellationToken);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    /// <summary>
+    /// Verifies cancelled image downloads do not retry another protocol or fallback source.
+    /// </summary>
+    [Fact]
+    public async Task Generate_WhenHttpCanceled_DoesNotFallback()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var handler = new CancelingHandler(cancellation.Token);
+        using var http = new HttpClient(handler);
+        using var manifest = JsonDocument.Parse("""{"icons":[{"src":"icon.png","sizes":"512x512","type":"image/png"}]}""");
+        var generator = new ImageGenerator(new HttpFactory(http), Settings(), NullLogger<ImageGenerator>.Instance);
+        var error = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            generator.Generate(new WindowsAppPackageOptions { Url = new Uri("https://example.com") }, WebAppManifestContext.From(manifest, new Uri("https://example.com/manifest.json")), AppContext.BaseDirectory));
+        Assert.Equal(cancellation.Token, error.CancellationToken);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    /// <summary>
+    /// Verifies queued builds expose the path-based package entry point.
+    /// </summary>
+    [Fact]
+    public void WindowsAppPackageCreator_ExposesFileOutput()
+    {
+        var method = typeof(WindowsAppPackageCreator).GetMethod("CreateAppPackageFileAsync");
+        Assert.NotNull(method);
+        Assert.Equal(new[] { typeof(WindowsAppPackageOptions), typeof(AnalyticsInfo), typeof(CancellationToken) }, method.GetParameters().Select(parameter => parameter.ParameterType));
+        var resultType = Assert.Single(method.ReturnType.GenericTypeArguments);
+        Assert.Equal(typeof(string), resultType.GetProperty("FilePath")?.PropertyType);
+        Assert.Equal(typeof(ModernWindowsPackageResult), resultType.GetProperty("ModernAppPackage")?.PropertyType);
+        Assert.DoesNotContain(resultType.GetProperties(), property => property.PropertyType == typeof(byte[]));
+    }
+
+    /// <summary>
+    /// Verifies file output survives until the owning DI scope is disposed, with a single success event.
+    /// </summary>
+    [Fact]
+    public async Task CreateAppPackageFileAsync_RetainsFilesUntilScopeDisposal()
+    {
+        using var fixture = new PipelineFixture();
+        var result = await fixture.Creator.CreateAppPackageFileAsync(fixture.PackageOptions, new AnalyticsInfo(), CancellationToken.None);
+        Assert.True(File.Exists(result.FilePath));
+        Assert.True(File.Exists(fixture.PackageOptions.ManifestFilePath));
+        using (var zip = ZipFile.OpenRead(result.FilePath))
+        {
+            Assert.Empty(zip.Entries);
+        }
+        Assert.Null(result.ModernAppPackage);
+        Assert.Equal("WindowsTestPackageEvent", Assert.Single(fixture.Channel.Events).Name);
+
+        fixture.Scope.Dispose();
+        Assert.False(File.Exists(result.FilePath));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(fixture.Root));
+    }
+
+    /// <summary>
+    /// Verifies the legacy endpoint still returns ZIP bytes and cleans them up immediately.
+    /// </summary>
+    [Fact]
+    public async Task CreateAppPackageAsync_ReturnsBytesAndCleansFiles()
+    {
+        using var fixture = new PipelineFixture();
+        var result = await fixture.Creator.CreateAppPackageAsync(fixture.PackageOptions, new AnalyticsInfo(), CancellationToken.None);
+        using var zip = new ZipArchive(new MemoryStream(result.PackageBytes), ZipArchiveMode.Read);
+        Assert.Empty(zip.Entries);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(fixture.Root));
+        Assert.Equal("WindowsTestPackageEvent", Assert.Single(fixture.Channel.Events).Name);
+    }
+
+    /// <summary>
+    /// Verifies failed builds retain diagnostics until disposal and record exactly one failure.
+    /// </summary>
+    [Fact]
+    public async Task CreateAppPackageFileAsync_WhenBuildFails_CleansAtScopeDisposal()
+    {
+        using var fixture = new PipelineFixture();
+        fixture.PackageOptions.GenerateModernPackage = true;
+        await Assert.ThrowsAsync<ProcessException>(() =>
+            fixture.Creator.CreateAppPackageFileAsync(fixture.PackageOptions, new AnalyticsInfo(), CancellationToken.None));
+        Assert.True(File.Exists(fixture.PackageOptions.ManifestFilePath));
+        Assert.Equal("WindowsPackageFailureEvent", Assert.Single(fixture.Channel.Events).Name);
+
+        fixture.Scope.Dispose();
+        Assert.Empty(Directory.EnumerateFileSystemEntries(fixture.Root));
+    }
+
+    /// <summary>
+    /// Verifies scoped cancellation reaches an in-flight HTTP request without recording a build failure.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CreateAppPackageFileAsync_WhenCanceled_StopsHttpAndSkipsFailureTelemetry(bool generatingImages)
+    {
+        using var handler = new BlockingHandler(generatingImages);
+        using var fixture = new PipelineFixture(handler);
+        using var cancellation = new CancellationTokenSource();
+        var run = fixture.Creator.CreateAppPackageFileAsync(fixture.PackageOptions, new AnalyticsInfo(), cancellation.Token);
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        var error = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(cancellation.Token, error.CancellationToken);
+        Assert.Empty(fixture.Channel.Events);
+        Assert.Equal(generatingImages ? 2 : 1, handler.RequestCount);
+        Assert.True(File.Exists(fixture.PackageOptions.ManifestFilePath));
+
+        fixture.Scope.Dispose();
+        Assert.Empty(Directory.EnumerateFileSystemEntries(fixture.Root));
+    }
+
+    /// <summary>
+    /// Verifies cancellation stops manifest discovery's in-flight request and preserves its token.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Find_WhenTokenCanceled_StopsInFlightRequest(bool explicitManifestUrl)
+    {
+        using var handler = new BlockingHandler();
+        using var fixture = new PipelineFixture(handler);
+        using var cancellation = new CancellationTokenSource();
+        fixture.PackageOptions.Manifest?.Dispose();
+        fixture.PackageOptions.Manifest = null;
+        fixture.PackageOptions.ManifestUrl = explicitManifestUrl ? new Uri("https://example.com/manifest.json") : null;
+        var run = fixture.Creator.CreateAppPackageFileAsync(fixture.PackageOptions, new AnalyticsInfo(), cancellation.Token);
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        var error = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(cancellation.Token, error.CancellationToken);
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Empty(fixture.Channel.Events);
+    }
+
+    /// <summary>
+    /// Verifies all native pipeline entry points reject an already-cancelled build before file access.
+    /// </summary>
+    [Fact]
+    public async Task NativePipeline_WhenAlreadyCanceled_DoesNotTouchFiles()
+    {
+        using var fixture = new PipelineFixture();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var manifest = WebAppManifestContext.From(fixture.PackageOptions.Manifest!, fixture.PackageOptions.Url);
+        var images = new ImageGeneratorResult([]);
+        var token = cancellation.Token;
+        var calls = new Func<Task>[]
+        {
+            () => fixture.MakeAppx.Execute("missing", "missing", token),
+            () => fixture.MakeAppx.Bundle("missing", new Version(1, 0), token),
+            () => fixture.MakeAppx.BundlePlatforms([], "missing", new Version(1, 0), token),
+            () => fixture.MakePri.Execute("missing", "missing", token),
+            () => fixture.Classic.Create(fixture.PackageOptions, manifest, images, "missing", null, token),
+            () => fixture.Spartan.Create(fixture.PackageOptions, manifest, images, "missing", token),
+            () => fixture.Modern.Create(fixture.PackageOptions, images, manifest, "missing", token),
+            () => fixture.PwaBuilder.Run(fixture.PackageOptions, images, manifest, "missing", "", token),
+            () => fixture.Creator.CreateMsixAsync(fixture.PackageOptions, token)
+        };
+        foreach (var call in calls)
+        {
+            var error = await Assert.ThrowsAnyAsync<OperationCanceledException>(call);
+            Assert.Equal(token, error.CancellationToken);
+        }
+        Assert.Empty(Directory.EnumerateFileSystemEntries(fixture.Root));
+    }
+
+    /// <summary>
+    /// Verifies ZIP contents and Unicode install scripts remain identical across all package flavors.
+    /// </summary>
+    [Fact]
+    public async Task CreateZipPackage_PreservesAllPackageEntries()
+    {
+        using var fixture = new PipelineFixture();
+        var artifacts = fixture.Temp.CreateDirectory();
+        string WriteArtifact(string name, string content)
+        {
+            var path = Path.Combine(artifacts, name);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        var modern = new ModernWindowsPackageResult(WriteArtifact("modern.msixbundle", "modern"), WriteArtifact("sideload.msix", "sideload"), new HostedPackage());
+        var classic = new ClassicWindowsPackageResult { AppxFilePath = WriteArtifact("classic.appxbundle", "classic") };
+        var loose = fixture.Temp.CreateDirectory();
+        await File.WriteAllTextAsync(Path.Combine(loose, "AppxManifest.xml"), "spartan-manifest");
+        var spartan = new SpartanWindowsPackageResult { AppxPath = WriteArtifact("spartan.appxbundle", "spartan"), AppxLooseFilesDirectory = loose };
+        fixture.Settings.InstallScriptPath = WriteArtifact("install-template.ps1", "$$APP_DISPLAY_NAME$$ $$MSIX_FILE_NAME$$");
+        fixture.Settings.SpartanInstallScriptPath = WriteArtifact("spartan-template.ps1", "$$APP_DISPLAY_NAME$$");
+        fixture.Settings.PwaInstallerPath = WriteArtifact("installer.exe", "installer");
+        fixture.Settings.ReadmePath = WriteArtifact("modern-readme.html", "modern-readme");
+        fixture.Settings.SpartanReadmePath = WriteArtifact("spartan-readme.html", "spartan-readme");
+        fixture.PackageOptions.Name = "PWA Café";
+        fixture.PackageOptions.GenerateModernPackage = true;
+
+        var createZip = typeof(WindowsAppPackageCreator).GetMethod("CreateZipPackage", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var path = await (Task<string>)createZip.Invoke(fixture.Creator, [fixture.PackageOptions, modern, classic, spartan, CancellationToken.None])!;
+        using var zip = ZipFile.OpenRead(path);
+        Assert.Equal(new[]
+        {
+            "EdgeHTML-sideload\\AppxManifest.xml", "PWA Café.classic.appxbundle", "PWA Café.edgehtml.appxbundle",
+            "PWA Café.msixbundle", "PWA Café.sideload.msix", "install-edgehtml.ps1", "install.ps1",
+            "readme-edgehtml.html", "readme.html", "utils\\pwainstaller.exe"
+        }.Order(), zip.Entries.Select(entry => entry.FullName).Order());
+        using var script = zip.GetEntry("install.ps1")!.Open();
+        using var bytes = new MemoryStream();
+        await script.CopyToAsync(bytes);
+        Assert.Equal(new byte[] { 0xef, 0xbb, 0xbf }, bytes.ToArray()[..3]);
+        Assert.Equal("PWA Café PWA Café.sideload.msix", System.Text.Encoding.UTF8.GetString(bytes.ToArray()[3..]));
+    }
+
+    private static IOptions<AppSettings> Settings() => Options.Create(new AppSettings
+    {
+        ImageGeneratorApiUrl = new Uri("https://example.com/images"),
+        OutputDirectory = Path.Combine(AppContext.BaseDirectory, $"pipeline-{Guid.NewGuid()}")
+    });
+
+    private sealed class HttpFactory(HttpClient http) : IHttpClientFactory
+    {
+        /// <inheritdoc/>
+        public HttpClient CreateClient(string name) => http;
+    }
+
+    private sealed class CancelingHandler(CancellationToken token) : HttpMessageHandler
+    {
+        /// <summary>
+        /// Gets the request count.
+        /// </summary>
+        public int RequestCount { get; private set; }
+
+        /// <inheritdoc/>
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            throw new OperationCanceledException(token);
+        }
+    }
+
+    private sealed class BlockingHandler(bool onlyPost = false) : HttpMessageHandler
+    {
+        /// <summary>
+        /// Signals when the cancellable request starts.
+        /// </summary>
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Gets the request count.
+        /// </summary>
+        public int RequestCount { get; private set; }
+
+        /// <inheritdoc/>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            if (onlyPost && request.Method != HttpMethod.Post)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1, 2, 3]) };
+            }
+            Started.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("The request should have been cancelled.");
+        }
+    }
+
+    private sealed class ImageHandler : HttpMessageHandler
+    {
+        /// <inheritdoc/>
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            using var bytes = new MemoryStream();
+            if (request.Method == HttpMethod.Post)
+            {
+                using var zip = new ZipArchive(bytes, ZipArchiveMode.Create, leaveOpen: true);
+                using var image = zip.CreateEntry("windows/Square44x44Logo.scale-100.png").Open();
+                image.Write([1, 2, 3]);
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(request.Method == HttpMethod.Post ? bytes.ToArray() : [1, 2, 3])
+            });
+        }
+    }
+
+    private sealed class TelemetryChannel : ITelemetryChannel
+    {
+        /// <summary>
+        /// Gets locally captured build events.
+        /// </summary>
+        public List<EventTelemetry> Events { get; } = [];
+
+        /// <inheritdoc/>
+        public bool? DeveloperMode { get; set; }
+
+        /// <inheritdoc/>
+        public string EndpointAddress { get; set; } = "";
+
+        /// <inheritdoc/>
+        public void Send(ITelemetry item)
+        {
+            if (item is EventTelemetry telemetry)
+            {
+                Events.Add(telemetry);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Flush() { }
+
+        /// <inheritdoc/>
+        public void Dispose() { }
+    }
+
+    private sealed class Host(string root) : IWebHostEnvironment
+    {
+        /// <inheritdoc/>
+        public string ApplicationName { get; set; } = "PackagingTests";
+        /// <inheritdoc/>
+        public string EnvironmentName { get; set; } = "Development";
+        /// <inheritdoc/>
+        public string ContentRootPath { get; set; } = root;
+        /// <inheritdoc/>
+        public string WebRootPath { get; set; } = root;
+        /// <inheritdoc/>
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        /// <inheritdoc/>
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
+    private sealed class PipelineFixture : IDisposable
+    {
+        private readonly ServiceProvider provider;
+        private readonly HttpClient http;
+        private readonly ZombieProcessKiller killer;
+        private readonly TelemetryConfiguration telemetry;
+
+        /// <summary>
+        /// Creates an isolated pipeline with in-memory HTTP and telemetry.
+        /// </summary>
+        public PipelineFixture(HttpMessageHandler? handler = null)
+        {
+            Root = Directory.CreateDirectory(Path.Combine(AppContext.BaseDirectory, $"pipeline-{Guid.NewGuid()}")).FullName;
+            Settings = new AppSettings
+            {
+                ImageGeneratorApiUrl = new Uri("https://example.com/images"),
+                OutputDirectory = Root,
+                PwaBuilderPath = "missing-native-tool.exe",
+                ApplicationInsightsConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000001"
+            };
+            var settings = Options.Create(Settings);
+            provider = new ServiceCollection()
+                .AddScoped(_ => new TempDirectory(settings, NullLogger<TempDirectory>.Instance))
+                .BuildServiceProvider();
+            Scope = provider.CreateScope();
+            Temp = Scope.ServiceProvider.GetRequiredService<TempDirectory>();
+            http = new HttpClient(handler ?? new ImageHandler());
+            var factory = new HttpFactory(http);
+            var host = new Host(Root);
+            killer = new ZombieProcessKiller(NullLogger<ZombieProcessKiller>.Instance);
+            var runner = new ProcessRunner(NullLogger<ProcessRunner>.Instance, killer);
+            MakeAppx = new MakeAppxWrapper(settings, runner, NullLogger<MakeAppxWrapper>.Instance);
+            MakePri = new MakePriWrapper(settings, runner, NullLogger<MakePriWrapper>.Instance);
+            PwaBuilder = new PwaBuilderWrapper(settings, runner, host, NullLogger<PwaBuilderWrapper>.Instance, factory, Temp,
+                new WindowsActionsService(Temp, factory, NullLogger<WindowsActionsService>.Instance));
+            Modern = new ModernWindowsPackageCreator(PwaBuilder, MakeAppx, MakePri, NullLogger<ModernWindowsPackageCreator>.Instance);
+            Classic = new ClassicWindowsPackageCreator(MakeAppx, MakePri, settings);
+            Spartan = new SpartanWindowsPackageCreator(MakePri, MakeAppx, settings);
+            Channel = new TelemetryChannel();
+            telemetry = new TelemetryConfiguration { TelemetryChannel = Channel, ConnectionString = Settings.ApplicationInsightsConnectionString };
+            var analytics = new Analytics(settings, NullLogger<Analytics>.Instance, new TelemetryClient(telemetry),
+                new CosmosDbService(settings, NullLogger<CosmosDbService>.Instance));
+            Creator = new WindowsAppPackageCreator(Modern, Classic, Spartan,
+                new WebManifestFinder(factory, NullLogger<WebManifestFinder>.Instance, Temp),
+                new ImageGenerator(factory, settings, NullLogger<ImageGenerator>.Instance),
+                Temp, analytics, host, factory, settings, NullLogger<WindowsAppPackageCreator>.Instance);
+            PackageOptions = new WindowsAppPackageOptions
+            {
+                Url = new Uri("https://example.com"),
+                Name = "Test PWA",
+                PackageId = "Example.PWA",
+                Version = "1.0.0",
+                GenerateModernPackage = false,
+                Manifest = JsonDocument.Parse("""{"icons":[{"src":"icon.png","sizes":"512x512","type":"image/png"}]}""")
+            };
+        }
+
+        /// <summary>Gets the owned artifact root.</summary>
+        public string Root { get; }
+        /// <summary>Gets the build settings.</summary>
+        public AppSettings Settings { get; }
+        /// <summary>Gets the disposable build scope.</summary>
+        public IServiceScope Scope { get; }
+        /// <summary>Gets the scoped temporary-file owner.</summary>
+        public TempDirectory Temp { get; }
+        /// <summary>Gets the locally captured telemetry.</summary>
+        public TelemetryChannel Channel { get; }
+        /// <summary>Gets the package entry point.</summary>
+        public WindowsAppPackageCreator Creator { get; }
+        /// <summary>Gets the package options.</summary>
+        public WindowsAppPackageOptions PackageOptions { get; }
+        /// <summary>Gets the SDK packager.</summary>
+        public MakeAppxWrapper MakeAppx { get; }
+        /// <summary>Gets the SDK resource generator.</summary>
+        public MakePriWrapper MakePri { get; }
+        /// <summary>Gets the classic package generator.</summary>
+        public ClassicWindowsPackageCreator Classic { get; }
+        /// <summary>Gets the EdgeHTML package generator.</summary>
+        public SpartanWindowsPackageCreator Spartan { get; }
+        /// <summary>Gets the modern package generator.</summary>
+        public ModernWindowsPackageCreator Modern { get; }
+        /// <summary>Gets the native PWABuilder tool.</summary>
+        public PwaBuilderWrapper PwaBuilder { get; }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Scope.Dispose();
+            provider.Dispose();
+            killer.Dispose();
+            telemetry.Dispose();
+            http.Dispose();
+            PackageOptions.Manifest?.Dispose();
+            Directory.Delete(Root, recursive: true);
+        }
+    }
+}

--- a/apps/pwabuilder-microsoft-store.Tests/ProcessRunnerTests.cs
+++ b/apps/pwabuilder-microsoft-store.Tests/ProcessRunnerTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using PWABuilder.MicrosoftStore;
+using PWABuilder.MicrosoftStore.Models;
 using System.Diagnostics;
+using System.Text;
 using Xunit;
 
 namespace PWABuilder.MicrosoftStore.Tests;
@@ -13,7 +15,7 @@ public sealed class ProcessRunnerTests
     [Fact]
     public async Task Run_WhenStandardErrorExceedsPipeCapacity_CompletesAndCapturesOutput()
     {
-        var scriptPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.cmd");
+        var scriptPath = Path.Combine(AppContext.BaseDirectory, $"{Guid.NewGuid()}.cmd");
         await File.WriteAllTextAsync(
             scriptPath,
             """
@@ -40,4 +42,111 @@ public sealed class ProcessRunnerTests
             File.Delete(scriptPath);
         }
     }
+
+    /// <summary>
+    /// Verifies cancellation is checked before launching the owned executable.
+    /// </summary>
+    [Fact]
+    public async Task Run_WhenAlreadyCanceled_DoesNotStartProcess()
+    {
+        var marker = Path.Combine(AppContext.BaseDirectory, $"{Guid.NewGuid()}.started");
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        using var processKiller = new ZombieProcessKiller(NullLogger<ZombieProcessKiller>.Instance);
+        var runner = new ProcessRunner(NullLogger<ProcessRunner>.Instance, processKiller);
+        try
+        {
+            var error = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                RunWithCancellation(runner, CmdPath, $"/d /c echo started>\"{marker}\"", TimeSpan.FromSeconds(5), cancellation.Token));
+            Assert.Equal(cancellation.Token, error.CancellationToken);
+            Assert.False(File.Exists(marker));
+        }
+        finally
+        {
+            File.Delete(marker);
+        }
+    }
+
+    /// <summary>
+    /// Verifies cancelling a running tool terminates both the tool and its descendant.
+    /// </summary>
+    [Fact]
+    public async Task Run_WhenCanceled_KillsOwnedProcessTree()
+    {
+        var directory = Directory.CreateDirectory(Path.Combine(AppContext.BaseDirectory, $"process-test-{Guid.NewGuid()}")).FullName;
+        var parentMarker = Path.Combine(directory, "parent.pid");
+        var childMarker = Path.Combine(directory, "child.pid");
+        var childScript = $"[IO.File]::WriteAllText('{childMarker}', [string]$PID); [Threading.Thread]::Sleep(60000)";
+        var parentScript = $"[IO.File]::WriteAllText('{parentMarker}', [string]$PID); & '{PowerShellPath}' -NoProfile -NonInteractive -EncodedCommand {Encode(childScript)}";
+        using var cancellation = new CancellationTokenSource();
+        using var processKiller = new ZombieProcessKiller(NullLogger<ZombieProcessKiller>.Instance);
+        var runner = new ProcessRunner(NullLogger<ProcessRunner>.Instance, processKiller);
+        var run = RunWithCancellation(runner, PowerShellPath, $"-NoProfile -NonInteractive -EncodedCommand {Encode(parentScript)}", TimeSpan.FromSeconds(20), cancellation.Token);
+        try
+        {
+            await WaitForFile(childMarker);
+            using var parent = Process.GetProcessById(int.Parse(await File.ReadAllTextAsync(parentMarker)));
+            using var child = Process.GetProcessById(int.Parse(await File.ReadAllTextAsync(childMarker)));
+            cancellation.Cancel();
+            var error = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.Equal(cancellation.Token, error.CancellationToken);
+            Assert.True(parent.HasExited);
+            Assert.True(child.HasExited);
+        }
+        finally
+        {
+            cancellation.Cancel();
+            foreach (var marker in new[] { parentMarker, childMarker })
+            {
+                if (File.Exists(marker))
+                {
+                    try
+                    {
+                        using var process = Process.GetProcessById(int.Parse(await File.ReadAllTextAsync(marker)));
+                        process.Kill(entireProcessTree: true);
+                        await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+                    }
+                    catch (ArgumentException) { }
+                    catch (InvalidOperationException) { }
+                }
+            }
+            try { await run.WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch (Exception) { }
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the existing timeout error retains the tool output.
+    /// </summary>
+    [Fact]
+    public async Task Run_WhenTimedOut_ThrowsProcessExceptionWithOutput()
+    {
+        using var processKiller = new ZombieProcessKiller(NullLogger<ZombieProcessKiller>.Instance);
+        var runner = new ProcessRunner(NullLogger<ProcessRunner>.Instance, processKiller);
+        var script = "[Console]::Out.WriteLine('before-timeout'); [Console]::Error.WriteLine('timeout-error'); [Threading.Thread]::Sleep(60000)";
+        var error = await Assert.ThrowsAsync<ProcessException>(() =>
+            runner.Run(PowerShellPath, $"-NoProfile -NonInteractive -EncodedCommand {Encode(script)}", TimeSpan.FromSeconds(3)));
+        Assert.Contains("timed out", error.Message);
+        Assert.Contains("before-timeout", error.StandardOutput);
+        Assert.Contains("timeout-error", error.StandardError);
+    }
+
+    private static Task<ProcessResult> RunWithCancellation(ProcessRunner runner, string path, string args, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        return runner.Run(path, args, timeout, cancellationToken: cancellationToken);
+    }
+
+    private static async Task WaitForFile(string path)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        while (!File.Exists(path) || new FileInfo(path).Length == 0)
+        {
+            await Task.Delay(25, timeout.Token);
+        }
+    }
+
+    private static string Encode(string script) => Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
+    private static string CmdPath => Environment.GetEnvironmentVariable("ComSpec") ?? throw new InvalidOperationException("ComSpec is not defined.");
+    private static string PowerShellPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "WindowsPowerShell", "v1.0", "powershell.exe");
 }

--- a/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobRegistrationTests.cs
+++ b/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobRegistrationTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using PWABuilder.MicrosoftStore.Jobs;
+using PWABuilder.MicrosoftStore.Models;
+using Xunit;
+
+namespace PWABuilder.MicrosoftStore.Tests;
+
+public sealed class WindowsPackageJobRegistrationTests
+{
+    [Fact]
+    public void Register_WhenDisabled_DoesNotRequireAzureOrRunWorkers()
+    {
+        var services = new ServiceCollection();
+        services.AddWindowsPackageJobs(new ConfigurationBuilder().Build());
+        using var provider = services.BuildServiceProvider();
+
+        Assert.False(provider.GetRequiredService<IOptions<WindowsPackageJobOptions>>().Value.Enabled);
+        Assert.Null(provider.GetService<IWindowsPackageJobStore>());
+        Assert.Empty(provider.GetServices<IHostedService>());
+        Assert.NotNull(provider.GetRequiredService<TimeProvider>());
+    }
+
+    [Fact]
+    public void Register_WhenEnabledWithoutStorage_FailsValidation()
+    {
+        using var provider = CreateProvider(new Dictionary<string, string?>
+        {
+            ["WindowsPackageJobs:Enabled"] = "true"
+        });
+        Assert.Throws<OptionsValidationException>(() => provider.GetRequiredService<IOptions<WindowsPackageJobOptions>>().Value);
+    }
+
+    [Theory]
+    [InlineData("RenewalSeconds", "60")]
+    [InlineData("WorkerCount", "0")]
+    [InlineData("QueueName", "UPPERCASE")]
+    [InlineData("BlobServiceUri", "http://example.com")]
+    [InlineData("CosmosContainerName", "package-analytics")]
+    public void Register_WhenConfigurationIsUnsafe_FailsValidation(string property, string value)
+    {
+        var config = ValidConfiguration();
+        config["WindowsPackageJobs:" + property] = value;
+        using var provider = CreateProvider(config);
+        Assert.Throws<OptionsValidationException>(() => provider.GetRequiredService<IOptions<WindowsPackageJobOptions>>().Value);
+    }
+
+    [Fact]
+    public void Register_WhenEnabled_AddsBoundedHostedWorkers()
+    {
+        var services = CreateServices(ValidConfiguration());
+        Assert.Contains(services, d => d.ServiceType == typeof(IHostedService) && d.ImplementationType == typeof(WindowsPackageJobWorker));
+        using var provider = services.BuildServiceProvider();
+        Assert.True(provider.GetRequiredService<IOptions<WindowsPackageJobOptions>>().Value.Enabled);
+    }
+
+    private static ServiceProvider CreateProvider(Dictionary<string, string?> config) =>
+        CreateServices(config).BuildServiceProvider();
+
+    private static ServiceCollection CreateServices(Dictionary<string, string?> config)
+    {
+        var services = new ServiceCollection();
+        services.AddOptions<AppSettings>().Configure(settings =>
+        {
+            settings.CosmosDbEndpoint = "https://example.documents.azure.com";
+            settings.CosmosDbDatabaseName = "pwabuilder";
+            settings.CosmosDbContainerName = "package-analytics";
+        });
+        services.AddWindowsPackageJobs(new ConfigurationBuilder().AddInMemoryCollection(config).Build());
+        return services;
+    }
+
+    private static Dictionary<string, string?> ValidConfiguration() => new()
+    {
+        ["WindowsPackageJobs:Enabled"] = "true",
+        ["WindowsPackageJobs:QueueServiceUri"] = "https://example.queue.core.windows.net",
+        ["WindowsPackageJobs:QueueName"] = "windows-package-jobs-nonprod",
+        ["WindowsPackageJobs:BlobServiceUri"] = "https://example.blob.core.windows.net",
+        ["WindowsPackageJobs:BlobContainerName"] = "windows-package-jobs-nonprod",
+        ["WindowsPackageJobs:CosmosContainerName"] = "windows-package-jobs-nonprod"
+    };
+}

--- a/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobStorageTests.cs
+++ b/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobStorageTests.cs
@@ -14,13 +14,18 @@ using Xunit;
 
 namespace PWABuilder.MicrosoftStore.Tests;
 
-/// <summary>Exercises the Azure SDK providers without network access or Azure resources.</summary>
+/// <summary>
+/// Exercises the Azure SDK providers without network access or Azure resources.
+/// </summary>
 public sealed class WindowsPackageJobStorageTests
 {
     private const string JobId = "0123456789abcdef0123456789abcdef";
+
     private const string AttemptId = "fedcba9876543210fedcba9876543210";
 
-    /// <summary>Private inputs precede the outbox document and preserve raw manifests.</summary>
+    /// <summary>
+    /// Private inputs precede the outbox document and preserve raw manifests.
+    /// </summary>
     [Fact]
     public async Task CreateAsync_PersistsImmutableInputBeforeCamelCaseJob()
     {
@@ -48,7 +53,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Equal($"[\"{JobId}\"]", writes[1].Headers["x-ms-documentdb-partitionkey"]);
     }
 
-    /// <summary>A failed input upload cannot create a dispatchable job.</summary>
+    /// <summary>
+    /// A failed input upload cannot create a dispatchable job.
+    /// </summary>
     [Fact]
     public async Task CreateAsync_WhenInputUploadFails_DoesNotWriteJob()
     {
@@ -58,7 +65,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.DoesNotContain(fixture.Requests, request => request.Uri.Host == "cosmos.invalid" && request.Method == HttpMethod.Post);
     }
 
-    /// <summary>A failed metadata write leaves an orphan input for lifecycle cleanup.</summary>
+    /// <summary>
+    /// A failed metadata write leaves an orphan input for lifecycle cleanup.
+    /// </summary>
     [Fact]
     public async Task CreateAsync_WhenCosmosWriteFails_DoesNotDeleteInput()
     {
@@ -69,7 +78,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.DoesNotContain(fixture.Requests, request => request.Method == HttpMethod.Delete);
     }
 
-    /// <summary>Reads restore revisions from Cosmos response headers.</summary>
+    /// <summary>
+    /// Reads restore revisions from Cosmos response headers.
+    /// </summary>
     [Fact]
     public async Task GetAsync_ReturnsResponseETag()
     {
@@ -80,7 +91,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Equal("\"response-etag\"", job.ETag);
     }
 
-    /// <summary>Outbox results keep system revisions and use a bounded oldest-first query.</summary>
+    /// <summary>
+    /// Outbox results keep system revisions and use a bounded oldest-first query.
+    /// </summary>
     [Fact]
     public async Task GetPendingDispatchAsync_ReturnsProjectedETagFromBoundedQuery()
     {
@@ -101,7 +114,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Contains("c._etag", text);
     }
 
-    /// <summary>Continuation pages preserve each job's independent concurrency revision.</summary>
+    /// <summary>
+    /// Continuation pages preserve each job's independent concurrency revision.
+    /// </summary>
     [Fact]
     public async Task GetPendingDispatchAsync_ReadsContinuationPages()
     {
@@ -114,7 +129,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.NotEqual(pending[0].Id, pending[1].Id);
     }
 
-    /// <summary>A full batch does not continue draining the outbox.</summary>
+    /// <summary>
+    /// A full batch does not continue draining the outbox.
+    /// </summary>
     [Fact]
     public async Task GetPendingDispatchAsync_StopsAt50Records()
     {
@@ -125,7 +142,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Single(fixture.Requests, request => request.Headers.ContainsKey("x-ms-documentdb-isquery"));
     }
 
-    /// <summary>Only missing metadata is translated into a missing job.</summary>
+    /// <summary>
+    /// Only missing metadata is translated into a missing job.
+    /// </summary>
     [Theory]
     [InlineData(HttpStatusCode.NotFound)]
     [InlineData(HttpStatusCode.Forbidden)]
@@ -143,7 +162,9 @@ public sealed class WindowsPackageJobStorageTests
         }
     }
 
-    /// <summary>Updates fence ownership with the supplied ETag and return the new revision.</summary>
+    /// <summary>
+    /// Updates fence ownership with the supplied ETag and return the new revision.
+    /// </summary>
     [Fact]
     public async Task TryReplaceAsync_UsesIfMatchAndReturnsNewETag()
     {
@@ -155,7 +176,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Equal("\"response-etag\"", updated!.ETag);
     }
 
-    /// <summary>Unconditional metadata overwrites are not permitted.</summary>
+    /// <summary>
+    /// Unconditional metadata overwrites are not permitted.
+    /// </summary>
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
@@ -168,7 +191,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.DoesNotContain(fixture.Requests, request => request.Method == HttpMethod.Put);
     }
 
-    /// <summary>Only failed optimistic concurrency checks represent lost ownership.</summary>
+    /// <summary>
+    /// Only failed optimistic concurrency checks represent lost ownership.
+    /// </summary>
     [Theory]
     [InlineData(HttpStatusCode.PreconditionFailed)]
     [InlineData(HttpStatusCode.Forbidden)]
@@ -187,7 +212,9 @@ public sealed class WindowsPackageJobStorageTests
         }
     }
 
-    /// <summary>Stored input JSON restores the manifest as a usable JsonDocument.</summary>
+    /// <summary>
+    /// Stored input JSON restores the manifest as a usable JsonDocument.
+    /// </summary>
     [Fact]
     public async Task ReadInputAsync_DeserializesWebJsonAndManifest()
     {
@@ -202,7 +229,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Equal("Partner", input.Analytics.PlatformId);
     }
 
-    /// <summary>Invalid input JSON never becomes a successful empty input.</summary>
+    /// <summary>
+    /// Invalid input JSON never becomes a successful empty input.
+    /// </summary>
     [Fact]
     public async Task ReadInputAsync_RejectsNullJson()
     {
@@ -211,7 +240,9 @@ public sealed class WindowsPackageJobStorageTests
         await Assert.ThrowsAsync<JsonException>(() => store.ReadInputAsync(JobId, CancellationToken.None));
     }
 
-    /// <summary>Artifacts use isolated, immutable attempt paths and streamed contents.</summary>
+    /// <summary>
+    /// Artifacts use isolated, immutable attempt paths and streamed contents.
+    /// </summary>
     [Fact]
     public async Task UploadArtifactAsync_UploadsFileToAttemptSpecificPath()
     {
@@ -234,7 +265,9 @@ public sealed class WindowsPackageJobStorageTests
         }
     }
 
-    /// <summary>Download streams remain open until the caller disposes them.</summary>
+    /// <summary>
+    /// Download streams remain open until the caller disposes them.
+    /// </summary>
     [Fact]
     public async Task OpenArtifactAsync_ReturnsReadableCallerOwnedStream()
     {
@@ -246,7 +279,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Equal(fixture.BlobBody, contents.ToArray());
     }
 
-    /// <summary>Messages contain only the raw reference and do not expire in the queue.</summary>
+    /// <summary>
+    /// Messages contain only the raw reference and do not expire in the queue.
+    /// </summary>
     [Fact]
     public async Task SendAsync_UsesRawJobIdAndInfiniteTtl()
     {
@@ -259,7 +294,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Equal("/jobs/messages", request.Uri.AbsolutePath);
     }
 
-    /// <summary>Receiving does not acknowledge, including malformed queue messages.</summary>
+    /// <summary>
+    /// Receiving does not acknowledge, including malformed queue messages.
+    /// </summary>
     [Theory]
     [InlineData(JobId)]
     [InlineData("invalid-job-reference")]
@@ -274,7 +311,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Contains("visibilitytimeout=120", request.Uri.Query);
     }
 
-    /// <summary>An empty queue is distinct from a storage failure.</summary>
+    /// <summary>
+    /// An empty queue is distinct from a storage failure.
+    /// </summary>
     [Fact]
     public async Task ReceiveAsync_EmptyQueueReturnsNull()
     {
@@ -282,7 +321,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Null(await fixture.CreateQueue().ReceiveAsync(CancellationToken.None));
     }
 
-    /// <summary>Renewals pass the latest receipt to subsequent acknowledgements.</summary>
+    /// <summary>
+    /// Renewals pass the latest receipt to subsequent acknowledgements.
+    /// </summary>
     [Fact]
     public async Task RenewAsync_ReturnsNewPopReceiptUsedForDelete()
     {
@@ -297,7 +338,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Contains("popreceipt=renewed-receipt", fixture.Requests.ElementAt(1).Uri.Query);
     }
 
-    /// <summary>Invalid or stale acknowledgement receipts surface to the processor.</summary>
+    /// <summary>
+    /// Invalid or stale acknowledgement receipts surface to the processor.
+    /// </summary>
     [Fact]
     public async Task DeleteAsync_PropagatesStaleReceiptError()
     {
@@ -306,7 +349,9 @@ public sealed class WindowsPackageJobStorageTests
         await Assert.ThrowsAsync<RequestFailedException>(() => queue.DeleteAsync(new("message-id", "stale", JobId, 4), CancellationToken.None));
     }
 
-    /// <summary>Poison messages are bounded references, without acknowledging their source.</summary>
+    /// <summary>
+    /// Poison messages are bounded references, without acknowledging their source.
+    /// </summary>
     [Fact]
     public async Task PoisonAsync_WritesSanitizedDiagnosticWithoutAcknowledging()
     {
@@ -327,7 +372,9 @@ public sealed class WindowsPackageJobStorageTests
         Assert.Equal(7, payload.RootElement.GetProperty("attempts").GetInt64());
     }
 
-    /// <summary>Cancelled operations cannot be accepted or acknowledged.</summary>
+    /// <summary>
+    /// Cancelled operations cannot be accepted or acknowledged.
+    /// </summary>
     [Theory]
     [InlineData("create")]
     [InlineData("get")]
@@ -368,7 +415,9 @@ public sealed class WindowsPackageJobStorageTests
             request.Uri.Host is "queue.invalid" or "blob.invalid" || request.Uri.AbsolutePath.Contains("/docs", StringComparison.Ordinal));
     }
 
-    /// <summary>Builds deterministic metadata for provider tests.</summary>
+    /// <summary>
+    /// Builds deterministic metadata for provider tests.
+    /// </summary>
     private static WindowsPackageJob CreateJob() => new()
     {
         Id = JobId,
@@ -378,27 +427,41 @@ public sealed class WindowsPackageJobStorageTests
         ETag = "\"old-etag\""
     };
 
-    /// <summary>Builds private input with optional manifest data.</summary>
+    /// <summary>
+    /// Builds private input with optional manifest data.
+    /// </summary>
     private static WindowsPackageJobInput CreateInput(JsonDocument? manifest = null) => new()
     {
         Options = new WindowsAppPackageOptions { Url = new Uri("https://example.com"), Manifest = manifest },
         Analytics = new PackageJobAnalytics { PlatformId = "Partner" }
     };
 
-    /// <summary>An SDK HTTP fixture whose transport never opens network connections.</summary>
+    /// <summary>
+    /// An SDK HTTP fixture whose transport never opens network connections.
+    /// </summary>
     private sealed class Fixture : HttpMessageHandler
     {
         private int outboxPage;
+
         internal readonly ConcurrentQueue<CapturedRequest> Requests = [];
+
         internal HttpStatusCode BlobStatus = HttpStatusCode.OK;
+
         internal HttpStatusCode CosmosStatus = HttpStatusCode.OK;
+
         internal HttpStatusCode QueueStatus = HttpStatusCode.OK;
+
         internal byte[] BlobBody = [];
+
         internal string? QueueBody = JobId;
+
         internal int OutboxPages = 1;
+
         internal int OutboxPageSize = 1;
 
-        /// <summary>Constructs the production store against an offline SDK transport.</summary>
+        /// <summary>
+        /// Constructs the production store against an offline SDK transport.
+        /// </summary>
         internal AzureWindowsPackageJobStore CreateStore()
         {
             var options = AzureWindowsPackageJobStore.CreateCosmosClientOptions();
@@ -412,7 +475,9 @@ public sealed class WindowsPackageJobStorageTests
             return new AzureWindowsPackageJobStore(cosmos, blobs, "database", "jobs");
         }
 
-        /// <summary>Constructs the production queue against an offline SDK transport.</summary>
+        /// <summary>
+        /// Constructs the production queue against an offline SDK transport.
+        /// </summary>
         internal AzureWindowsPackageJobQueue CreateQueue()
         {
             var options = new QueueClientOptions
@@ -448,7 +513,9 @@ public sealed class WindowsPackageJobStorageTests
             };
         }
 
-        /// <summary>Emulates Cosmos metadata discovery and point document operations.</summary>
+        /// <summary>
+        /// Emulates Cosmos metadata discovery and point document operations.
+        /// </summary>
         private HttpResponseMessage CosmosResponse(CapturedRequest request)
         {
             if (request.Uri.AbsolutePath is "/")
@@ -513,7 +580,9 @@ public sealed class WindowsPackageJobStorageTests
             throw new InvalidOperationException($"Unexpected Cosmos request: {request.Method} {request.Uri}");
         }
 
-        /// <summary>Emulates immutable uploads and streaming downloads.</summary>
+        /// <summary>
+        /// Emulates immutable uploads and streaming downloads.
+        /// </summary>
         private HttpResponseMessage BlobResponse(CapturedRequest request)
         {
             var response = new HttpResponseMessage(BlobStatus is HttpStatusCode.OK && request.Method == HttpMethod.Put ? HttpStatusCode.Created : BlobStatus)
@@ -527,7 +596,9 @@ public sealed class WindowsPackageJobStorageTests
             return response;
         }
 
-        /// <summary>Emulates queue receipts, sends, and explicit acknowledgements.</summary>
+        /// <summary>
+        /// Emulates queue receipts, sends, and explicit acknowledgements.
+        /// </summary>
         private HttpResponseMessage QueueResponse(CapturedRequest request)
         {
             if (QueueStatus is not HttpStatusCode.OK)
@@ -562,11 +633,15 @@ public sealed class WindowsPackageJobStorageTests
             return response;
         }
 
-        /// <summary>Creates a JSON response for the SDK.</summary>
+        /// <summary>
+        /// Creates a JSON response for the SDK.
+        /// </summary>
         private static HttpResponseMessage JsonResponse(HttpStatusCode status, string json) =>
             new(status) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
     }
 
-    /// <summary>A captured outbound SDK request.</summary>
+    /// <summary>
+    /// A captured outbound SDK request.
+    /// </summary>
     private sealed record CapturedRequest(HttpMethod Method, Uri Uri, byte[] Body, Dictionary<string, string> Headers);
 }

--- a/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobStorageTests.cs
+++ b/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobStorageTests.cs
@@ -1,0 +1,572 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using Azure;
+using Azure.Core.Pipeline;
+using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
+using Microsoft.Azure.Cosmos;
+using PWABuilder.MicrosoftStore.Jobs;
+using PWABuilder.MicrosoftStore.Models;
+using Xunit;
+
+namespace PWABuilder.MicrosoftStore.Tests;
+
+/// <summary>Exercises the Azure SDK providers without network access or Azure resources.</summary>
+public sealed class WindowsPackageJobStorageTests
+{
+    private const string JobId = "0123456789abcdef0123456789abcdef";
+    private const string AttemptId = "fedcba9876543210fedcba9876543210";
+
+    /// <summary>Private inputs precede the outbox document and preserve raw manifests.</summary>
+    [Fact]
+    public async Task CreateAsync_PersistsImmutableInputBeforeCamelCaseJob()
+    {
+        using var fixture = new Fixture();
+        using var manifest = JsonDocument.Parse("""{"name":"Example","icons":[{"src":"/icon.png"}]}""");
+        using var store = fixture.CreateStore();
+        await store.CreateAsync(CreateJob(), CreateInput(manifest), CancellationToken.None);
+
+        var writes = fixture.Requests.Where(request => request.Method != HttpMethod.Get).ToArray();
+        Assert.Equal(2, writes.Length);
+        Assert.Equal($"/packages/inputs/{JobId}.json", writes[0].Uri.AbsolutePath);
+        Assert.Equal("*", writes[0].Headers["If-None-Match"]);
+        using var input = JsonDocument.Parse(writes[0].Body);
+        Assert.Equal("Example", input.RootElement.GetProperty("options").GetProperty("manifest").GetProperty("name").GetString());
+        Assert.Equal("Partner", input.RootElement.GetProperty("analytics").GetProperty("platformId").GetString());
+        using var job = JsonDocument.Parse(writes[1].Body);
+        Assert.Equal(JobId, job.RootElement.GetProperty("id").GetString());
+        Assert.True(job.RootElement.GetProperty("needsDispatch").GetBoolean());
+        Assert.Equal("Queued", job.RootElement.GetProperty("status").GetString());
+        Assert.Equal(3600, job.RootElement.GetProperty("ttl").GetInt32());
+        Assert.True(job.RootElement.TryGetProperty("createdAt", out _));
+        Assert.False(job.RootElement.TryGetProperty("ETag", out _));
+        Assert.False(job.RootElement.TryGetProperty("eTag", out _));
+        Assert.False(job.RootElement.TryGetProperty("_etag", out _));
+        Assert.Equal($"[\"{JobId}\"]", writes[1].Headers["x-ms-documentdb-partitionkey"]);
+    }
+
+    /// <summary>A failed input upload cannot create a dispatchable job.</summary>
+    [Fact]
+    public async Task CreateAsync_WhenInputUploadFails_DoesNotWriteJob()
+    {
+        using var fixture = new Fixture { BlobStatus = HttpStatusCode.PreconditionFailed };
+        using var store = fixture.CreateStore();
+        await Assert.ThrowsAsync<RequestFailedException>(() => store.CreateAsync(CreateJob(), CreateInput(), CancellationToken.None));
+        Assert.DoesNotContain(fixture.Requests, request => request.Uri.Host == "cosmos.invalid" && request.Method == HttpMethod.Post);
+    }
+
+    /// <summary>A failed metadata write leaves an orphan input for lifecycle cleanup.</summary>
+    [Fact]
+    public async Task CreateAsync_WhenCosmosWriteFails_DoesNotDeleteInput()
+    {
+        using var fixture = new Fixture { CosmosStatus = HttpStatusCode.Forbidden };
+        using var store = fixture.CreateStore();
+        await Assert.ThrowsAsync<CosmosException>(() => store.CreateAsync(CreateJob(), CreateInput(), CancellationToken.None));
+        Assert.Contains(fixture.Requests, request => request.Uri.AbsolutePath == $"/packages/inputs/{JobId}.json");
+        Assert.DoesNotContain(fixture.Requests, request => request.Method == HttpMethod.Delete);
+    }
+
+    /// <summary>Reads restore revisions from Cosmos response headers.</summary>
+    [Fact]
+    public async Task GetAsync_ReturnsResponseETag()
+    {
+        using var fixture = new Fixture();
+        using var store = fixture.CreateStore();
+        var job = await store.GetAsync(JobId, CancellationToken.None);
+        Assert.Equal(JobId, job!.Id);
+        Assert.Equal("\"response-etag\"", job.ETag);
+    }
+
+    /// <summary>Outbox results keep system revisions and use a bounded oldest-first query.</summary>
+    [Fact]
+    public async Task GetPendingDispatchAsync_ReturnsProjectedETagFromBoundedQuery()
+    {
+        using var fixture = new Fixture();
+        using var store = fixture.CreateStore();
+        var pending = await store.GetPendingDispatchAsync(CancellationToken.None);
+        var job = Assert.Single(pending);
+        Assert.Equal(JobId, job.Id);
+        Assert.Equal("\"outbox-etag\"", job.ETag);
+        var request = Assert.Single(fixture.Requests, request =>
+            request.Headers.TryGetValue("x-ms-documentdb-isquery", out var value) && value == "True");
+        using var query = JsonDocument.Parse(request.Body);
+        var text = query.RootElement.GetProperty("query").GetString()!;
+        Assert.Contains("TOP 50", text);
+        Assert.Contains("c.needsDispatch = true", text);
+        Assert.Contains("c.status = @status", text);
+        Assert.Contains("ORDER BY c.createdAt", text);
+        Assert.Contains("c._etag", text);
+    }
+
+    /// <summary>Continuation pages preserve each job's independent concurrency revision.</summary>
+    [Fact]
+    public async Task GetPendingDispatchAsync_ReadsContinuationPages()
+    {
+        using var fixture = new Fixture { OutboxPages = 2 };
+        using var store = fixture.CreateStore();
+        var pending = await store.GetPendingDispatchAsync(CancellationToken.None);
+        Assert.Equal(2, pending.Count);
+        Assert.Equal("\"outbox-etag\"", pending[0].ETag);
+        Assert.Equal("\"outbox-etag-1\"", pending[1].ETag);
+        Assert.NotEqual(pending[0].Id, pending[1].Id);
+    }
+
+    /// <summary>A full batch does not continue draining the outbox.</summary>
+    [Fact]
+    public async Task GetPendingDispatchAsync_StopsAt50Records()
+    {
+        using var fixture = new Fixture { OutboxPages = 2, OutboxPageSize = 50 };
+        using var store = fixture.CreateStore();
+        var pending = await store.GetPendingDispatchAsync(CancellationToken.None);
+        Assert.Equal(50, pending.Count);
+        Assert.Single(fixture.Requests, request => request.Headers.ContainsKey("x-ms-documentdb-isquery"));
+    }
+
+    /// <summary>Only missing metadata is translated into a missing job.</summary>
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public async Task GetAsync_OnlyNotFoundReturnsNull(HttpStatusCode status)
+    {
+        using var fixture = new Fixture { CosmosStatus = status };
+        using var store = fixture.CreateStore();
+        if (status is HttpStatusCode.NotFound)
+        {
+            Assert.Null(await store.GetAsync(JobId, CancellationToken.None));
+        }
+        else
+        {
+            await Assert.ThrowsAsync<CosmosException>(() => store.GetAsync(JobId, CancellationToken.None));
+        }
+    }
+
+    /// <summary>Updates fence ownership with the supplied ETag and return the new revision.</summary>
+    [Fact]
+    public async Task TryReplaceAsync_UsesIfMatchAndReturnsNewETag()
+    {
+        using var fixture = new Fixture();
+        using var store = fixture.CreateStore();
+        var updated = await store.TryReplaceAsync(CreateJob() with { ETag = "\"old-etag\"" }, CancellationToken.None);
+        var write = Assert.Single(fixture.Requests, request => request.Method == HttpMethod.Put);
+        Assert.Equal("\"old-etag\"", write.Headers["If-Match"]);
+        Assert.Equal("\"response-etag\"", updated!.ETag);
+    }
+
+    /// <summary>Unconditional metadata overwrites are not permitted.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("*")]
+    public async Task TryReplaceAsync_RejectsMissingETag(string etag)
+    {
+        using var fixture = new Fixture();
+        using var store = fixture.CreateStore();
+        await Assert.ThrowsAsync<ArgumentException>(() => store.TryReplaceAsync(CreateJob() with { ETag = etag }, CancellationToken.None));
+        Assert.DoesNotContain(fixture.Requests, request => request.Method == HttpMethod.Put);
+    }
+
+    /// <summary>Only failed optimistic concurrency checks represent lost ownership.</summary>
+    [Theory]
+    [InlineData(HttpStatusCode.PreconditionFailed)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.NotFound)]
+    public async Task TryReplaceAsync_OnlyPreconditionFailureReturnsNull(HttpStatusCode status)
+    {
+        using var fixture = new Fixture { CosmosStatus = status };
+        using var store = fixture.CreateStore();
+        if (status is HttpStatusCode.PreconditionFailed)
+        {
+            Assert.Null(await store.TryReplaceAsync(CreateJob(), CancellationToken.None));
+        }
+        else
+        {
+            await Assert.ThrowsAsync<CosmosException>(() => store.TryReplaceAsync(CreateJob(), CancellationToken.None));
+        }
+    }
+
+    /// <summary>Stored input JSON restores the manifest as a usable JsonDocument.</summary>
+    [Fact]
+    public async Task ReadInputAsync_DeserializesWebJsonAndManifest()
+    {
+        using var fixture = new Fixture
+        {
+            BlobBody = Encoding.UTF8.GetBytes("""{"options":{"url":"https://example.com","manifest":{"name":"Restored"}},"analytics":{"platformId":"Partner"}}""")
+        };
+        using var store = fixture.CreateStore();
+        var input = await store.ReadInputAsync(JobId, CancellationToken.None);
+        using var manifest = input.Options.Manifest;
+        Assert.Equal("Restored", manifest!.RootElement.GetProperty("name").GetString());
+        Assert.Equal("Partner", input.Analytics.PlatformId);
+    }
+
+    /// <summary>Invalid input JSON never becomes a successful empty input.</summary>
+    [Fact]
+    public async Task ReadInputAsync_RejectsNullJson()
+    {
+        using var fixture = new Fixture { BlobBody = Encoding.UTF8.GetBytes("null") };
+        using var store = fixture.CreateStore();
+        await Assert.ThrowsAsync<JsonException>(() => store.ReadInputAsync(JobId, CancellationToken.None));
+    }
+
+    /// <summary>Artifacts use isolated, immutable attempt paths and streamed contents.</summary>
+    [Fact]
+    public async Task UploadArtifactAsync_UploadsFileToAttemptSpecificPath()
+    {
+        using var fixture = new Fixture();
+        using var store = fixture.CreateStore();
+        var path = Path.Combine(Directory.GetCurrentDirectory(), $"storage-test-{Guid.NewGuid():N}.zip");
+        try
+        {
+            await File.WriteAllBytesAsync(path, [80, 75, 3, 4]);
+            var name = await store.UploadArtifactAsync(JobId, AttemptId, path, CancellationToken.None);
+            Assert.Equal($"artifacts/{JobId}/{AttemptId}.zip", name);
+            var request = Assert.Single(fixture.Requests, request => request.Uri.Host == "blob.invalid");
+            Assert.Equal($"/packages/{name}", request.Uri.AbsolutePath);
+            Assert.Equal("*", request.Headers["If-None-Match"]);
+            Assert.Equal([80, 75, 3, 4], request.Body);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>Download streams remain open until the caller disposes them.</summary>
+    [Fact]
+    public async Task OpenArtifactAsync_ReturnsReadableCallerOwnedStream()
+    {
+        using var fixture = new Fixture { BlobBody = [80, 75, 3, 4] };
+        using var store = fixture.CreateStore();
+        await using var stream = await store.OpenArtifactAsync($"artifacts/{JobId}/{AttemptId}.zip", CancellationToken.None);
+        using var contents = new MemoryStream();
+        await stream.CopyToAsync(contents);
+        Assert.Equal(fixture.BlobBody, contents.ToArray());
+    }
+
+    /// <summary>Messages contain only the raw reference and do not expire in the queue.</summary>
+    [Fact]
+    public async Task SendAsync_UsesRawJobIdAndInfiniteTtl()
+    {
+        using var fixture = new Fixture();
+        var queue = fixture.CreateQueue();
+        await queue.SendAsync(JobId, CancellationToken.None);
+        var request = Assert.Single(fixture.Requests);
+        Assert.Equal(JobId, XDocument.Load(new MemoryStream(request.Body)).Root!.Element("MessageText")!.Value);
+        Assert.Contains("messagettl=-1", request.Uri.Query);
+        Assert.Equal("/jobs/messages", request.Uri.AbsolutePath);
+    }
+
+    /// <summary>Receiving does not acknowledge, including malformed queue messages.</summary>
+    [Theory]
+    [InlineData(JobId)]
+    [InlineData("invalid-job-reference")]
+    public async Task ReceiveAsync_PreservesMessageWithoutDeleting(string jobId)
+    {
+        using var fixture = new Fixture { QueueBody = jobId };
+        var queue = fixture.CreateQueue();
+        var message = await queue.ReceiveAsync(CancellationToken.None);
+        Assert.Equal(new PackageJobMessage("message-id", "old-receipt", jobId, 4), message);
+        var request = Assert.Single(fixture.Requests);
+        Assert.Equal(HttpMethod.Get, request.Method);
+        Assert.Contains("visibilitytimeout=120", request.Uri.Query);
+    }
+
+    /// <summary>An empty queue is distinct from a storage failure.</summary>
+    [Fact]
+    public async Task ReceiveAsync_EmptyQueueReturnsNull()
+    {
+        using var fixture = new Fixture { QueueBody = null };
+        Assert.Null(await fixture.CreateQueue().ReceiveAsync(CancellationToken.None));
+    }
+
+    /// <summary>Renewals pass the latest receipt to subsequent acknowledgements.</summary>
+    [Fact]
+    public async Task RenewAsync_ReturnsNewPopReceiptUsedForDelete()
+    {
+        using var fixture = new Fixture();
+        var queue = fixture.CreateQueue();
+        var message = new PackageJobMessage("message-id", "old-receipt", JobId, 4);
+        var renewed = await queue.RenewAsync(message, TimeSpan.FromSeconds(90), CancellationToken.None);
+        Assert.Equal(message with { PopReceipt = "renewed-receipt" }, renewed);
+        await queue.DeleteAsync(renewed, CancellationToken.None);
+        Assert.Contains("popreceipt=old-receipt", fixture.Requests.ElementAt(0).Uri.Query);
+        Assert.Contains("visibilitytimeout=90", fixture.Requests.ElementAt(0).Uri.Query);
+        Assert.Contains("popreceipt=renewed-receipt", fixture.Requests.ElementAt(1).Uri.Query);
+    }
+
+    /// <summary>Invalid or stale acknowledgement receipts surface to the processor.</summary>
+    [Fact]
+    public async Task DeleteAsync_PropagatesStaleReceiptError()
+    {
+        using var fixture = new Fixture { QueueStatus = HttpStatusCode.BadRequest };
+        var queue = fixture.CreateQueue();
+        await Assert.ThrowsAsync<RequestFailedException>(() => queue.DeleteAsync(new("message-id", "stale", JobId, 4), CancellationToken.None));
+    }
+
+    /// <summary>Poison messages are bounded references, without acknowledging their source.</summary>
+    [Fact]
+    public async Task PoisonAsync_WritesSanitizedDiagnosticWithoutAcknowledging()
+    {
+        using var fixture = new Fixture();
+        var queue = fixture.CreateQueue();
+        var message = new PackageJobMessage("message-id\nunsafe", "receipt-secret", new string('x', 5000), 7);
+        await queue.PoisonAsync(message, "invalid\n" + new string('!', 5000), CancellationToken.None);
+        var request = Assert.Single(fixture.Requests);
+        Assert.Equal("/jobs-poison/messages", request.Uri.AbsolutePath);
+        Assert.Contains("messagettl=-1", request.Uri.Query);
+        var text = XDocument.Load(new MemoryStream(request.Body)).Root!.Element("MessageText")!.Value;
+        Assert.True(text.Length < 1024);
+        Assert.DoesNotContain("receipt-secret", text);
+        using var payload = JsonDocument.Parse(text);
+        Assert.True(payload.RootElement.GetProperty("jobId").GetString()!.Length <= 64);
+        Assert.DoesNotContain("\n", payload.RootElement.GetProperty("messageId").GetString()!);
+        Assert.DoesNotContain("\n", payload.RootElement.GetProperty("reason").GetString()!);
+        Assert.Equal(7, payload.RootElement.GetProperty("attempts").GetInt64());
+    }
+
+    /// <summary>Cancelled operations cannot be accepted or acknowledged.</summary>
+    [Theory]
+    [InlineData("create")]
+    [InlineData("get")]
+    [InlineData("pending")]
+    [InlineData("replace")]
+    [InlineData("input")]
+    [InlineData("artifact")]
+    [InlineData("send")]
+    [InlineData("receive")]
+    [InlineData("renew")]
+    [InlineData("delete")]
+    [InlineData("poison")]
+    public async Task CancelledOperations_PropagateCancellation(string operation)
+    {
+        using var fixture = new Fixture();
+        using var store = fixture.CreateStore();
+        var queue = fixture.CreateQueue();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var token = cancellation.Token;
+        var message = new PackageJobMessage("message-id", "receipt", JobId, 1);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation switch
+        {
+            "create" => store.CreateAsync(CreateJob(), CreateInput(), token),
+            "get" => store.GetAsync(JobId, token),
+            "pending" => store.GetPendingDispatchAsync(token),
+            "replace" => store.TryReplaceAsync(CreateJob(), token),
+            "input" => store.ReadInputAsync(JobId, token),
+            "artifact" => store.OpenArtifactAsync($"artifacts/{JobId}/{AttemptId}.zip", token),
+            "send" => queue.SendAsync(JobId, token),
+            "receive" => queue.ReceiveAsync(token),
+            "renew" => queue.RenewAsync(message, TimeSpan.FromSeconds(120), token),
+            "delete" => queue.DeleteAsync(message, token),
+            "poison" => queue.PoisonAsync(message, "invalid", token),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation))
+        });
+        Assert.DoesNotContain(fixture.Requests, request =>
+            request.Uri.Host is "queue.invalid" or "blob.invalid" || request.Uri.AbsolutePath.Contains("/docs", StringComparison.Ordinal));
+    }
+
+    /// <summary>Builds deterministic metadata for provider tests.</summary>
+    private static WindowsPackageJob CreateJob() => new()
+    {
+        Id = JobId,
+        CreatedAt = DateTimeOffset.Parse("2026-09-08T12:00:00Z"),
+        ExpiresAt = DateTimeOffset.Parse("2026-09-08T13:00:00Z"),
+        Ttl = 3600,
+        ETag = "\"old-etag\""
+    };
+
+    /// <summary>Builds private input with optional manifest data.</summary>
+    private static WindowsPackageJobInput CreateInput(JsonDocument? manifest = null) => new()
+    {
+        Options = new WindowsAppPackageOptions { Url = new Uri("https://example.com"), Manifest = manifest },
+        Analytics = new PackageJobAnalytics { PlatformId = "Partner" }
+    };
+
+    /// <summary>An SDK HTTP fixture whose transport never opens network connections.</summary>
+    private sealed class Fixture : HttpMessageHandler
+    {
+        private int outboxPage;
+        internal readonly ConcurrentQueue<CapturedRequest> Requests = [];
+        internal HttpStatusCode BlobStatus = HttpStatusCode.OK;
+        internal HttpStatusCode CosmosStatus = HttpStatusCode.OK;
+        internal HttpStatusCode QueueStatus = HttpStatusCode.OK;
+        internal byte[] BlobBody = [];
+        internal string? QueueBody = JobId;
+        internal int OutboxPages = 1;
+        internal int OutboxPageSize = 1;
+
+        /// <summary>Constructs the production store against an offline SDK transport.</summary>
+        internal AzureWindowsPackageJobStore CreateStore()
+        {
+            var options = AzureWindowsPackageJobStore.CreateCosmosClientOptions();
+            options.ConnectionMode = ConnectionMode.Gateway;
+            options.LimitToEndpoint = true;
+            options.HttpClientFactory = () => new HttpClient(this, disposeHandler: false);
+            var cosmos = new CosmosClient("https://cosmos.invalid", Convert.ToBase64String(new byte[64]), options);
+            var blobOptions = new BlobClientOptions { Transport = new HttpClientTransport(new HttpClient(this, disposeHandler: false)) };
+            blobOptions.Retry.MaxRetries = 0;
+            var blobs = new BlobContainerClient(new Uri("https://blob.invalid/packages"), blobOptions);
+            return new AzureWindowsPackageJobStore(cosmos, blobs, "database", "jobs");
+        }
+
+        /// <summary>Constructs the production queue against an offline SDK transport.</summary>
+        internal AzureWindowsPackageJobQueue CreateQueue()
+        {
+            var options = new QueueClientOptions
+            {
+                Transport = new HttpClientTransport(new HttpClient(this, disposeHandler: false)),
+                MessageEncoding = QueueMessageEncoding.None
+            };
+            options.Retry.MaxRetries = 0;
+            return new AzureWindowsPackageJobQueue(
+                new QueueClient(new Uri("https://queue.invalid/jobs"), options),
+                new QueueClient(new Uri("https://queue.invalid/jobs-poison"), options),
+                new WindowsPackageJobOptions());
+        }
+
+        /// <inheritdoc/>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var body = request.Content is null ? [] : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+            var headers = request.Headers.ToDictionary(header => header.Key, header => string.Join(",", header.Value), StringComparer.OrdinalIgnoreCase);
+            var captured = new CapturedRequest(request.Method, request.RequestUri!, body, headers);
+            Requests.Enqueue(captured);
+            if (Requests.Count > 20)
+            {
+                throw new InvalidOperationException("Excess offline requests: " + string.Join(", ", Requests.Select(item => item.Uri.AbsolutePath)));
+            }
+            return request.RequestUri!.Host switch
+            {
+                "cosmos.invalid" => CosmosResponse(captured),
+                "blob.invalid" => BlobResponse(captured),
+                "queue.invalid" => QueueResponse(captured),
+                _ => throw new InvalidOperationException("Unexpected network request.")
+            };
+        }
+
+        /// <summary>Emulates Cosmos metadata discovery and point document operations.</summary>
+        private HttpResponseMessage CosmosResponse(CapturedRequest request)
+        {
+            if (request.Uri.AbsolutePath is "/")
+            {
+                return JsonResponse(HttpStatusCode.OK, """
+                    {"id":"offline","_rid":"AAAAAA==","writableLocations":[{"name":"West US","databaseAccountEndpoint":"https://cosmos.invalid/"}],"readableLocations":[{"name":"West US","databaseAccountEndpoint":"https://cosmos.invalid/"}],"userConsistencyPolicy":{"defaultConsistencyLevel":"Session"},"queryEngineConfiguration":"{\"maxSqlQueryInputLength\":262144}"}
+                    """);
+            }
+            if (request.Method == HttpMethod.Get && request.Uri.AbsolutePath.TrimEnd('/') is "/dbs/database/colls/jobs")
+            {
+                return JsonResponse(HttpStatusCode.OK, """
+                    {"id":"jobs","_rid":"PaYSALITqjg=","_self":"dbs/PaYSAA==/colls/PaYSALITqjg=/","partitionKey":{"paths":["/id"],"kind":"Hash","version":2}}
+                    """);
+            }
+            if (request.Uri.AbsolutePath.EndsWith("/pkranges", StringComparison.Ordinal))
+            {
+                if (request.Headers.ContainsKey("If-None-Match"))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.NotModified);
+                }
+                var ranges = JsonResponse(HttpStatusCode.OK, """
+                    {"_rid":"PaYSALITqjg=","PartitionKeyRanges":[{"id":"0","minInclusive":"","maxExclusive":"FF"}],"_count":1}
+                    """);
+                ranges.Headers.TryAddWithoutValidation("ETag", "\"ranges-etag\"");
+                return ranges;
+            }
+            if (request.Uri.AbsolutePath.Contains("/docs", StringComparison.Ordinal))
+            {
+                if (request.Headers.ContainsKey("x-ms-documentdb-isquery"))
+                {
+                    var documents = Enumerable.Range(outboxPage * OutboxPageSize, OutboxPageSize).Select(index =>
+                    {
+                        var rid = Convert.FromBase64String("PaYSALITqjgBAAAAAAAAAA==");
+                        BitConverter.GetBytes(index + 1).CopyTo(rid, 8);
+                        return new
+                        {
+                            _rid = Convert.ToBase64String(rid),
+                            orderByItems = new[] { new { item = DateTimeOffset.Parse("2026-09-08T12:00:00Z").AddSeconds(index).ToString("O") } },
+                            payload = new
+                            {
+                                job = new { id = index is 0 ? JobId : index.ToString("x32"), status = "Queued", needsDispatch = true },
+                                _etag = index is 0 ? "\"outbox-etag\"" : $"\"outbox-etag-{index}\""
+                            }
+                        };
+                    });
+                    var page = JsonResponse(HttpStatusCode.OK, JsonSerializer.Serialize(new { Documents = documents, _count = OutboxPageSize }));
+                    if (++outboxPage < OutboxPages)
+                    {
+                        page.Headers.TryAddWithoutValidation("x-ms-continuation", "next-page");
+                    }
+                    return page;
+                }
+                var content = request.Method == HttpMethod.Get
+                    ? $$"""{"id":"{{JobId}}","status":"Queued","needsDispatch":true,"_etag":"\"document-etag\""}"""
+                    : Encoding.UTF8.GetString(request.Body);
+                var response = JsonResponse(CosmosStatus, content);
+                response.Headers.TryAddWithoutValidation("etag", "\"response-etag\"");
+                response.Headers.TryAddWithoutValidation("x-ms-request-charge", "1");
+                response.Headers.TryAddWithoutValidation("x-ms-activity-id", "00000000-0000-0000-0000-000000000001");
+                return response;
+            }
+            throw new InvalidOperationException($"Unexpected Cosmos request: {request.Method} {request.Uri}");
+        }
+
+        /// <summary>Emulates immutable uploads and streaming downloads.</summary>
+        private HttpResponseMessage BlobResponse(CapturedRequest request)
+        {
+            var response = new HttpResponseMessage(BlobStatus is HttpStatusCode.OK && request.Method == HttpMethod.Put ? HttpStatusCode.Created : BlobStatus)
+            {
+                Content = new ByteArrayContent(request.Method == HttpMethod.Get ? BlobBody : [])
+            };
+            response.Headers.TryAddWithoutValidation("ETag", "\"blob-etag\"");
+            response.Content.Headers.TryAddWithoutValidation("Last-Modified", "Tue, 08 Sep 2026 12:00:00 GMT");
+            response.Headers.TryAddWithoutValidation("x-ms-blob-type", "BlockBlob");
+            response.Content.Headers.ContentLength = request.Method == HttpMethod.Get ? BlobBody.Length : 0;
+            return response;
+        }
+
+        /// <summary>Emulates queue receipts, sends, and explicit acknowledgements.</summary>
+        private HttpResponseMessage QueueResponse(CapturedRequest request)
+        {
+            if (QueueStatus is not HttpStatusCode.OK)
+            {
+                return new HttpResponseMessage(QueueStatus)
+                {
+                    Content = new StringContent("<Error><Code>PopReceiptMismatch</Code><Message>Receipt mismatch.</Message></Error>", Encoding.UTF8, "application/xml")
+                };
+            }
+            var content = request.Method == HttpMethod.Get && QueueBody is not null
+                ? new XElement("QueueMessagesList", new XElement("QueueMessage",
+                    new XElement("MessageId", "message-id"),
+                    new XElement("PopReceipt", "old-receipt"),
+                    new XElement("InsertionTime", "Tue, 08 Sep 2026 12:00:00 GMT"),
+                    new XElement("ExpirationTime", "Fri, 31 Dec 9999 23:59:59 GMT"),
+                    new XElement("TimeNextVisible", "Tue, 08 Sep 2026 12:02:00 GMT"),
+                    new XElement("DequeueCount", 4),
+                    new XElement("MessageText", QueueBody))).ToString()
+                : "<QueueMessagesList />";
+            if (request.Method == HttpMethod.Post)
+            {
+                content = """
+                    <QueueMessagesList><QueueMessage><MessageId>message-id</MessageId><InsertionTime>Tue, 08 Sep 2026 12:00:00 GMT</InsertionTime><ExpirationTime>Fri, 31 Dec 9999 23:59:59 GMT</ExpirationTime><PopReceipt>old-receipt</PopReceipt><TimeNextVisible>Tue, 08 Sep 2026 12:02:00 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>
+                    """;
+            }
+            var status = request.Method == HttpMethod.Post ? HttpStatusCode.Created
+                : request.Method == HttpMethod.Put || request.Method == HttpMethod.Delete ? HttpStatusCode.NoContent
+                : HttpStatusCode.OK;
+            var response = new HttpResponseMessage(status) { Content = new StringContent(content, Encoding.UTF8, "application/xml") };
+            response.Headers.TryAddWithoutValidation("x-ms-popreceipt", "renewed-receipt");
+            response.Headers.TryAddWithoutValidation("x-ms-time-next-visible", "Tue, 08 Sep 2026 12:03:00 GMT");
+            return response;
+        }
+
+        /// <summary>Creates a JSON response for the SDK.</summary>
+        private static HttpResponseMessage JsonResponse(HttpStatusCode status, string json) =>
+            new(status) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+    }
+
+    /// <summary>A captured outbound SDK request.</summary>
+    private sealed record CapturedRequest(HttpMethod Method, Uri Uri, byte[] Body, Dictionary<string, string> Headers);
+}

--- a/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobTests.cs
+++ b/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobTests.cs
@@ -224,9 +224,13 @@ public sealed class WindowsPackageJobTests
     internal sealed class Fixture
     {
         internal readonly List<string> Events = [];
+
         internal readonly FakeStore Store;
+
         internal readonly FakeQueue Queue;
+
         internal readonly FakeBuilder Builder;
+
         internal readonly WindowsPackageJobProcessor Processor;
 
         internal Fixture(WindowsPackageJobOptions? options = null)
@@ -252,8 +256,11 @@ public sealed class WindowsPackageJobTests
             ExpiresAt = DateTimeOffset.UtcNow.AddDays(1),
             ETag = "0"
         };
+
         internal Exception? UploadError;
+
         internal bool RejectCompletion;
+
         internal WindowsPackageJobInput? SavedInput;
 
         public Task CreateAsync(WindowsPackageJob job, WindowsPackageJobInput input, CancellationToken token)
@@ -309,12 +316,19 @@ public sealed class WindowsPackageJobTests
     internal sealed class FakeQueue(List<string> events) : IWindowsPackageJobQueue
     {
         internal Exception? SendError;
+
         internal Exception? RenewError;
+
         internal Exception? PoisonError;
+
         internal string? SentJobId;
+
         internal Action? OnRenew;
+
         internal string? LatestReceipt;
+
         internal string? DeletedReceipt;
+
         internal Task<PackageJobMessage>? RenewResponse;
 
         public Task SendAsync(string jobId, CancellationToken token)
@@ -366,11 +380,17 @@ public sealed class WindowsPackageJobTests
     internal sealed class FakeBuilder(List<string> events) : IWindowsPackageJobBuilder
     {
         internal int Builds;
+
         internal WindowsPackageJobInput? Input;
+
         internal Exception? Error;
+
         internal Action? OnBuild;
+
         internal bool WaitForCancellation;
+
         internal bool WasCancelled;
+
         internal Task? WaitFor;
 
         public async Task<string> BuildAsync(WindowsPackageJobInput input, CancellationToken token)

--- a/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobTests.cs
+++ b/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobTests.cs
@@ -1,0 +1,406 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using PWABuilder.MicrosoftStore.Jobs;
+using PWABuilder.MicrosoftStore.Models;
+using Xunit;
+
+namespace PWABuilder.MicrosoftStore.Tests;
+
+public sealed class WindowsPackageJobTests
+{
+    [Fact]
+    public async Task Process_WhenSuccessful_PersistsArtifactAndCompletionBeforeAcknowledging()
+    {
+        var fixture = new Fixture();
+        await fixture.Process();
+
+        Assert.Equal(WindowsPackageJob.Completed, fixture.Store.Job!.Status);
+        Assert.Equal(["build", "upload", "complete", "ack"], fixture.Events);
+        Assert.Equal("Partner", fixture.Builder.Input!.Analytics.PlatformId);
+    }
+
+    [Fact]
+    public async Task Process_WhenCompletedMessageIsRedelivered_DoesNotBuildAgain()
+    {
+        var fixture = new Fixture();
+        await fixture.Process();
+        fixture.Events.Clear();
+        await fixture.Process();
+
+        Assert.Equal(["ack"], fixture.Events);
+        Assert.Equal(1, fixture.Builder.Builds);
+    }
+
+    [Fact]
+    public async Task Process_WhenWorkerCrashed_ReclaimsExpiredAttempt()
+    {
+        var fixture = new Fixture();
+        fixture.Store.Job = fixture.Store.Job! with
+        {
+            Status = WindowsPackageJob.InProgress,
+            LeaseExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            Attempts = 1
+        };
+        await fixture.Process();
+
+        Assert.Equal(WindowsPackageJob.Completed, fixture.Store.Job!.Status);
+        Assert.Equal(2, fixture.Store.Job.Attempts);
+    }
+
+    [Fact]
+    public async Task Process_WhenAnotherWorkerOwnsJob_DoesNotBuildOrAcknowledge()
+    {
+        var fixture = new Fixture();
+        fixture.Store.Job = fixture.Store.Job! with
+        {
+            Status = WindowsPackageJob.InProgress,
+            LeaseExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+        };
+        await fixture.Process();
+
+        Assert.Equal(0, fixture.Builder.Builds);
+        Assert.DoesNotContain("ack", fixture.Events);
+    }
+
+    [Fact]
+    public async Task Process_WhenBuildFails_LeavesMessageForRetry()
+    {
+        var fixture = new Fixture();
+        fixture.Builder.Error = new IOException("Transient tool failure");
+        await fixture.Process();
+
+        Assert.Equal(WindowsPackageJob.Queued, fixture.Store.Job!.Status);
+        Assert.Equal(1, fixture.Store.Job.Attempts);
+        Assert.False(fixture.Store.Job.NeedsDispatch);
+        Assert.DoesNotContain("ack", fixture.Events);
+    }
+
+    [Fact]
+    public async Task Process_WhenAttemptsExhausted_PoisonsBeforeAcknowledging()
+    {
+        var fixture = new Fixture();
+        fixture.Store.Job = fixture.Store.Job! with { Attempts = 3 };
+        await fixture.Process();
+
+        Assert.Equal(WindowsPackageJob.Failed, fixture.Store.Job!.Status);
+        Assert.Equal(0, fixture.Builder.Builds);
+        Assert.True(fixture.Events.IndexOf("poison") < fixture.Events.IndexOf("ack"));
+    }
+
+    [Fact]
+    public async Task Process_WhenUploadFails_DoesNotReportCompletion()
+    {
+        var fixture = new Fixture();
+        fixture.Store.UploadError = new IOException("Storage unavailable");
+        await fixture.Process();
+
+        Assert.Equal(WindowsPackageJob.Queued, fixture.Store.Job!.Status);
+        Assert.DoesNotContain("complete", fixture.Events);
+        Assert.DoesNotContain("ack", fixture.Events);
+    }
+
+    [Fact]
+    public async Task Process_WhenCancelled_LeavesMessageRecoverable()
+    {
+        var fixture = new Fixture();
+        using var cancellation = new CancellationTokenSource();
+        fixture.Builder.OnBuild = cancellation.Cancel;
+        await fixture.Process(cancellation.Token);
+
+        Assert.DoesNotContain("ack", fixture.Events);
+        Assert.NotEqual(WindowsPackageJob.Completed, fixture.Store.Job!.Status);
+    }
+
+    [Fact]
+    public async Task Process_WhenExpired_DoesNotBuild()
+    {
+        var fixture = new Fixture();
+        fixture.Store.Job = fixture.Store.Job! with { ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(-1) };
+        await fixture.Process();
+
+        Assert.Equal(WindowsPackageJob.Expired, fixture.Store.Job!.Status);
+        Assert.Equal(0, fixture.Builder.Builds);
+        Assert.Contains("ack", fixture.Events);
+    }
+
+    [Fact]
+    public async Task Dispatch_WhenEnqueueFails_PreservesPendingRecord()
+    {
+        var fixture = new Fixture();
+        fixture.Queue.SendError = new IOException("Queue unavailable");
+        await Assert.ThrowsAsync<IOException>(() => fixture.Processor.DispatchAsync(CancellationToken.None));
+        Assert.True(fixture.Store.Job!.NeedsDispatch);
+
+        fixture.Queue.SendError = null;
+        await fixture.Processor.DispatchAsync(CancellationToken.None);
+        Assert.False(fixture.Store.Job.NeedsDispatch);
+        Assert.Equal(fixture.Store.Job.Id, fixture.Queue.SentJobId);
+    }
+
+    [Fact]
+    public async Task Process_WhenCompletionETagChanged_DoesNotAcknowledgeOrPublishStaleOutput()
+    {
+        var fixture = new Fixture();
+        fixture.Store.RejectCompletion = true;
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Process());
+
+        Assert.DoesNotContain("ack", fixture.Events);
+        Assert.NotEqual(WindowsPackageJob.Completed, fixture.Store.Job!.Status);
+    }
+
+    [Fact]
+    public async Task Process_WhenVisibilityRenewalFails_CancelsBuildAndDoesNotAcknowledge()
+    {
+        var fixture = new Fixture(new WindowsPackageJobOptions { RenewalSeconds = 1 });
+        fixture.Queue.RenewError = new IOException("Lease lost");
+        fixture.Builder.WaitForCancellation = true;
+        await Assert.ThrowsAsync<IOException>(() => fixture.Process().WaitAsync(TimeSpan.FromSeconds(10)));
+
+        Assert.True(fixture.Builder.WasCancelled);
+        Assert.DoesNotContain("ack", fixture.Events);
+        Assert.DoesNotContain("complete", fixture.Events);
+    }
+
+    [Fact]
+    public async Task Process_WhenPoisonWriteFails_DoesNotAcknowledge()
+    {
+        var fixture = new Fixture();
+        fixture.Store.Job = fixture.Store.Job! with { Attempts = 3 };
+        fixture.Queue.PoisonError = new IOException("Poison storage unavailable");
+        await Assert.ThrowsAsync<IOException>(() => fixture.Process());
+
+        Assert.Equal(WindowsPackageJob.Failed, fixture.Store.Job!.Status);
+        Assert.DoesNotContain("ack", fixture.Events);
+    }
+
+    [Fact]
+    public async Task Process_AfterVisibilityRenewal_AcknowledgesLatestReceipt()
+    {
+        var fixture = new Fixture(new WindowsPackageJobOptions { RenewalSeconds = 1 });
+        var renewed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.Queue.OnRenew = () => renewed.TrySetResult();
+        fixture.Builder.WaitFor = renewed.Task;
+        await fixture.Process().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.NotNull(fixture.Queue.LatestReceipt);
+        Assert.NotEqual("receipt", fixture.Queue.DeletedReceipt);
+        Assert.Equal(fixture.Queue.LatestReceipt, fixture.Queue.DeletedReceipt);
+        Assert.Equal(WindowsPackageJob.Completed, fixture.Store.Job!.Status);
+    }
+
+    [Fact]
+    public async Task Lease_WhenRenewalFailsWhileCompletionWaits_DoesNotPublishCompletion()
+    {
+        var staleCompletions = 0;
+        for (var i = 0; i < 2000; i++)
+        {
+            var fixture = new Fixture();
+            var renewalResponse = new TaskCompletionSource<PackageJobMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            fixture.Queue.RenewResponse = renewalResponse.Task;
+            fixture.Store.Job = fixture.Store.Job! with { LeaseExpiresAt = DateTimeOffset.UtcNow.AddMinutes(2) };
+            using var lease = new PackageJobLease(fixture.Store, fixture.Queue, fixture.Store.Job,
+                new PackageJobMessage("message", "receipt", fixture.Store.Job.Id, 1),
+                new WindowsPackageJobOptions { RenewalSeconds = 0 }, TimeProvider.System);
+            using var build = new CancellationTokenSource();
+            using var stopRenewal = new CancellationTokenSource();
+            var renew = lease.RenewUntilStoppedAsync(build, stopRenewal.Token);
+            var finish = lease.FinishAsync(j => j with { Status = WindowsPackageJob.Completed }, default);
+
+            renewalResponse.SetException(new IOException("Visibility renewal failed"));
+            await Assert.ThrowsAsync<IOException>(() => renew);
+            try
+            {
+                await finish;
+                staleCompletions++;
+            }
+            catch (InvalidOperationException)
+            {
+                Assert.NotEqual(WindowsPackageJob.Completed, fixture.Store.Job.Status);
+            }
+        }
+        Assert.Equal(0, staleCompletions);
+    }
+
+    internal sealed class Fixture
+    {
+        internal readonly List<string> Events = [];
+        internal readonly FakeStore Store;
+        internal readonly FakeQueue Queue;
+        internal readonly FakeBuilder Builder;
+        internal readonly WindowsPackageJobProcessor Processor;
+
+        internal Fixture(WindowsPackageJobOptions? options = null)
+        {
+            Store = new FakeStore(Events);
+            Queue = new FakeQueue(Events);
+            Builder = new FakeBuilder(Events);
+            Processor = new WindowsPackageJobProcessor(Store, Queue, Builder,
+                Options.Create(options ?? new WindowsPackageJobOptions()), TimeProvider.System,
+                NullLogger<WindowsPackageJobProcessor>.Instance);
+        }
+
+        internal Task Process(CancellationToken token = default) =>
+            Processor.ProcessAsync(new PackageJobMessage("message", "receipt", Store.Job!.Id, 1), token);
+    }
+
+    internal sealed class FakeStore(List<string> events) : IWindowsPackageJobStore
+    {
+        internal WindowsPackageJob? Job = new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(1),
+            ETag = "0"
+        };
+        internal Exception? UploadError;
+        internal bool RejectCompletion;
+        internal WindowsPackageJobInput? SavedInput;
+
+        public Task CreateAsync(WindowsPackageJob job, WindowsPackageJobInput input, CancellationToken token)
+        {
+            SavedInput = input;
+            Job = job with { ETag = "0" };
+            return Task.CompletedTask;
+        }
+
+        public Task<WindowsPackageJob?> GetAsync(string id, CancellationToken token) =>
+            Task.FromResult(Job?.Id == id ? Job : null);
+
+        public Task<IReadOnlyList<WindowsPackageJob>> GetPendingDispatchAsync(CancellationToken token) =>
+            Task.FromResult<IReadOnlyList<WindowsPackageJob>>(Job is { NeedsDispatch: true } ? [Job] : []);
+
+        public Task<WindowsPackageJob?> TryReplaceAsync(WindowsPackageJob job, CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+            if (Job?.ETag != job.ETag || (RejectCompletion && job.Status == WindowsPackageJob.Completed))
+            {
+                return Task.FromResult<WindowsPackageJob?>(null);
+            }
+
+            Job = job with { ETag = Guid.NewGuid().ToString() };
+            if (Job.Status == WindowsPackageJob.Completed)
+            {
+                events.Add("complete");
+            }
+            return Task.FromResult<WindowsPackageJob?>(Job);
+        }
+
+        public Task<WindowsPackageJobInput> ReadInputAsync(string id, CancellationToken token) =>
+            Task.FromResult(new WindowsPackageJobInput
+            {
+                Options = new WindowsAppPackageOptions { Url = new Uri("https://example.com") },
+                Analytics = new PackageJobAnalytics { PlatformId = "Partner" }
+            });
+
+        public Task<string> UploadArtifactAsync(string id, string attemptId, string path, CancellationToken token)
+        {
+            if (UploadError is not null)
+            {
+                throw UploadError;
+            }
+            events.Add("upload");
+            return Task.FromResult($"{id}/{attemptId}.zip");
+        }
+
+        public Task<Stream> OpenArtifactAsync(string name, CancellationToken token) =>
+            Task.FromResult<Stream>(new MemoryStream([1, 2, 3]));
+    }
+
+    internal sealed class FakeQueue(List<string> events) : IWindowsPackageJobQueue
+    {
+        internal Exception? SendError;
+        internal Exception? RenewError;
+        internal Exception? PoisonError;
+        internal string? SentJobId;
+        internal Action? OnRenew;
+        internal string? LatestReceipt;
+        internal string? DeletedReceipt;
+        internal Task<PackageJobMessage>? RenewResponse;
+
+        public Task SendAsync(string jobId, CancellationToken token)
+        {
+            if (SendError is not null)
+            {
+                throw SendError;
+            }
+            SentJobId = jobId;
+            return Task.CompletedTask;
+        }
+
+        public Task<PackageJobMessage?> ReceiveAsync(CancellationToken token) =>
+            Task.FromResult<PackageJobMessage?>(null);
+
+        public Task<PackageJobMessage> RenewAsync(PackageJobMessage message, TimeSpan visibility, CancellationToken token)
+        {
+            if (RenewResponse is not null)
+            {
+                return RenewResponse;
+            }
+            if (RenewError is not null)
+            {
+                throw RenewError;
+            }
+            LatestReceipt = Guid.NewGuid().ToString();
+            OnRenew?.Invoke();
+            return Task.FromResult(message with { PopReceipt = LatestReceipt });
+        }
+
+        public Task DeleteAsync(PackageJobMessage message, CancellationToken token)
+        {
+            DeletedReceipt = message.PopReceipt;
+            events.Add("ack");
+            return Task.CompletedTask;
+        }
+
+        public Task PoisonAsync(PackageJobMessage message, string reason, CancellationToken token)
+        {
+            if (PoisonError is not null)
+            {
+                throw PoisonError;
+            }
+            events.Add("poison");
+            return Task.CompletedTask;
+        }
+    }
+
+    internal sealed class FakeBuilder(List<string> events) : IWindowsPackageJobBuilder
+    {
+        internal int Builds;
+        internal WindowsPackageJobInput? Input;
+        internal Exception? Error;
+        internal Action? OnBuild;
+        internal bool WaitForCancellation;
+        internal bool WasCancelled;
+        internal Task? WaitFor;
+
+        public async Task<string> BuildAsync(WindowsPackageJobInput input, CancellationToken token)
+        {
+            Builds++;
+            Input = input;
+            events.Add("build");
+            OnBuild?.Invoke();
+            token.ThrowIfCancellationRequested();
+            if (WaitFor is not null)
+            {
+                await WaitFor.WaitAsync(token);
+            }
+            if (WaitForCancellation)
+            {
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    WasCancelled = true;
+                    throw;
+                }
+            }
+            if (Error is not null)
+            {
+                throw Error;
+            }
+            return "package.zip";
+        }
+    }
+}

--- a/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobsControllerTests.cs
+++ b/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobsControllerTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using PWABuilder.MicrosoftStore.Controllers;
+using PWABuilder.MicrosoftStore.Jobs;
+using PWABuilder.MicrosoftStore.Models;
+using Xunit;
+
+namespace PWABuilder.MicrosoftStore.Tests;
+
+public sealed class WindowsPackageJobsControllerTests
+{
+    [Fact]
+    public async Task Enqueue_WhenDisabled_ReturnsServiceUnavailable()
+    {
+        var controller = CreateController(false);
+        var response = Assert.IsType<ObjectResult>(await controller.EnqueuePackageJob(ValidOptions(), default));
+        Assert.Equal(503, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Enqueue_WhenValid_PersistsBeforeReturningAccepted()
+    {
+        var store = new WindowsPackageJobTests.FakeStore([]);
+        var controller = CreateController(true, store);
+        controller.Request.Headers["platform-identifier"] = "Partner";
+        controller.Request.Headers["platform-identifier-version"] = "2";
+        controller.Request.Headers["correlation-id"] = "trace-id";
+        var response = Assert.IsType<AcceptedResult>(await controller.EnqueuePackageJob(ValidOptions(), default));
+        var status = Assert.IsType<WindowsPackageJobStatus>(response.Value);
+
+        Assert.Equal(store.Job!.Id, status.Id);
+        Assert.Equal("Partner", store.Job.PlatformId);
+        Assert.True(store.Job.NeedsDispatch);
+        Assert.Equal($"/msix/getPackageJob?id={status.Id}", response.Location);
+        Assert.Equal("2", controller.Response.Headers.RetryAfter);
+    }
+
+    [Fact]
+    public async Task Enqueue_WhenInvalid_DoesNotPersist()
+    {
+        var store = new WindowsPackageJobTests.FakeStore([]);
+        var original = store.Job;
+        var controller = CreateController(true, store);
+        var response = await controller.EnqueuePackageJob(new WindowsAppPackageOptions
+        {
+            Url = new Uri("http://localhost")
+        }, default);
+
+        Assert.IsType<BadRequestObjectResult>(response);
+        Assert.Same(original, store.Job);
+    }
+
+    [Fact]
+    public async Task GetStatus_DoesNotExposePrivateBuildInputsOrLease()
+    {
+        var store = new WindowsPackageJobTests.FakeStore([]);
+        var controller = CreateController(true, store);
+        var response = Assert.IsType<OkObjectResult>(await controller.GetPackageJob(store.Job!.Id, default));
+        var json = System.Text.Json.JsonSerializer.Serialize(response.Value);
+
+        Assert.DoesNotContain("Options", json);
+        Assert.DoesNotContain("ETag", json);
+        Assert.DoesNotContain("Lease", json);
+        Assert.DoesNotContain("ArtifactName", json);
+    }
+
+    [Fact]
+    public async Task Download_WhenNotCompleted_ReturnsConflict()
+    {
+        var store = new WindowsPackageJobTests.FakeStore([]);
+        var controller = CreateController(true, store);
+        Assert.IsType<ConflictObjectResult>(await controller.DownloadPackageZip(store.Job!.Id, default));
+    }
+
+    [Fact]
+    public async Task Download_WhenCompleted_ReturnsStream()
+    {
+        var store = new WindowsPackageJobTests.FakeStore([]);
+        store.Job = store.Job! with { Status = WindowsPackageJob.Completed, ArtifactName = "output.zip" };
+        var controller = CreateController(true, store);
+        var response = Assert.IsType<FileStreamResult>(await controller.DownloadPackageZip(store.Job.Id, default));
+
+        Assert.Equal("application/zip", response.ContentType);
+        await response.FileStream.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Download_WhenExpired_ReturnsGone()
+    {
+        var store = new WindowsPackageJobTests.FakeStore([]);
+        store.Job = store.Job! with
+        {
+            Status = WindowsPackageJob.Completed,
+            ArtifactName = "output.zip",
+            ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(-1)
+        };
+        var controller = CreateController(true, store);
+        var response = Assert.IsType<ObjectResult>(await controller.DownloadPackageZip(store.Job.Id, default));
+        Assert.Equal(410, response.StatusCode);
+    }
+
+    private static WindowsPackageJobsController CreateController(bool enabled, IWindowsPackageJobStore? store = null) =>
+        new(Options.Create(new WindowsPackageJobOptions { Enabled = enabled }),
+            Options.Create(new AppSettings { ImageGeneratorApiUrl = new Uri("https://example.com/images") }),
+            TimeProvider.System, store)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+    private static WindowsAppPackageOptions ValidOptions() => new()
+    {
+        Url = new Uri("https://example.com"),
+        PackageId = "Example.App",
+        Version = "1.0.0"
+    };
+}

--- a/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobsHttpTests.cs
+++ b/apps/pwabuilder-microsoft-store.Tests/WindowsPackageJobsHttpTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using PWABuilder.MicrosoftStore.Controllers;
+using PWABuilder.MicrosoftStore.Jobs;
+using PWABuilder.MicrosoftStore.Models;
+using Xunit;
+
+namespace PWABuilder.MicrosoftStore.Tests;
+
+public sealed class WindowsPackageJobsHttpTests
+{
+    [Fact]
+    public async Task QueuedEndpoints_AcceptPollAndStreamUsingRealHttpRouting()
+    {
+        var store = new WindowsPackageJobTests.FakeStore([]);
+        await using var app = CreateApp(store);
+        await app.StartAsync();
+        using var client = new HttpClient { BaseAddress = new Uri(app.Urls.Single()) };
+        client.DefaultRequestHeaders.Add("platform-identifier", "Partner");
+        client.DefaultRequestHeaders.Add("platform-identifier-version", "2");
+        client.DefaultRequestHeaders.Add("correlation-id", "partner-trace");
+
+        using var enqueue = await client.PostAsJsonAsync("/msix/enqueuePackageJob?ref=partner", new
+        {
+            url = "https://example.com",
+            packageId = "Example.Pwa",
+            version = "1.0.0",
+            manifest = new { name = "Example" }
+        });
+        Assert.Equal(HttpStatusCode.Accepted, enqueue.StatusCode);
+        var accepted = await enqueue.Content.ReadFromJsonAsync<WindowsPackageJobStatus>();
+        Assert.NotNull(accepted);
+        Assert.Equal("Queued", accepted.Status);
+        Assert.Equal("partner-trace", store.SavedInput!.Analytics.CorrelationId);
+        Assert.Equal("Partner", store.SavedInput.Analytics.PlatformId);
+        Assert.Equal("2", store.SavedInput.Analytics.PlatformVersion);
+        Assert.Equal("partner", store.SavedInput.Analytics.Referrer);
+        Assert.Equal("Example", store.SavedInput.Options.Manifest!.RootElement.GetProperty("name").GetString());
+
+        using var poll = await client.GetAsync(enqueue.Headers.Location);
+        Assert.Equal(HttpStatusCode.OK, poll.StatusCode);
+        var status = await poll.Content.ReadFromJsonAsync<WindowsPackageJobStatus>();
+        Assert.Equal(accepted.Id, status!.Id);
+
+        store.Job = store.Job! with { Status = WindowsPackageJob.Completed, ArtifactName = "artifact.zip" };
+        using var download = await client.GetAsync($"/msix/downloadPackageZip?id={accepted.Id}");
+        Assert.Equal(HttpStatusCode.OK, download.StatusCode);
+        Assert.Equal("application/zip", download.Content.Headers.ContentType!.MediaType);
+        Assert.Equal(new byte[] { 1, 2, 3 }, await download.Content.ReadAsByteArrayAsync());
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task Enqueue_WhenRequiredUrlIsMissing_ReturnsBadRequestWithoutPersisting()
+    {
+        var store = new WindowsPackageJobTests.FakeStore([]);
+        await using var app = CreateApp(store);
+        await app.StartAsync();
+        using var client = new HttpClient { BaseAddress = new Uri(app.Urls.Single()) };
+        using var response = await client.PostAsJsonAsync("/msix/enqueuePackageJob", new { packageId = "Example.Pwa", version = "1.0.0" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Null(store.SavedInput);
+        await app.StopAsync();
+    }
+
+    private static WebApplication CreateApp(IWindowsPackageJobStore store)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.Configure<WindowsPackageJobOptions>(o => o.Enabled = true);
+        builder.Services.Configure<AppSettings>(_ => { });
+        builder.Services.AddSingleton(store);
+        builder.Services.AddSingleton(TimeProvider.System);
+        builder.Services.AddControllers().AddApplicationPart(typeof(WindowsPackageJobsController).Assembly);
+        var app = builder.Build();
+        app.MapControllers();
+        return app;
+    }
+}

--- a/apps/pwabuilder-microsoft-store/Controllers/WindowsPackageJobsController.cs
+++ b/apps/pwabuilder-microsoft-store/Controllers/WindowsPackageJobsController.cs
@@ -9,7 +9,9 @@ using PWABuilder.MicrosoftStore.Models;
 
 namespace PWABuilder.MicrosoftStore.Controllers;
 
-/// <summary>Optional asynchronous packaging API; legacy MSIX endpoints remain unchanged.</summary>
+/// <summary>
+/// Optional asynchronous packaging API; legacy MSIX endpoints remain unchanged.
+/// </summary>
 [ApiController]
 [Route("msix")]
 public sealed class WindowsPackageJobsController(
@@ -18,7 +20,9 @@ public sealed class WindowsPackageJobsController(
     TimeProvider clock,
     IWindowsPackageJobStore? store = null) : ControllerBase
 {
-    /// <summary>Durably accepts a Windows package job without holding the HTTP connection open.</summary>
+    /// <summary>
+    /// Durably accepts a Windows package job without holding the HTTP connection open.
+    /// </summary>
     [HttpPost("enqueuePackageJob")]
     [RequestSizeLimit(2 * 1024 * 1024)]
     public async Task<IActionResult> EnqueuePackageJob(WindowsAppPackageOptions packageOptions, CancellationToken token)
@@ -66,7 +70,9 @@ public sealed class WindowsPackageJobsController(
         return Accepted($"{Request.PathBase}/msix/getPackageJob?id={job.Id}", ToStatus(job));
     }
 
-    /// <summary>Returns safe job status. Random job IDs are bearer capabilities.</summary>
+    /// <summary>
+    /// Returns safe job status. Random job IDs are bearer capabilities.
+    /// </summary>
     [HttpGet("getPackageJob")]
     public async Task<IActionResult> GetPackageJob(string id, CancellationToken token)
     {
@@ -88,7 +94,9 @@ public sealed class WindowsPackageJobsController(
         return Ok(ToStatus(job));
     }
 
-    /// <summary>Streams an unexpired completed ZIP without buffering it in application memory.</summary>
+    /// <summary>
+    /// Streams an unexpired completed ZIP without buffering it in application memory.
+    /// </summary>
     [HttpGet("downloadPackageZip")]
     public async Task<IActionResult> DownloadPackageZip(string id, CancellationToken token)
     {
@@ -119,7 +127,9 @@ public sealed class WindowsPackageJobsController(
         return File(stream, "application/zip", "windows-package.zip");
     }
 
-    /// <summary>Maps durable metadata to the public polling contract.</summary>
+    /// <summary>
+    /// Maps durable metadata to the public polling contract.
+    /// </summary>
     private WindowsPackageJobStatus ToStatus(WindowsPackageJob job)
     {
         var expired = job.ExpiresAt <= clock.GetUtcNow();
@@ -135,7 +145,9 @@ public sealed class WindowsPackageJobsController(
                 ? $"{Request.PathBase}/msix/downloadPackageZip?id={job.Id}" : null);
     }
 
-    /// <summary>Reports the disabled feature without constructing storage dependencies.</summary>
+    /// <summary>
+    /// Reports the disabled feature without constructing storage dependencies.
+    /// </summary>
     private ObjectResult Unavailable() =>
         StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Queued Windows packaging is not enabled." });
 }

--- a/apps/pwabuilder-microsoft-store/Controllers/WindowsPackageJobsController.cs
+++ b/apps/pwabuilder-microsoft-store/Controllers/WindowsPackageJobsController.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using PWABuilder.MicrosoftStore.Jobs;
+using PWABuilder.MicrosoftStore.Models;
+
+namespace PWABuilder.MicrosoftStore.Controllers;
+
+/// <summary>Optional asynchronous packaging API; legacy MSIX endpoints remain unchanged.</summary>
+[ApiController]
+[Route("msix")]
+public sealed class WindowsPackageJobsController(
+    IOptions<WindowsPackageJobOptions> options,
+    IOptions<AppSettings> appSettings,
+    TimeProvider clock,
+    IWindowsPackageJobStore? store = null) : ControllerBase
+{
+    /// <summary>Durably accepts a Windows package job without holding the HTTP connection open.</summary>
+    [HttpPost("enqueuePackageJob")]
+    [RequestSizeLimit(2 * 1024 * 1024)]
+    public async Task<IActionResult> EnqueuePackageJob(WindowsAppPackageOptions packageOptions, CancellationToken token)
+    {
+        if (!options.Value.Enabled || store is null)
+        {
+            return Unavailable();
+        }
+
+        var errors = packageOptions.GetValidationErrors(appSettings.Value);
+        if (errors.Count > 0)
+        {
+            return BadRequest(new { errors });
+        }
+
+        // These paths are generated on the worker, never accepted from remote callers.
+        packageOptions.ManifestFilePath = null;
+        var now = clock.GetUtcNow();
+        var job = new WindowsPackageJob
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            CreatedAt = now,
+            ExpiresAt = now.AddHours(options.Value.JobLifetimeHours),
+            Ttl = checked((options.Value.JobLifetimeHours + 24) * 3600),
+            PlatformId = Request.Headers["platform-identifier"].ToString()
+        };
+        var input = new WindowsPackageJobInput
+        {
+            Options = packageOptions,
+            Analytics = new PackageJobAnalytics
+            {
+                PlatformId = job.PlatformId,
+                PlatformVersion = Request.Headers["platform-identifier-version"].ToString(),
+                CorrelationId = Request.Headers["correlation-id"].ToString() is { Length: > 0 } correlation
+                    ? correlation : job.Id,
+                Referrer = Request.Query["ref"].ToString()
+            }
+        };
+
+        // The persisted NeedsDispatch flag is an outbox. A queue outage or API crash
+        // after this write cannot silently drop the accepted job.
+        await store.CreateAsync(job, input, token);
+        Response.Headers.RetryAfter = options.Value.PollSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        Response.Headers.CacheControl = "no-store";
+        return Accepted($"{Request.PathBase}/msix/getPackageJob?id={job.Id}", ToStatus(job));
+    }
+
+    /// <summary>Returns safe job status. Random job IDs are bearer capabilities.</summary>
+    [HttpGet("getPackageJob")]
+    public async Task<IActionResult> GetPackageJob(string id, CancellationToken token)
+    {
+        Response.Headers.CacheControl = "no-store";
+        if (!options.Value.Enabled || store is null)
+        {
+            return Unavailable();
+        }
+        if (!Guid.TryParseExact(id, "N", out _))
+        {
+            return BadRequest(new { error = "Invalid job ID." });
+        }
+        var job = await store.GetAsync(id, token);
+        if (job is null)
+        {
+            return NotFound();
+        }
+        Response.Headers.RetryAfter = options.Value.PollSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return Ok(ToStatus(job));
+    }
+
+    /// <summary>Streams an unexpired completed ZIP without buffering it in application memory.</summary>
+    [HttpGet("downloadPackageZip")]
+    public async Task<IActionResult> DownloadPackageZip(string id, CancellationToken token)
+    {
+        Response.Headers.CacheControl = "no-store";
+        if (!options.Value.Enabled || store is null)
+        {
+            return Unavailable();
+        }
+        if (!Guid.TryParseExact(id, "N", out _))
+        {
+            return BadRequest(new { error = "Invalid job ID." });
+        }
+        var job = await store.GetAsync(id, token);
+        if (job is null)
+        {
+            return NotFound();
+        }
+        if (job.ExpiresAt <= clock.GetUtcNow() || job.Status is WindowsPackageJob.Expired)
+        {
+            return StatusCode(StatusCodes.Status410Gone, new { error = "Job expired." });
+        }
+        if (job.Status is not WindowsPackageJob.Completed || job.ArtifactName is null)
+        {
+            return Conflict(ToStatus(job));
+        }
+
+        var stream = await store.OpenArtifactAsync(job.ArtifactName, token);
+        return File(stream, "application/zip", "windows-package.zip");
+    }
+
+    /// <summary>Maps durable metadata to the public polling contract.</summary>
+    private WindowsPackageJobStatus ToStatus(WindowsPackageJob job)
+    {
+        var expired = job.ExpiresAt <= clock.GetUtcNow();
+        return new WindowsPackageJobStatus(
+            job.Id,
+            expired ? WindowsPackageJob.Expired : job.Status,
+            job.CreatedAt,
+            job.ExpiresAt,
+            job.FinishedAt,
+            job.Attempts,
+            expired ? "Job expired." : job.Error,
+            !expired && job.Status is WindowsPackageJob.Completed
+                ? $"{Request.PathBase}/msix/downloadPackageZip?id={job.Id}" : null);
+    }
+
+    /// <summary>Reports the disabled feature without constructing storage dependencies.</summary>
+    private ObjectResult Unavailable() =>
+        StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Queued Windows packaging is not enabled." });
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/AzureWindowsPackageJobQueue.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/AzureWindowsPackageJobQueue.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Identity;
+using Azure.Storage.Queues;
+using Microsoft.Extensions.Options;
+using PWABuilder.MicrosoftStore.Models;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Delivers job references through pre-provisioned Azure Storage queues.</summary>
+public sealed class AzureWindowsPackageJobQueue : IWindowsPackageJobQueue
+{
+    private static readonly TimeSpan InfiniteTimeToLive = TimeSpan.FromSeconds(-1);
+
+    private readonly QueueClient queue;
+    private readonly QueueClient poisonQueue;
+    private readonly TimeSpan visibility;
+
+    /// <summary>Connects to the work and poison queues using the configured managed identity.</summary>
+    public AzureWindowsPackageJobQueue(IOptions<WindowsPackageJobOptions> options, IOptions<AppSettings> appSettings)
+    {
+        var configuration = options.Value;
+        var identity = appSettings.Value.AzureManagedIdentityApplicationId;
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuration.QueueName);
+        var credential = string.IsNullOrWhiteSpace(identity)
+            ? new ManagedIdentityCredential()
+            : new ManagedIdentityCredential(identity);
+        var service = new QueueServiceClient(new Uri(configuration.QueueServiceUri), credential,
+            new QueueClientOptions { MessageEncoding = QueueMessageEncoding.None });
+        queue = service.GetQueueClient(configuration.QueueName);
+        poisonQueue = service.GetQueueClient(configuration.QueueName + "-poison");
+        visibility = TimeSpan.FromSeconds(configuration.VisibilitySeconds);
+    }
+
+    /// <summary>Uses supplied SDK clients for queue delivery.</summary>
+    internal AzureWindowsPackageJobQueue(QueueClient queue, QueueClient poisonQueue, WindowsPackageJobOptions options)
+    {
+        this.queue = queue;
+        this.poisonQueue = poisonQueue;
+        visibility = TimeSpan.FromSeconds(options.VisibilitySeconds);
+    }
+
+    /// <inheritdoc/>
+    public async Task SendAsync(string jobId, CancellationToken token)
+    {
+        await queue.SendMessageAsync(jobId, timeToLive: InfiniteTimeToLive, cancellationToken: token);
+    }
+
+    /// <inheritdoc/>
+    public async Task<PackageJobMessage?> ReceiveAsync(CancellationToken token)
+    {
+        var response = await queue.ReceiveMessagesAsync(maxMessages: 1, visibilityTimeout: visibility, cancellationToken: token);
+        var message = response.Value.FirstOrDefault();
+        return message is null
+            ? null
+            : new PackageJobMessage(message.MessageId, message.PopReceipt, message.MessageText, message.DequeueCount);
+    }
+
+    /// <inheritdoc/>
+    public async Task<PackageJobMessage> RenewAsync(PackageJobMessage message, TimeSpan visibility, CancellationToken token)
+    {
+        var response = await queue.UpdateMessageAsync(message.MessageId, message.PopReceipt,
+            messageText: null, visibilityTimeout: visibility, cancellationToken: token);
+        return message with { PopReceipt = response.Value.PopReceipt };
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteAsync(PackageJobMessage message, CancellationToken token)
+    {
+        await queue.DeleteMessageAsync(message.MessageId, message.PopReceipt, token);
+    }
+
+    /// <inheritdoc/>
+    public async Task PoisonAsync(PackageJobMessage message, string reason, CancellationToken token)
+    {
+        var diagnostic = JsonSerializer.Serialize(new
+        {
+            jobId = Guid.TryParseExact(message.JobId, "N", out var id) ? id.ToString("N") : "invalid",
+            messageId = Sanitize(message.MessageId, 64),
+            reason = Sanitize(reason, 160),
+            attempts = message.DequeueCount
+        });
+        await poisonQueue.SendMessageAsync(diagnostic, timeToLive: InfiniteTimeToLive, cancellationToken: token);
+    }
+
+    /// <summary>Bounds diagnostics and excludes control characters and arbitrary markup.</summary>
+    private static string Sanitize(string value, int limit) =>
+        new(value.Take(limit).Where(character => char.IsAsciiLetterOrDigit(character) || character is ' ' or '-' or '_' or '.').ToArray());
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/AzureWindowsPackageJobQueue.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/AzureWindowsPackageJobQueue.cs
@@ -10,16 +10,22 @@ using PWABuilder.MicrosoftStore.Models;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Delivers job references through pre-provisioned Azure Storage queues.</summary>
+/// <summary>
+/// Delivers job references through pre-provisioned Azure Storage queues.
+/// </summary>
 public sealed class AzureWindowsPackageJobQueue : IWindowsPackageJobQueue
 {
     private static readonly TimeSpan InfiniteTimeToLive = TimeSpan.FromSeconds(-1);
 
     private readonly QueueClient queue;
+
     private readonly QueueClient poisonQueue;
+
     private readonly TimeSpan visibility;
 
-    /// <summary>Connects to the work and poison queues using the configured managed identity.</summary>
+    /// <summary>
+    /// Connects to the work and poison queues using the configured managed identity.
+    /// </summary>
     public AzureWindowsPackageJobQueue(IOptions<WindowsPackageJobOptions> options, IOptions<AppSettings> appSettings)
     {
         var configuration = options.Value;
@@ -35,7 +41,9 @@ public sealed class AzureWindowsPackageJobQueue : IWindowsPackageJobQueue
         visibility = TimeSpan.FromSeconds(configuration.VisibilitySeconds);
     }
 
-    /// <summary>Uses supplied SDK clients for queue delivery.</summary>
+    /// <summary>
+    /// Uses supplied SDK clients for queue delivery.
+    /// </summary>
     internal AzureWindowsPackageJobQueue(QueueClient queue, QueueClient poisonQueue, WindowsPackageJobOptions options)
     {
         this.queue = queue;
@@ -86,7 +94,9 @@ public sealed class AzureWindowsPackageJobQueue : IWindowsPackageJobQueue
         await poisonQueue.SendMessageAsync(diagnostic, timeToLive: InfiniteTimeToLive, cancellationToken: token);
     }
 
-    /// <summary>Bounds diagnostics and excludes control characters and arbitrary markup.</summary>
+    /// <summary>
+    /// Bounds diagnostics and excludes control characters and arbitrary markup.
+    /// </summary>
     private static string Sanitize(string value, int limit) =>
         new(value.Take(limit).Where(character => char.IsAsciiLetterOrDigit(character) || character is ' ' or '-' or '_' or '.').ToArray());
 }

--- a/apps/pwabuilder-microsoft-store/Jobs/AzureWindowsPackageJobStore.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/AzureWindowsPackageJobStore.cs
@@ -20,17 +20,25 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Persists private packaging inputs and artifacts in Blob Storage and job state in Cosmos DB.</summary>
-/// <remarks>Requires pre-provisioned resources. Register as a singleton so the dedicated Cosmos client is reused and disposed.</remarks>
+/// <summary>
+/// Persists private packaging inputs and artifacts in Blob Storage and job state in Cosmos DB.
+/// </summary>
+/// <remarks>
+/// Requires pre-provisioned resources. Register as a singleton so the dedicated Cosmos client is reused and disposed.
+/// </remarks>
 public sealed class AzureWindowsPackageJobStore : IWindowsPackageJobStore, IDisposable
 {
     private static readonly JsonSerializerOptions InputJsonOptions = new(JsonSerializerDefaults.Web);
 
     private readonly CosmosClient cosmosClient;
+
     private readonly Container jobs;
+
     private readonly BlobContainerClient blobs;
 
-    /// <summary>Connects to pre-provisioned resources using the configured managed identity.</summary>
+    /// <summary>
+    /// Connects to pre-provisioned resources using the configured managed identity.
+    /// </summary>
     public AzureWindowsPackageJobStore(IOptions<WindowsPackageJobOptions> options, IOptions<AppSettings> appSettings)
     {
         var settings = appSettings.Value;
@@ -47,7 +55,9 @@ public sealed class AzureWindowsPackageJobStore : IWindowsPackageJobStore, IDisp
         jobs = cosmosClient.GetContainer(settings.CosmosDbDatabaseName, configuration.CosmosContainerName);
     }
 
-    /// <summary>Uses supplied SDK clients, taking ownership of the dedicated Cosmos client.</summary>
+    /// <summary>
+    /// Uses supplied SDK clients, taking ownership of the dedicated Cosmos client.
+    /// </summary>
     internal AzureWindowsPackageJobStore(CosmosClient cosmosClient, BlobContainerClient blobs, string databaseName, string containerName)
     {
         this.cosmosClient = cosmosClient;
@@ -164,20 +174,28 @@ public sealed class AzureWindowsPackageJobStore : IWindowsPackageJobStore, IDisp
     /// <inheritdoc/>
     public void Dispose() => cosmosClient.Dispose();
 
-    /// <summary>Keeps Cosmos' Newtonsoft serializer and the job contract's JSON attributes authoritative.</summary>
+    /// <summary>
+    /// Keeps Cosmos' Newtonsoft serializer and the job contract's JSON attributes authoritative.
+    /// </summary>
     internal static CosmosClientOptions CreateCosmosClientOptions() => new()
     {
         SerializerOptions = new CosmosSerializationOptions { PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase }
     };
 
-    /// <summary>Projects Cosmos' system ETag separately from the job's ignored ETag property.</summary>
+    /// <summary>
+    /// Projects Cosmos' system ETag separately from the job's ignored ETag property.
+    /// </summary>
     private sealed class DispatchRecord
     {
-        /// <summary>Gets the job selected by the outbox query.</summary>
+        /// <summary>
+        /// Gets the job selected by the outbox query.
+        /// </summary>
         [JsonProperty("job")]
         public required WindowsPackageJob Job { get; init; }
 
-        /// <summary>Gets the persisted revision for a conditional outbox update.</summary>
+        /// <summary>
+        /// Gets the persisted revision for a conditional outbox update.
+        /// </summary>
         [JsonProperty("_etag")]
         public required string ETag { get; init; }
     }

--- a/apps/pwabuilder-microsoft-store/Jobs/AzureWindowsPackageJobStore.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/AzureWindowsPackageJobStore.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using PWABuilder.MicrosoftStore.Models;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+[assembly: InternalsVisibleTo("PWABuilder.MicrosoftStore.Tests")]
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Persists private packaging inputs and artifacts in Blob Storage and job state in Cosmos DB.</summary>
+/// <remarks>Requires pre-provisioned resources. Register as a singleton so the dedicated Cosmos client is reused and disposed.</remarks>
+public sealed class AzureWindowsPackageJobStore : IWindowsPackageJobStore, IDisposable
+{
+    private static readonly JsonSerializerOptions InputJsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly CosmosClient cosmosClient;
+    private readonly Container jobs;
+    private readonly BlobContainerClient blobs;
+
+    /// <summary>Connects to pre-provisioned resources using the configured managed identity.</summary>
+    public AzureWindowsPackageJobStore(IOptions<WindowsPackageJobOptions> options, IOptions<AppSettings> appSettings)
+    {
+        var settings = appSettings.Value;
+        var configuration = options.Value;
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuration.BlobContainerName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuration.CosmosContainerName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(settings.CosmosDbDatabaseName);
+        var credential = string.IsNullOrWhiteSpace(settings.AzureManagedIdentityApplicationId)
+            ? new ManagedIdentityCredential()
+            : new ManagedIdentityCredential(settings.AzureManagedIdentityApplicationId);
+        blobs = new BlobServiceClient(new Uri(configuration.BlobServiceUri), credential)
+            .GetBlobContainerClient(configuration.BlobContainerName);
+        cosmosClient = new CosmosClient(settings.CosmosDbEndpoint, credential, CreateCosmosClientOptions());
+        jobs = cosmosClient.GetContainer(settings.CosmosDbDatabaseName, configuration.CosmosContainerName);
+    }
+
+    /// <summary>Uses supplied SDK clients, taking ownership of the dedicated Cosmos client.</summary>
+    internal AzureWindowsPackageJobStore(CosmosClient cosmosClient, BlobContainerClient blobs, string databaseName, string containerName)
+    {
+        this.cosmosClient = cosmosClient;
+        this.blobs = blobs;
+        jobs = cosmosClient.GetContainer(databaseName, containerName);
+    }
+
+    /// <inheritdoc/>
+    public async Task CreateAsync(WindowsPackageJob job, WindowsPackageJobInput input, CancellationToken token)
+    {
+        await using var content = new MemoryStream();
+        await JsonSerializer.SerializeAsync(content, input, InputJsonOptions, token);
+        content.Position = 0;
+        await blobs.GetBlobClient($"inputs/{job.Id}.json").UploadAsync(content, new BlobUploadOptions
+        {
+            Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
+            HttpHeaders = new BlobHttpHeaders { ContentType = "application/json" }
+        }, token);
+
+        // Never delete the input after an ambiguous Cosmos failure; storage lifecycle rules reclaim orphans.
+        await jobs.CreateItemAsync(job, new PartitionKey(job.Id), cancellationToken: token);
+    }
+
+    /// <inheritdoc/>
+    public async Task<WindowsPackageJob?> GetAsync(string id, CancellationToken token)
+    {
+        try
+        {
+            var response = await jobs.ReadItemAsync<WindowsPackageJob>(id, new PartitionKey(id), cancellationToken: token);
+            return response.Resource with { ETag = response.ETag };
+        }
+        catch (CosmosException exception) when (exception.StatusCode is HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<WindowsPackageJob>> GetPendingDispatchAsync(CancellationToken token)
+    {
+        var query = new QueryDefinition(
+            "SELECT TOP 50 c AS job, c._etag FROM c WHERE c.needsDispatch = true AND c.status = @status ORDER BY c.createdAt")
+            .WithParameter("@status", WindowsPackageJob.Queued);
+        using var iterator = jobs.GetItemQueryIterator<DispatchRecord>(query, requestOptions: new QueryRequestOptions
+        {
+            MaxItemCount = 50
+        });
+        var pending = new List<WindowsPackageJob>(50);
+        while (iterator.HasMoreResults && pending.Count < 50)
+        {
+            var page = await iterator.ReadNextAsync(token);
+            foreach (var record in page)
+            {
+                pending.Add(record.Job with { ETag = record.ETag });
+                if (pending.Count is 50)
+                {
+                    break;
+                }
+            }
+        }
+        return pending;
+    }
+
+    /// <inheritdoc/>
+    public async Task<WindowsPackageJob?> TryReplaceAsync(WindowsPackageJob job, CancellationToken token)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(job.ETag);
+        if (job.ETag is "*")
+        {
+            throw new ArgumentException("A specific job revision is required.", nameof(job));
+        }
+        try
+        {
+            var response = await jobs.ReplaceItemAsync(job, job.Id, new PartitionKey(job.Id),
+                new ItemRequestOptions { IfMatchEtag = job.ETag }, token);
+            return response.Resource with { ETag = response.ETag };
+        }
+        catch (CosmosException exception) when (exception.StatusCode is HttpStatusCode.PreconditionFailed)
+        {
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<WindowsPackageJobInput> ReadInputAsync(string id, CancellationToken token)
+    {
+        var response = await blobs.GetBlobClient($"inputs/{id}.json").DownloadStreamingAsync(cancellationToken: token);
+        await using var content = response.Value.Content;
+        return await JsonSerializer.DeserializeAsync<WindowsPackageJobInput>(content, InputJsonOptions, token)
+            ?? throw new System.Text.Json.JsonException("The stored packaging input is null.");
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> UploadArtifactAsync(string id, string attemptId, string path, CancellationToken token)
+    {
+        var name = $"artifacts/{id}/{attemptId}.zip";
+        await using var content = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read,
+            bufferSize: 81920, FileOptions.Asynchronous | FileOptions.SequentialScan);
+        await blobs.GetBlobClient(name).UploadAsync(content, new BlobUploadOptions
+        {
+            Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
+            HttpHeaders = new BlobHttpHeaders { ContentType = "application/zip" }
+        }, token);
+        return name;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Stream> OpenArtifactAsync(string name, CancellationToken token)
+    {
+        var response = await blobs.GetBlobClient(name).DownloadStreamingAsync(cancellationToken: token);
+        return response.Value.Content;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => cosmosClient.Dispose();
+
+    /// <summary>Keeps Cosmos' Newtonsoft serializer and the job contract's JSON attributes authoritative.</summary>
+    internal static CosmosClientOptions CreateCosmosClientOptions() => new()
+    {
+        SerializerOptions = new CosmosSerializationOptions { PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase }
+    };
+
+    /// <summary>Projects Cosmos' system ETag separately from the job's ignored ETag property.</summary>
+    private sealed class DispatchRecord
+    {
+        /// <summary>Gets the job selected by the outbox query.</summary>
+        [JsonProperty("job")]
+        public required WindowsPackageJob Job { get; init; }
+
+        /// <summary>Gets the persisted revision for a conditional outbox update.</summary>
+        [JsonProperty("_etag")]
+        public required string ETag { get; init; }
+    }
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobBuilder.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobBuilder.cs
@@ -3,9 +3,13 @@ using System.Threading.Tasks;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Builds a ZIP within a per-job scope; files survive until scope disposal.</summary>
+/// <summary>
+/// Builds a ZIP within a per-job scope; files survive until scope disposal.
+/// </summary>
 public interface IWindowsPackageJobBuilder
 {
-    /// <summary>Returns the generated ZIP path without buffering it in memory.</summary>
+    /// <summary>
+    /// Returns the generated ZIP path without buffering it in memory.
+    /// </summary>
     Task<string> BuildAsync(WindowsPackageJobInput input, CancellationToken token);
 }

--- a/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobBuilder.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobBuilder.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Builds a ZIP within a per-job scope; files survive until scope disposal.</summary>
+public interface IWindowsPackageJobBuilder
+{
+    /// <summary>Returns the generated ZIP path without buffering it in memory.</summary>
+    Task<string> BuildAsync(WindowsPackageJobInput input, CancellationToken token);
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobQueue.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobQueue.cs
@@ -4,24 +4,42 @@ using System.Threading.Tasks;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>A received queue message. Renewal returns a new pop receipt.</summary>
+/// <summary>
+/// A received queue message. Renewal returns a new pop receipt.
+/// </summary>
 /// <param name="MessageId">Queue-generated ID.</param>
 /// <param name="PopReceipt">Current acknowledgement/renewal token.</param>
 /// <param name="JobId">Durable job reference, not its inputs.</param>
 /// <param name="DequeueCount">Number of deliveries.</param>
 public sealed record PackageJobMessage(string MessageId, string PopReceipt, string JobId, long DequeueCount);
 
-/// <summary>At-least-once delivery with explicit renewal and acknowledgement.</summary>
+/// <summary>
+/// At-least-once delivery with explicit renewal and acknowledgement.
+/// </summary>
 public interface IWindowsPackageJobQueue
 {
-    /// <summary>Enqueues a small job reference.</summary>
+    /// <summary>
+    /// Enqueues a small job reference.
+    /// </summary>
     Task SendAsync(string jobId, CancellationToken token);
-    /// <summary>Receives without deleting; null means the queue is empty.</summary>
+
+    /// <summary>
+    /// Receives without deleting; null means the queue is empty.
+    /// </summary>
     Task<PackageJobMessage?> ReceiveAsync(CancellationToken token);
-    /// <summary>Updates invisibility and returns the new pop receipt.</summary>
+
+    /// <summary>
+    /// Updates invisibility and returns the new pop receipt.
+    /// </summary>
     Task<PackageJobMessage> RenewAsync(PackageJobMessage message, TimeSpan visibility, CancellationToken token);
-    /// <summary>Acknowledges processing with the latest pop receipt.</summary>
+
+    /// <summary>
+    /// Acknowledges processing with the latest pop receipt.
+    /// </summary>
     Task DeleteAsync(PackageJobMessage message, CancellationToken token);
-    /// <summary>Writes a diagnostic reference to the poison queue before acknowledgement.</summary>
+
+    /// <summary>
+    /// Writes a diagnostic reference to the poison queue before acknowledgement.
+    /// </summary>
     Task PoisonAsync(PackageJobMessage message, string reason, CancellationToken token);
 }

--- a/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobQueue.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobQueue.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>A received queue message. Renewal returns a new pop receipt.</summary>
+/// <param name="MessageId">Queue-generated ID.</param>
+/// <param name="PopReceipt">Current acknowledgement/renewal token.</param>
+/// <param name="JobId">Durable job reference, not its inputs.</param>
+/// <param name="DequeueCount">Number of deliveries.</param>
+public sealed record PackageJobMessage(string MessageId, string PopReceipt, string JobId, long DequeueCount);
+
+/// <summary>At-least-once delivery with explicit renewal and acknowledgement.</summary>
+public interface IWindowsPackageJobQueue
+{
+    /// <summary>Enqueues a small job reference.</summary>
+    Task SendAsync(string jobId, CancellationToken token);
+    /// <summary>Receives without deleting; null means the queue is empty.</summary>
+    Task<PackageJobMessage?> ReceiveAsync(CancellationToken token);
+    /// <summary>Updates invisibility and returns the new pop receipt.</summary>
+    Task<PackageJobMessage> RenewAsync(PackageJobMessage message, TimeSpan visibility, CancellationToken token);
+    /// <summary>Acknowledges processing with the latest pop receipt.</summary>
+    Task DeleteAsync(PackageJobMessage message, CancellationToken token);
+    /// <summary>Writes a diagnostic reference to the poison queue before acknowledgement.</summary>
+    Task PoisonAsync(PackageJobMessage message, string reason, CancellationToken token);
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobStore.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobStore.cs
@@ -5,21 +5,43 @@ using System.Threading.Tasks;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Durable job metadata and private input/output storage.</summary>
+/// <summary>
+/// Durable job metadata and private input/output storage.
+/// </summary>
 public interface IWindowsPackageJobStore
 {
-    /// <summary>Persists inputs before creating the dispatchable job document.</summary>
+    /// <summary>
+    /// Persists inputs before creating the dispatchable job document.
+    /// </summary>
     Task CreateAsync(WindowsPackageJob job, WindowsPackageJobInput input, CancellationToken token);
-    /// <summary>Point-reads a job with its current ETag.</summary>
+
+    /// <summary>
+    /// Point-reads a job with its current ETag.
+    /// </summary>
     Task<WindowsPackageJob?> GetAsync(string id, CancellationToken token);
-    /// <summary>Reads a bounded batch of pending outbox records.</summary>
+
+    /// <summary>
+    /// Reads a bounded batch of pending outbox records.
+    /// </summary>
     Task<IReadOnlyList<WindowsPackageJob>> GetPendingDispatchAsync(CancellationToken token);
-    /// <summary>Replaces a job only if its ETag still matches; null means ownership changed.</summary>
+
+    /// <summary>
+    /// Replaces a job only if its ETag still matches; null means ownership changed.
+    /// </summary>
     Task<WindowsPackageJob?> TryReplaceAsync(WindowsPackageJob job, CancellationToken token);
-    /// <summary>Reads private build inputs.</summary>
+
+    /// <summary>
+    /// Reads private build inputs.
+    /// </summary>
     Task<WindowsPackageJobInput> ReadInputAsync(string id, CancellationToken token);
-    /// <summary>Uploads a build output to an attempt-specific location.</summary>
+
+    /// <summary>
+    /// Uploads a build output to an attempt-specific location.
+    /// </summary>
     Task<string> UploadArtifactAsync(string id, string attemptId, string path, CancellationToken token);
-    /// <summary>Opens a completed artifact for streaming.</summary>
+
+    /// <summary>
+    /// Opens a completed artifact for streaming.
+    /// </summary>
     Task<Stream> OpenArtifactAsync(string name, CancellationToken token);
 }

--- a/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobStore.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/IWindowsPackageJobStore.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Durable job metadata and private input/output storage.</summary>
+public interface IWindowsPackageJobStore
+{
+    /// <summary>Persists inputs before creating the dispatchable job document.</summary>
+    Task CreateAsync(WindowsPackageJob job, WindowsPackageJobInput input, CancellationToken token);
+    /// <summary>Point-reads a job with its current ETag.</summary>
+    Task<WindowsPackageJob?> GetAsync(string id, CancellationToken token);
+    /// <summary>Reads a bounded batch of pending outbox records.</summary>
+    Task<IReadOnlyList<WindowsPackageJob>> GetPendingDispatchAsync(CancellationToken token);
+    /// <summary>Replaces a job only if its ETag still matches; null means ownership changed.</summary>
+    Task<WindowsPackageJob?> TryReplaceAsync(WindowsPackageJob job, CancellationToken token);
+    /// <summary>Reads private build inputs.</summary>
+    Task<WindowsPackageJobInput> ReadInputAsync(string id, CancellationToken token);
+    /// <summary>Uploads a build output to an attempt-specific location.</summary>
+    Task<string> UploadArtifactAsync(string id, string attemptId, string path, CancellationToken token);
+    /// <summary>Opens a completed artifact for streaming.</summary>
+    Task<Stream> OpenArtifactAsync(string name, CancellationToken token);
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/PackageJobLease.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/PackageJobLease.cs
@@ -17,16 +17,24 @@ internal sealed class PackageJobLease(
     TimeProvider clock) : IDisposable
 {
     private readonly SemaphoreSlim gate = new(1, 1);
+
     private WindowsPackageJob current = job;
+
     private bool released;
 
-    /// <summary>Latest queue receipt, including renewals.</summary>
+    /// <summary>
+    /// Latest queue receipt, including renewals.
+    /// </summary>
     public PackageJobMessage Message { get; private set; } = message;
 
-    /// <summary>Whether exclusive ownership was lost.</summary>
+    /// <summary>
+    /// Whether exclusive ownership was lost.
+    /// </summary>
     public bool Lost { get; private set; }
 
-    /// <summary>Renews the queue message and durable ownership until completion.</summary>
+    /// <summary>
+    /// Renews the queue message and durable ownership until completion.
+    /// </summary>
     public async Task RenewUntilStoppedAsync(CancellationTokenSource build, CancellationToken stop)
     {
         try
@@ -75,7 +83,9 @@ internal sealed class PackageJobLease(
         }
     }
 
-    /// <summary>Persists a state transition against the latest revision and releases ownership.</summary>
+    /// <summary>
+    /// Persists a state transition against the latest revision and releases ownership.
+    /// </summary>
     public async Task<WindowsPackageJob> FinishAsync(Func<WindowsPackageJob, WindowsPackageJob> transition, CancellationToken token)
     {
         await gate.WaitAsync(token);
@@ -98,7 +108,9 @@ internal sealed class PackageJobLease(
         }
     }
 
-    /// <summary>Refuses writes after the durable lease has expired.</summary>
+    /// <summary>
+    /// Refuses writes after the durable lease has expired.
+    /// </summary>
     private void EnsureOwnership()
     {
         if (Lost || current.LeaseExpiresAt <= clock.GetUtcNow())

--- a/apps/pwabuilder-microsoft-store/Jobs/PackageJobLease.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/PackageJobLease.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>
+/// Serializes queue receipt renewal and conditional job updates. A failed renewal
+/// cancels the build; an ETag mismatch prevents a stale worker from publishing its result.
+/// </summary>
+internal sealed class PackageJobLease(
+    IWindowsPackageJobStore store,
+    IWindowsPackageJobQueue queue,
+    WindowsPackageJob job,
+    PackageJobMessage message,
+    WindowsPackageJobOptions options,
+    TimeProvider clock) : IDisposable
+{
+    private readonly SemaphoreSlim gate = new(1, 1);
+    private WindowsPackageJob current = job;
+    private bool released;
+
+    /// <summary>Latest queue receipt, including renewals.</summary>
+    public PackageJobMessage Message { get; private set; } = message;
+
+    /// <summary>Whether exclusive ownership was lost.</summary>
+    public bool Lost { get; private set; }
+
+    /// <summary>Renews the queue message and durable ownership until completion.</summary>
+    public async Task RenewUntilStoppedAsync(CancellationTokenSource build, CancellationToken stop)
+    {
+        try
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(options.RenewalSeconds), clock, stop);
+                await gate.WaitAsync(stop);
+                try
+                {
+                    if (released)
+                    {
+                        return;
+                    }
+                    EnsureOwnership();
+                    // Bound storage calls too: a hung renewal must not leave an unfenced builder running.
+                    using var renewal = CancellationTokenSource.CreateLinkedTokenSource(stop);
+                    renewal.CancelAfter(TimeSpan.FromSeconds(options.RenewalSeconds));
+                    Message = await queue.RenewAsync(Message, TimeSpan.FromSeconds(options.VisibilitySeconds), renewal.Token);
+                    current = await store.TryReplaceAsync(current with
+                    {
+                        LeaseExpiresAt = clock.GetUtcNow().AddSeconds(options.VisibilitySeconds)
+                    }, renewal.Token) ?? throw new InvalidOperationException("Job ownership changed during renewal.");
+                }
+                catch
+                {
+                    // Fence a completion already waiting on the semaphore before releasing it.
+                    Lost = true;
+                    throw;
+                }
+                finally
+                {
+                    gate.Release();
+                }
+            }
+        }
+        catch (OperationCanceledException) when (stop.IsCancellationRequested)
+        {
+            // Normal shutdown of this job's renewal loop.
+        }
+        catch
+        {
+            Lost = true;
+            await build.CancelAsync();
+            throw;
+        }
+    }
+
+    /// <summary>Persists a state transition against the latest revision and releases ownership.</summary>
+    public async Task<WindowsPackageJob> FinishAsync(Func<WindowsPackageJob, WindowsPackageJob> transition, CancellationToken token)
+    {
+        await gate.WaitAsync(token);
+        try
+        {
+            EnsureOwnership();
+            current = await store.TryReplaceAsync(transition(current) with { LeaseExpiresAt = null }, token)
+                ?? throw new InvalidOperationException("Job ownership changed before completion.");
+            released = true;
+            return current;
+        }
+        catch
+        {
+            Lost = true;
+            throw;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>Refuses writes after the durable lease has expired.</summary>
+    private void EnsureOwnership()
+    {
+        if (Lost || current.LeaseExpiresAt <= clock.GetUtcNow())
+        {
+            throw new InvalidOperationException("Job ownership expired.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => gate.Dispose();
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJob.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJob.cs
@@ -1,0 +1,52 @@
+using System;
+using Newtonsoft.Json;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Durable job state. Conditional Cosmos writes fence stale workers.</summary>
+public sealed record WindowsPackageJob
+{
+    /// <summary>Waiting for processing.</summary>
+    public const string Queued = "Queued";
+    /// <summary>Owned by a worker.</summary>
+    public const string InProgress = "InProgress";
+    /// <summary>Artifact and final state have been persisted.</summary>
+    public const string Completed = "Completed";
+    /// <summary>No more attempts will be made.</summary>
+    public const string Failed = "Failed";
+    /// <summary>The job's processing/download lifetime has elapsed.</summary>
+    public const string Expired = "Expired";
+
+    /// <summary>Random, unguessable job ID, also used as the partition key.</summary>
+    [JsonProperty("id")]
+    public required string Id { get; init; }
+    /// <summary>Current state.</summary>
+    public string Status { get; init; } = Queued;
+    /// <summary>When the request was durably accepted.</summary>
+    public DateTimeOffset CreatedAt { get; init; }
+    /// <summary>Processing and downloads are disallowed after this time.</summary>
+    public DateTimeOffset ExpiresAt { get; init; }
+    /// <summary>When the last terminal transition occurred.</summary>
+    public DateTimeOffset? FinishedAt { get; init; }
+    /// <summary>Attempts already started, including interrupted attempts.</summary>
+    public int Attempts { get; init; }
+    /// <summary>Outbox flag, cleared only after successful queue submission.</summary>
+    public bool NeedsDispatch { get; init; } = true;
+    /// <summary>Earliest time a queued retry can start.</summary>
+    public DateTimeOffset? RetryAfter { get; init; }
+    /// <summary>Exclusive ownership expires unless renewed by the worker.</summary>
+    public DateTimeOffset? LeaseExpiresAt { get; init; }
+    /// <summary>Attempt-specific artifact path, set only on completion.</summary>
+    public string? ArtifactName { get; init; }
+    /// <summary>Safe client-facing failure description; diagnostics belong in logs.</summary>
+    public string? Error { get; init; }
+    /// <summary>Self-reported caller name for operational reporting, not authorization.</summary>
+    public string? PlatformId { get; init; }
+    /// <summary>Cosmos time to live. Provision the container with TTL enabled.</summary>
+    [JsonProperty("ttl")]
+    public int Ttl { get; init; }
+    /// <summary>Cosmos revision, not included in persisted request bodies.</summary>
+    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string ETag { get; init; } = string.Empty;
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJob.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJob.cs
@@ -3,49 +3,106 @@ using Newtonsoft.Json;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Durable job state. Conditional Cosmos writes fence stale workers.</summary>
+/// <summary>
+/// Durable job state. Conditional Cosmos writes fence stale workers.
+/// </summary>
 public sealed record WindowsPackageJob
 {
-    /// <summary>Waiting for processing.</summary>
+    /// <summary>
+    /// Waiting for processing.
+    /// </summary>
     public const string Queued = "Queued";
-    /// <summary>Owned by a worker.</summary>
+
+    /// <summary>
+    /// Owned by a worker.
+    /// </summary>
     public const string InProgress = "InProgress";
-    /// <summary>Artifact and final state have been persisted.</summary>
+
+    /// <summary>
+    /// Artifact and final state have been persisted.
+    /// </summary>
     public const string Completed = "Completed";
-    /// <summary>No more attempts will be made.</summary>
+
+    /// <summary>
+    /// No more attempts will be made.
+    /// </summary>
     public const string Failed = "Failed";
-    /// <summary>The job's processing/download lifetime has elapsed.</summary>
+
+    /// <summary>
+    /// The job's processing/download lifetime has elapsed.
+    /// </summary>
     public const string Expired = "Expired";
 
-    /// <summary>Random, unguessable job ID, also used as the partition key.</summary>
+    /// <summary>
+    /// Random, unguessable job ID, also used as the partition key.
+    /// </summary>
     [JsonProperty("id")]
     public required string Id { get; init; }
-    /// <summary>Current state.</summary>
+
+    /// <summary>
+    /// Current state.
+    /// </summary>
     public string Status { get; init; } = Queued;
-    /// <summary>When the request was durably accepted.</summary>
+
+    /// <summary>
+    /// When the request was durably accepted.
+    /// </summary>
     public DateTimeOffset CreatedAt { get; init; }
-    /// <summary>Processing and downloads are disallowed after this time.</summary>
+
+    /// <summary>
+    /// Processing and downloads are disallowed after this time.
+    /// </summary>
     public DateTimeOffset ExpiresAt { get; init; }
-    /// <summary>When the last terminal transition occurred.</summary>
+
+    /// <summary>
+    /// When the last terminal transition occurred.
+    /// </summary>
     public DateTimeOffset? FinishedAt { get; init; }
-    /// <summary>Attempts already started, including interrupted attempts.</summary>
+
+    /// <summary>
+    /// Attempts already started, including interrupted attempts.
+    /// </summary>
     public int Attempts { get; init; }
-    /// <summary>Outbox flag, cleared only after successful queue submission.</summary>
+
+    /// <summary>
+    /// Outbox flag, cleared only after successful queue submission.
+    /// </summary>
     public bool NeedsDispatch { get; init; } = true;
-    /// <summary>Earliest time a queued retry can start.</summary>
+
+    /// <summary>
+    /// Earliest time a queued retry can start.
+    /// </summary>
     public DateTimeOffset? RetryAfter { get; init; }
-    /// <summary>Exclusive ownership expires unless renewed by the worker.</summary>
+
+    /// <summary>
+    /// Exclusive ownership expires unless renewed by the worker.
+    /// </summary>
     public DateTimeOffset? LeaseExpiresAt { get; init; }
-    /// <summary>Attempt-specific artifact path, set only on completion.</summary>
+
+    /// <summary>
+    /// Attempt-specific artifact path, set only on completion.
+    /// </summary>
     public string? ArtifactName { get; init; }
-    /// <summary>Safe client-facing failure description; diagnostics belong in logs.</summary>
+
+    /// <summary>
+    /// Safe client-facing failure description; diagnostics belong in logs.
+    /// </summary>
     public string? Error { get; init; }
-    /// <summary>Self-reported caller name for operational reporting, not authorization.</summary>
+
+    /// <summary>
+    /// Self-reported caller name for operational reporting, not authorization.
+    /// </summary>
     public string? PlatformId { get; init; }
-    /// <summary>Cosmos time to live. Provision the container with TTL enabled.</summary>
+
+    /// <summary>
+    /// Cosmos time to live. Provision the container with TTL enabled.
+    /// </summary>
     [JsonProperty("ttl")]
     public int Ttl { get; init; }
-    /// <summary>Cosmos revision, not included in persisted request bodies.</summary>
+
+    /// <summary>
+    /// Cosmos revision, not included in persisted request bodies.
+    /// </summary>
     [JsonIgnore]
     [System.Text.Json.Serialization.JsonIgnore]
     public string ETag { get; init; } = string.Empty;

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobBuilder.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobBuilder.cs
@@ -4,7 +4,9 @@ using PWABuilder.MicrosoftStore.Services;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Adapts the existing Windows packaging pipeline to a scoped background job.</summary>
+/// <summary>
+/// Adapts the existing Windows packaging pipeline to a scoped background job.
+/// </summary>
 public sealed class WindowsPackageJobBuilder(WindowsAppPackageCreator creator) : IWindowsPackageJobBuilder
 {
     /// <inheritdoc/>

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobBuilder.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobBuilder.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using PWABuilder.MicrosoftStore.Services;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Adapts the existing Windows packaging pipeline to a scoped background job.</summary>
+public sealed class WindowsPackageJobBuilder(WindowsAppPackageCreator creator) : IWindowsPackageJobBuilder
+{
+    /// <inheritdoc/>
+    public async Task<string> BuildAsync(WindowsPackageJobInput input, CancellationToken token)
+    {
+        var result = await creator.CreateAppPackageFileAsync(input.Options, input.Analytics.ToAnalyticsInfo(), token);
+        return result.FilePath;
+    }
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobInput.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobInput.cs
@@ -2,28 +2,50 @@ using PWABuilder.MicrosoftStore.Models;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Private build inputs stored in Blob Storage, never returned by status APIs.</summary>
+/// <summary>
+/// Private build inputs stored in Blob Storage, never returned by status APIs.
+/// </summary>
 public sealed record WindowsPackageJobInput
 {
-    /// <summary>Windows packaging options.</summary>
+    /// <summary>
+    /// Windows packaging options.
+    /// </summary>
     public required WindowsAppPackageOptions Options { get; init; }
-    /// <summary>Attribution captured at submission, independent of the worker's HTTP context.</summary>
+
+    /// <summary>
+    /// Attribution captured at submission, independent of the worker's HTTP context.
+    /// </summary>
     public required PackageJobAnalytics Analytics { get; init; }
 }
 
-/// <summary>Serializable caller metadata associated with a queued request.</summary>
+/// <summary>
+/// Serializable caller metadata associated with a queued request.
+/// </summary>
 public sealed record PackageJobAnalytics
 {
-    /// <summary>Calling platform name.</summary>
+    /// <summary>
+    /// Calling platform name.
+    /// </summary>
     public string? PlatformId { get; init; }
-    /// <summary>Calling platform version.</summary>
+
+    /// <summary>
+    /// Calling platform version.
+    /// </summary>
     public string? PlatformVersion { get; init; }
-    /// <summary>Trace correlation ID; not used as a job identity or idempotency key.</summary>
+
+    /// <summary>
+    /// Trace correlation ID; not used as a job identity or idempotency key.
+    /// </summary>
     public string? CorrelationId { get; init; }
-    /// <summary>Optional marketing referral.</summary>
+
+    /// <summary>
+    /// Optional marketing referral.
+    /// </summary>
     public string? Referrer { get; init; }
 
-    /// <summary>Converts persisted attribution to existing packaging analytics.</summary>
+    /// <summary>
+    /// Converts persisted attribution to existing packaging analytics.
+    /// </summary>
     public AnalyticsInfo ToAnalyticsInfo() => new()
     {
         platformId = PlatformId,

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobInput.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobInput.cs
@@ -1,0 +1,34 @@
+using PWABuilder.MicrosoftStore.Models;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Private build inputs stored in Blob Storage, never returned by status APIs.</summary>
+public sealed record WindowsPackageJobInput
+{
+    /// <summary>Windows packaging options.</summary>
+    public required WindowsAppPackageOptions Options { get; init; }
+    /// <summary>Attribution captured at submission, independent of the worker's HTTP context.</summary>
+    public required PackageJobAnalytics Analytics { get; init; }
+}
+
+/// <summary>Serializable caller metadata associated with a queued request.</summary>
+public sealed record PackageJobAnalytics
+{
+    /// <summary>Calling platform name.</summary>
+    public string? PlatformId { get; init; }
+    /// <summary>Calling platform version.</summary>
+    public string? PlatformVersion { get; init; }
+    /// <summary>Trace correlation ID; not used as a job identity or idempotency key.</summary>
+    public string? CorrelationId { get; init; }
+    /// <summary>Optional marketing referral.</summary>
+    public string? Referrer { get; init; }
+
+    /// <summary>Converts persisted attribution to existing packaging analytics.</summary>
+    public AnalyticsInfo ToAnalyticsInfo() => new()
+    {
+        platformId = PlatformId,
+        platformIdVersion = PlatformVersion,
+        correlationId = CorrelationId,
+        referrer = Referrer
+    };
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobOptions.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobOptions.cs
@@ -2,59 +2,91 @@ using System.ComponentModel.DataAnnotations;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Opt-in configuration for durable Windows packaging.</summary>
+/// <summary>
+/// Opt-in configuration for durable Windows packaging.
+/// </summary>
 public sealed class WindowsPackageJobOptions
 {
-    /// <summary>Enables the asynchronous API and its storage dependencies.</summary>
+    /// <summary>
+    /// Enables the asynchronous API and its storage dependencies.
+    /// </summary>
     public bool Enabled { get; set; }
 
-    /// <summary>Runs workers in this instance; disable on API-only instances.</summary>
+    /// <summary>
+    /// Runs workers in this instance; disable on API-only instances.
+    /// </summary>
     public bool RunWorkers { get; set; } = true;
 
-    /// <summary>Azure Queue Storage service URI, without a queue name.</summary>
+    /// <summary>
+    /// Azure Queue Storage service URI, without a queue name.
+    /// </summary>
     public string QueueServiceUri { get; set; } = string.Empty;
 
-    /// <summary>Environment-specific queue name. The poison queue adds "-poison".</summary>
+    /// <summary>
+    /// Environment-specific queue name. The poison queue adds "-poison".
+    /// </summary>
     public string QueueName { get; set; } = string.Empty;
 
-    /// <summary>Azure Blob Storage service URI.</summary>
+    /// <summary>
+    /// Azure Blob Storage service URI.
+    /// </summary>
     public string BlobServiceUri { get; set; } = string.Empty;
 
-    /// <summary>Private container for inputs and outputs.</summary>
+    /// <summary>
+    /// Private container for inputs and outputs.
+    /// </summary>
     public string BlobContainerName { get; set; } = string.Empty;
 
-    /// <summary>Dedicated Cosmos container, partitioned on /id, in AppSettings' database.</summary>
+    /// <summary>
+    /// Dedicated Cosmos container, partitioned on /id, in AppSettings' database.
+    /// </summary>
     public string CosmosContainerName { get; set; } = string.Empty;
 
-    /// <summary>Maximum queued builds running on this instance.</summary>
+    /// <summary>
+    /// Maximum queued builds running on this instance.
+    /// </summary>
     [Range(1, 16)]
     public int WorkerCount { get; set; } = 1;
 
-    /// <summary>Maximum attempts, including recovery after a worker crash.</summary>
+    /// <summary>
+    /// Maximum attempts, including recovery after a worker crash.
+    /// </summary>
     [Range(1, 10)]
     public int MaxAttempts { get; set; } = 3;
 
-    /// <summary>Time to process and download a job before it expires.</summary>
+    /// <summary>
+    /// Time to process and download a job before it expires.
+    /// </summary>
     [Range(1, 720)]
     public int JobLifetimeHours { get; set; } = 168;
 
-    /// <summary>Maximum duration of one build attempt, independent of HTTP connections.</summary>
+    /// <summary>
+    /// Maximum duration of one build attempt, independent of HTTP connections.
+    /// </summary>
     [Range(1, 120)]
     public int AttemptTimeoutMinutes { get; set; } = 30;
 
-    /// <summary>Queue visibility and exclusive job ownership duration.</summary>
+    /// <summary>
+    /// Queue visibility and exclusive job ownership duration.
+    /// </summary>
     [Range(30, 600)]
     public int VisibilitySeconds { get; set; } = 120;
 
-    /// <summary>Renewal interval, at most one third of the visibility duration.</summary>
+    /// <summary>
+    /// Renewal interval, at most one third of the visibility duration.
+    /// </summary>
     [Range(1, 120)]
     public int RenewalSeconds { get; set; } = 30;
 
-    /// <summary>Idle polling interval for workers and pending dispatch records.</summary>
+    /// <summary>
+    /// Idle polling interval for workers and pending dispatch records.
+    /// </summary>
     [Range(1, 60)]
     public int PollSeconds { get; set; } = 2;
 
-    /// <summary>Initial retry delay, exponentially increased up to ten minutes.</summary>
+    /// <summary>
+    /// Initial retry delay, exponentially increased up to ten minutes.
+    /// </summary>
     [Range(1, 300)]
     public int RetryDelaySeconds { get; set; } = 30;
 }

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobOptions.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobOptions.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Opt-in configuration for durable Windows packaging.</summary>
+public sealed class WindowsPackageJobOptions
+{
+    /// <summary>Enables the asynchronous API and its storage dependencies.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>Runs workers in this instance; disable on API-only instances.</summary>
+    public bool RunWorkers { get; set; } = true;
+
+    /// <summary>Azure Queue Storage service URI, without a queue name.</summary>
+    public string QueueServiceUri { get; set; } = string.Empty;
+
+    /// <summary>Environment-specific queue name. The poison queue adds "-poison".</summary>
+    public string QueueName { get; set; } = string.Empty;
+
+    /// <summary>Azure Blob Storage service URI.</summary>
+    public string BlobServiceUri { get; set; } = string.Empty;
+
+    /// <summary>Private container for inputs and outputs.</summary>
+    public string BlobContainerName { get; set; } = string.Empty;
+
+    /// <summary>Dedicated Cosmos container, partitioned on /id, in AppSettings' database.</summary>
+    public string CosmosContainerName { get; set; } = string.Empty;
+
+    /// <summary>Maximum queued builds running on this instance.</summary>
+    [Range(1, 16)]
+    public int WorkerCount { get; set; } = 1;
+
+    /// <summary>Maximum attempts, including recovery after a worker crash.</summary>
+    [Range(1, 10)]
+    public int MaxAttempts { get; set; } = 3;
+
+    /// <summary>Time to process and download a job before it expires.</summary>
+    [Range(1, 720)]
+    public int JobLifetimeHours { get; set; } = 168;
+
+    /// <summary>Maximum duration of one build attempt, independent of HTTP connections.</summary>
+    [Range(1, 120)]
+    public int AttemptTimeoutMinutes { get; set; } = 30;
+
+    /// <summary>Queue visibility and exclusive job ownership duration.</summary>
+    [Range(30, 600)]
+    public int VisibilitySeconds { get; set; } = 120;
+
+    /// <summary>Renewal interval, at most one third of the visibility duration.</summary>
+    [Range(1, 120)]
+    public int RenewalSeconds { get; set; } = 30;
+
+    /// <summary>Idle polling interval for workers and pending dispatch records.</summary>
+    [Range(1, 60)]
+    public int PollSeconds { get; set; } = 2;
+
+    /// <summary>Initial retry delay, exponentially increased up to ten minutes.</summary>
+    [Range(1, 300)]
+    public int RetryDelaySeconds { get; set; } = 30;
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobProcessor.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobProcessor.cs
@@ -6,7 +6,9 @@ using Microsoft.Extensions.Options;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Crash-recoverable, at-least-once Windows packaging job lifecycle.</summary>
+/// <summary>
+/// Crash-recoverable, at-least-once Windows packaging job lifecycle.
+/// </summary>
 public sealed class WindowsPackageJobProcessor(
     IWindowsPackageJobStore store,
     IWindowsPackageJobQueue queue,
@@ -30,7 +32,9 @@ public sealed class WindowsPackageJobProcessor(
         }
     }
 
-    /// <summary>Processes one delivery, acknowledging only durable terminal outcomes.</summary>
+    /// <summary>
+    /// Processes one delivery, acknowledging only durable terminal outcomes.
+    /// </summary>
     public async Task ProcessAsync(PackageJobMessage message, CancellationToken stoppingToken)
     {
         if (!Guid.TryParseExact(message.JobId, "N", out _))
@@ -143,7 +147,9 @@ public sealed class WindowsPackageJobProcessor(
         }
     }
 
-    /// <summary>Records retries before allowing the unacknowledged message to reappear.</summary>
+    /// <summary>
+    /// Records retries before allowing the unacknowledged message to reappear.
+    /// </summary>
     private async Task RecordFailureAsync(PackageJobLease lease, CancellationToken token)
     {
         var updated = await lease.FinishAsync(j =>
@@ -170,13 +176,17 @@ public sealed class WindowsPackageJobProcessor(
         }
     }
 
-    /// <summary>Acknowledges only after terminal status (and any poison entry) is durable.</summary>
+    /// <summary>
+    /// Acknowledges only after terminal status (and any poison entry) is durable.
+    /// </summary>
     private Task AcknowledgeTerminalAsync(WindowsPackageJob job, PackageJobMessage message, CancellationToken token) =>
         job.Status is WindowsPackageJob.Failed
             ? PoisonAndDeleteAsync(message, job.Error ?? "Job failed.", token)
             : queue.DeleteAsync(message, token);
 
-    /// <summary>Poison delivery can itself duplicate after a crash; it is diagnostic, not executable work.</summary>
+    /// <summary>
+    /// Poison delivery can itself duplicate after a crash; it is diagnostic, not executable work.
+    /// </summary>
     private async Task PoisonAndDeleteAsync(PackageJobMessage message, string reason, CancellationToken token)
     {
         await queue.PoisonAsync(message, reason, token);

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobProcessor.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobProcessor.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Crash-recoverable, at-least-once Windows packaging job lifecycle.</summary>
+public sealed class WindowsPackageJobProcessor(
+    IWindowsPackageJobStore store,
+    IWindowsPackageJobQueue queue,
+    IWindowsPackageJobBuilder builder,
+    IOptions<WindowsPackageJobOptions> options,
+    TimeProvider clock,
+    ILogger<WindowsPackageJobProcessor> logger)
+{
+    private readonly WindowsPackageJobOptions settings = options.Value;
+
+    /// <summary>
+    /// Dispatches persisted outbox records. A crash between send and clear can duplicate
+    /// delivery, but cannot lose an accepted job.
+    /// </summary>
+    public async Task DispatchAsync(CancellationToken token)
+    {
+        foreach (var job in await store.GetPendingDispatchAsync(token))
+        {
+            await queue.SendAsync(job.Id, token);
+            await store.TryReplaceAsync(job with { NeedsDispatch = false }, token);
+        }
+    }
+
+    /// <summary>Processes one delivery, acknowledging only durable terminal outcomes.</summary>
+    public async Task ProcessAsync(PackageJobMessage message, CancellationToken stoppingToken)
+    {
+        if (!Guid.TryParseExact(message.JobId, "N", out _))
+        {
+            await PoisonAndDeleteAsync(message, "Invalid job reference.", stoppingToken);
+            return;
+        }
+
+        var job = await store.GetAsync(message.JobId, stoppingToken);
+        if (job is null)
+        {
+            if (message.DequeueCount >= settings.MaxAttempts)
+            {
+                await PoisonAndDeleteAsync(message, "Job record missing or expired.", stoppingToken);
+            }
+            return;
+        }
+        if (job.Status is WindowsPackageJob.Completed or WindowsPackageJob.Expired)
+        {
+            await queue.DeleteAsync(message, stoppingToken);
+            return;
+        }
+        if (job.Status is WindowsPackageJob.Failed)
+        {
+            await PoisonAndDeleteAsync(message, job.Error ?? "Job failed.", stoppingToken);
+            return;
+        }
+
+        var now = clock.GetUtcNow();
+        if (job.LeaseExpiresAt > now || job.RetryAfter > now)
+        {
+            // Do not delete an overlapping delivery: it may have replaced the original
+            // receipt after a visibility timeout. Leave it available for recovery.
+            return;
+        }
+
+        var expired = job.ExpiresAt <= now;
+        var exhausted = job.Attempts >= settings.MaxAttempts;
+        var claimed = await store.TryReplaceAsync(job with
+        {
+            Status = WindowsPackageJob.InProgress,
+            Attempts = job.Attempts + (expired || exhausted ? 0 : 1),
+            NeedsDispatch = false,
+            RetryAfter = null,
+            LeaseExpiresAt = now.AddSeconds(settings.VisibilitySeconds)
+        }, stoppingToken);
+        if (claimed is null)
+        {
+            return;
+        }
+
+        using var lease = new PackageJobLease(store, queue, claimed, message, settings, clock);
+        using var attempt = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+        using var stopRenewal = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+        var remaining = claimed.ExpiresAt - now;
+        var deadline = TimeSpan.FromMinutes(settings.AttemptTimeoutMinutes);
+        attempt.CancelAfter(remaining <= TimeSpan.Zero ? TimeSpan.Zero : remaining < deadline ? remaining : deadline);
+        var renewalTask = lease.RenewUntilStoppedAsync(attempt, stopRenewal.Token);
+
+        try
+        {
+            if (expired || exhausted)
+            {
+                var terminal = await lease.FinishAsync(j => j with
+                {
+                    Status = expired ? WindowsPackageJob.Expired : WindowsPackageJob.Failed,
+                    Error = expired ? "Job expired." : "Maximum build attempts exceeded.",
+                    FinishedAt = clock.GetUtcNow()
+                }, stoppingToken);
+                await AcknowledgeTerminalAsync(terminal, lease.Message, stoppingToken);
+                return;
+            }
+
+            logger.LogInformation("Starting Windows job {JobId}, attempt {Attempt}, platform {PlatformId}",
+                claimed.Id, claimed.Attempts, claimed.PlatformId);
+            string artifact;
+            try
+            {
+                var input = await store.ReadInputAsync(claimed.Id, attempt.Token);
+                var path = await builder.BuildAsync(input, attempt.Token);
+                artifact = await store.UploadArtifactAsync(claimed.Id, Guid.NewGuid().ToString("N"), path, attempt.Token);
+                attempt.Token.ThrowIfCancellationRequested();
+            }
+            catch (Exception error) when (!stoppingToken.IsCancellationRequested && !lease.Lost)
+            {
+                logger.LogError(error, "Windows job {JobId} attempt {Attempt} failed", claimed.Id, claimed.Attempts);
+                await RecordFailureAsync(lease, stoppingToken);
+                return;
+            }
+
+            var completed = await lease.FinishAsync(j => j with
+            {
+                Status = WindowsPackageJob.Completed,
+                ArtifactName = artifact,
+                Error = null,
+                FinishedAt = clock.GetUtcNow()
+            }, attempt.Token);
+            await AcknowledgeTerminalAsync(completed, lease.Message, stoppingToken);
+            logger.LogInformation("Completed Windows job {JobId}, platform {PlatformId}", claimed.Id, claimed.PlatformId);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested || lease.Lost)
+        {
+            logger.LogInformation("Leaving Windows job {JobId} unacknowledged for recovery", claimed.Id);
+        }
+        finally
+        {
+            await stopRenewal.CancelAsync();
+            // Renewal exceptions are observed, not swallowed; the host logs and retries.
+            await renewalTask;
+        }
+    }
+
+    /// <summary>Records retries before allowing the unacknowledged message to reappear.</summary>
+    private async Task RecordFailureAsync(PackageJobLease lease, CancellationToken token)
+    {
+        var updated = await lease.FinishAsync(j =>
+        {
+            var expired = j.ExpiresAt <= clock.GetUtcNow();
+            var final = expired || j.Attempts >= settings.MaxAttempts;
+            var delay = TimeSpan.FromSeconds(Math.Min(600, settings.RetryDelaySeconds * Math.Pow(2, j.Attempts - 1)));
+            return j with
+            {
+                Status = expired ? WindowsPackageJob.Expired : final ? WindowsPackageJob.Failed : WindowsPackageJob.Queued,
+                Error = expired ? "Job expired." : final ? "Packaging failed after the maximum number of attempts." : "Build attempt failed; retry pending.",
+                FinishedAt = final ? clock.GetUtcNow() : null,
+                RetryAfter = final ? null : clock.GetUtcNow().Add(delay)
+            };
+        }, token);
+        if (updated.Status is WindowsPackageJob.Queued)
+        {
+            var delay = updated.RetryAfter!.Value - clock.GetUtcNow();
+            await queue.RenewAsync(lease.Message, delay > TimeSpan.Zero ? delay : TimeSpan.FromSeconds(1), token);
+        }
+        else
+        {
+            await AcknowledgeTerminalAsync(updated, lease.Message, token);
+        }
+    }
+
+    /// <summary>Acknowledges only after terminal status (and any poison entry) is durable.</summary>
+    private Task AcknowledgeTerminalAsync(WindowsPackageJob job, PackageJobMessage message, CancellationToken token) =>
+        job.Status is WindowsPackageJob.Failed
+            ? PoisonAndDeleteAsync(message, job.Error ?? "Job failed.", token)
+            : queue.DeleteAsync(message, token);
+
+    /// <summary>Poison delivery can itself duplicate after a crash; it is diagnostic, not executable work.</summary>
+    private async Task PoisonAndDeleteAsync(PackageJobMessage message, string reason, CancellationToken token)
+    {
+        await queue.PoisonAsync(message, reason, token);
+        await queue.DeleteAsync(message, token);
+    }
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobRegistration.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobRegistration.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using PWABuilder.MicrosoftStore.Models;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Registers the optional job API and validates its deployment prerequisites.</summary>
+public static class WindowsPackageJobRegistration
+{
+    /// <summary>Registers durable job services only when explicitly enabled.</summary>
+    public static IServiceCollection AddWindowsPackageJobs(this IServiceCollection services, IConfiguration configuration)
+    {
+        var section = configuration.GetSection("WindowsPackageJobs");
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddOptions<WindowsPackageJobOptions>()
+            .Bind(section)
+            .ValidateDataAnnotations()
+            .Validate(o => !o.Enabled ||
+                (IsServiceUri(o.QueueServiceUri) && IsServiceUri(o.BlobServiceUri)
+                 && IsStorageName(o.QueueName, 56) && IsStorageName(o.BlobContainerName, 63)
+                 && !string.IsNullOrWhiteSpace(o.CosmosContainerName)),
+                "Queued packaging requires explicit Azure service URIs and environment-specific queue, Blob, and Cosmos container names.")
+            .Validate(o => o.RenewalSeconds * 3 <= o.VisibilitySeconds,
+                "RenewalSeconds must be at most one third of VisibilitySeconds.")
+            .Validate<IOptions<AppSettings>>((o, app) => !o.Enabled ||
+                (IsServiceUri(app.Value.CosmosDbEndpoint)
+                 && !string.IsNullOrWhiteSpace(app.Value.CosmosDbDatabaseName)
+                 && o.CosmosContainerName != app.Value.CosmosDbContainerName),
+                "Configure a Cosmos endpoint/database and a job container distinct from package analytics.")
+            .ValidateOnStart();
+
+        if (section.GetValue<bool>("Enabled"))
+        {
+            services.AddSingleton<IWindowsPackageJobStore, AzureWindowsPackageJobStore>();
+            services.AddSingleton<IWindowsPackageJobQueue, AzureWindowsPackageJobQueue>();
+            services.AddScoped<IWindowsPackageJobBuilder, WindowsPackageJobBuilder>();
+            services.AddScoped<WindowsPackageJobProcessor>();
+            services.AddHostedService<WindowsPackageJobWorker>();
+        }
+        return services;
+    }
+
+    /// <summary>Requires HTTPS service roots rather than signed URLs or credentials in configuration.</summary>
+    private static bool IsServiceUri(string value) =>
+        Uri.TryCreate(value, UriKind.Absolute, out var uri)
+        && uri.Scheme is "https"
+        && uri.AbsolutePath is "/"
+        && string.IsNullOrEmpty(uri.UserInfo)
+        && string.IsNullOrEmpty(uri.Query)
+        && string.IsNullOrEmpty(uri.Fragment);
+
+    /// <summary>Checks Azure queue/container names, reserving room for the poison suffix.</summary>
+    private static bool IsStorageName(string name, int maxLength) =>
+        name.Length >= 3 && name.Length <= maxLength
+        && !name.Contains("--", StringComparison.Ordinal)
+        && Regex.IsMatch(name, "^[a-z0-9][a-z0-9-]*[a-z0-9]$", RegexOptions.CultureInvariant);
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobRegistration.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobRegistration.cs
@@ -8,10 +8,14 @@ using PWABuilder.MicrosoftStore.Models;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Registers the optional job API and validates its deployment prerequisites.</summary>
+/// <summary>
+/// Registers the optional job API and validates its deployment prerequisites.
+/// </summary>
 public static class WindowsPackageJobRegistration
 {
-    /// <summary>Registers durable job services only when explicitly enabled.</summary>
+    /// <summary>
+    /// Registers durable job services only when explicitly enabled.
+    /// </summary>
     public static IServiceCollection AddWindowsPackageJobs(this IServiceCollection services, IConfiguration configuration)
     {
         var section = configuration.GetSection("WindowsPackageJobs");
@@ -44,7 +48,9 @@ public static class WindowsPackageJobRegistration
         return services;
     }
 
-    /// <summary>Requires HTTPS service roots rather than signed URLs or credentials in configuration.</summary>
+    /// <summary>
+    /// Requires HTTPS service roots rather than signed URLs or credentials in configuration.
+    /// </summary>
     private static bool IsServiceUri(string value) =>
         Uri.TryCreate(value, UriKind.Absolute, out var uri)
         && uri.Scheme is "https"
@@ -53,7 +59,9 @@ public static class WindowsPackageJobRegistration
         && string.IsNullOrEmpty(uri.Query)
         && string.IsNullOrEmpty(uri.Fragment);
 
-    /// <summary>Checks Azure queue/container names, reserving room for the poison suffix.</summary>
+    /// <summary>
+    /// Checks Azure queue/container names, reserving room for the poison suffix.
+    /// </summary>
     private static bool IsStorageName(string name, int maxLength) =>
         name.Length >= 3 && name.Length <= maxLength
         && !name.Contains("--", StringComparison.Ordinal)

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobStatus.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobStatus.cs
@@ -2,7 +2,9 @@ using System;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Public polling response; excludes inputs, internal errors, and storage/lease details.</summary>
+/// <summary>
+/// Public polling response; excludes inputs, internal errors, and storage/lease details.
+/// </summary>
 /// <param name="Id">Job capability ID.</param>
 /// <param name="Status">Queued, InProgress, Completed, Failed, or Expired.</param>
 /// <param name="CreatedAt">Submission time.</param>

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobStatus.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobStatus.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Public polling response; excludes inputs, internal errors, and storage/lease details.</summary>
+/// <param name="Id">Job capability ID.</param>
+/// <param name="Status">Queued, InProgress, Completed, Failed, or Expired.</param>
+/// <param name="CreatedAt">Submission time.</param>
+/// <param name="ExpiresAt">Processing/download deadline.</param>
+/// <param name="FinishedAt">Terminal transition time.</param>
+/// <param name="Attempts">Number of attempts started.</param>
+/// <param name="Error">Safe client-facing error summary.</param>
+/// <param name="DownloadUrl">Download endpoint, only when completed and unexpired.</param>
+public sealed record WindowsPackageJobStatus(
+    string Id,
+    string Status,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset ExpiresAt,
+    DateTimeOffset? FinishedAt,
+    int Attempts,
+    string? Error,
+    string? DownloadUrl);

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobWorker.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobWorker.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace PWABuilder.MicrosoftStore.Jobs;
+
+/// <summary>Bounded consumers and a recoverable outbox dispatcher, owned by the host.</summary>
+public sealed class WindowsPackageJobWorker(
+    IServiceScopeFactory scopes,
+    IWindowsPackageJobQueue queue,
+    IOptions<WindowsPackageJobOptions> options,
+    ILogger<WindowsPackageJobWorker> logger) : BackgroundService
+{
+    private readonly WindowsPackageJobOptions settings = options.Value;
+
+    /// <inheritdoc/>
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // API-only instances still dispatch accepted jobs; dedicated workers can recover
+        // pending outbox records left by an API crash.
+        var count = settings.RunWorkers ? settings.WorkerCount : 0;
+        return Task.WhenAll(Enumerable.Range(0, count)
+            .Select(_ => RunLoopAsync(false, stoppingToken))
+            .Append(RunLoopAsync(true, stoppingToken)));
+    }
+
+    /// <summary>Creates a fresh scope for each delivery so temporary build files are isolated.</summary>
+    private async Task RunLoopAsync(bool dispatch, CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            var idle = dispatch;
+            try
+            {
+                await using var scope = scopes.CreateAsyncScope();
+                var processor = scope.ServiceProvider.GetRequiredService<WindowsPackageJobProcessor>();
+                if (dispatch)
+                {
+                    await processor.DispatchAsync(token);
+                }
+                else
+                {
+                    var message = await queue.ReceiveAsync(token);
+                    idle = message is null;
+                    if (message is not null)
+                    {
+                        await processor.ProcessAsync(message, token);
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception error)
+            {
+                logger.LogError(error, "Windows package {Loop} iteration failed; unacknowledged jobs remain recoverable",
+                    dispatch ? "dispatcher" : "worker");
+                idle = true;
+            }
+
+            if (idle)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(settings.PollSeconds), token);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobWorker.cs
+++ b/apps/pwabuilder-microsoft-store/Jobs/WindowsPackageJobWorker.cs
@@ -9,7 +9,9 @@ using Microsoft.Extensions.Options;
 
 namespace PWABuilder.MicrosoftStore.Jobs;
 
-/// <summary>Bounded consumers and a recoverable outbox dispatcher, owned by the host.</summary>
+/// <summary>
+/// Bounded consumers and a recoverable outbox dispatcher, owned by the host.
+/// </summary>
 public sealed class WindowsPackageJobWorker(
     IServiceScopeFactory scopes,
     IWindowsPackageJobQueue queue,
@@ -29,7 +31,9 @@ public sealed class WindowsPackageJobWorker(
             .Append(RunLoopAsync(true, stoppingToken)));
     }
 
-    /// <summary>Creates a fresh scope for each delivery so temporary build files are isolated.</summary>
+    /// <summary>
+    /// Creates a fresh scope for each delivery so temporary build files are isolated.
+    /// </summary>
     private async Task RunLoopAsync(bool dispatch, CancellationToken token)
     {
         while (!token.IsCancellationRequested)

--- a/apps/pwabuilder-microsoft-store/Models/WindowsAppPackageFileResult.cs
+++ b/apps/pwabuilder-microsoft-store/Models/WindowsAppPackageFileResult.cs
@@ -1,0 +1,19 @@
+namespace PWABuilder.MicrosoftStore.Models;
+
+/// <summary>
+/// A generated ZIP package whose files remain available until the owning packaging scope is disposed.
+/// </summary>
+/// <param name="FilePath">The path of the generated ZIP file.</param>
+/// <param name="ModernAppPackage">The modern Windows package metadata, if requested.</param>
+public sealed record WindowsAppPackageFileResult(string FilePath, ModernWindowsPackageResult? ModernAppPackage)
+{
+    /// <summary>
+    /// Gets the classic package metadata retained for the legacy byte-array API.
+    /// </summary>
+    internal ClassicWindowsPackageResult? ClassicAppPackage { get; init; }
+
+    /// <summary>
+    /// Gets the EdgeHTML package metadata retained for the legacy byte-array API.
+    /// </summary>
+    internal SpartanWindowsPackageResult? EdgeHtmlAppPackage { get; init; }
+}

--- a/apps/pwabuilder-microsoft-store/PWABuilder.MicrosoftStore.csproj
+++ b/apps/pwabuilder-microsoft-store/PWABuilder.MicrosoftStore.csproj
@@ -13,6 +13,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />

--- a/apps/pwabuilder-microsoft-store/Services/AppxUpdaterBase.cs
+++ b/apps/pwabuilder-microsoft-store/Services/AppxUpdaterBase.cs
@@ -8,6 +8,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Reflection.Metadata.Ecma335;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 
@@ -37,6 +38,7 @@ namespace PWABuilder.MicrosoftStore
         /// <param name="options">The package options.</param>
         /// <param name="outputDirectory">The directory to store the artifacts in.</param>
         /// <param name="webManifest">The web manifest of the PWA.</param>
+        /// <param name="cancelToken">Cancels extraction and packaging.</param>
         /// <returns>The path to the .appx file.</returns>
         protected async Task<UpdatedAppx> GenerateAppx(
             string appxTemplatePath, 
@@ -44,17 +46,20 @@ namespace PWABuilder.MicrosoftStore
             WindowsAppPackageOptions options, 
             WebAppManifestContext webManifest, 
             ImageGeneratorResult appImages, 
-            string outputDirectory)
+            string outputDirectory,
+            CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             // Extract the project template .appx file (really, a .zip file) into a subdir of outputDirectory.
             var projectDirectory = ExtractAppx(appxTemplatePath, outputDirectory);
+            cancelToken.ThrowIfCancellationRequested();
 
             // Update the template with the real app information.
             var publisher = GetPublisher(options, webManifest);
-            await UpdateProjectFiles(outputDirectory, projectDirectory, appVersion, options, webManifest, publisher, appImages);
+            await UpdateProjectFiles(outputDirectory, projectDirectory, appVersion, options, webManifest, publisher, appImages, cancelToken);
 
             // Finally, repackage the appx from the unzipped files.
-            var appxFilePath = await makeAppx.Execute(projectDirectory, outputDirectory);
+            var appxFilePath = await makeAppx.Execute(projectDirectory, outputDirectory, cancelToken);
 
             return new UpdatedAppx
             {
@@ -73,6 +78,7 @@ namespace PWABuilder.MicrosoftStore
         /// <param name="webManifest"></param>
         /// <param name="publisher"></param>
         /// <param name="appImages"></param>
+        /// <param name="cancelToken">Cancels file updates and resource generation.</param>
         /// <returns></returns>
         protected virtual async Task UpdateProjectFiles(
             string outputDirectory,
@@ -81,17 +87,20 @@ namespace PWABuilder.MicrosoftStore
             WindowsAppPackageOptions options,
             WebAppManifestContext webManifest,
             Publisher publisher,
-            ImageGeneratorResult appImages)
+            ImageGeneratorResult appImages,
+            CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             // Update the AppManifest.xml file
             var appxManifestFilePath = Path.Combine(projectDirectory, "AppxManifest.xml");
             var xmlDoc = new XmlDocument();
             xmlDoc.Load(appxManifestFilePath);
             await UpdateAppxManifest(xmlDoc, options, version, webManifest, publisher);
             xmlDoc.Save(appxManifestFilePath);
+            cancelToken.ThrowIfCancellationRequested();
 
             // Bring in the updated images.
-            await UpdateAppImages(outputDirectory, projectDirectory, appImages);
+            await UpdateAppImages(outputDirectory, projectDirectory, appImages, cancelToken);
         }
 
         protected virtual Task UpdateAppxManifest(
@@ -250,27 +259,30 @@ namespace PWABuilder.MicrosoftStore
             return strippedAndTrimmed;
         }
 
-        private async Task UpdateAppImages(string outputDirectory, string projectDirectory, ImageGeneratorResult appImages)
+        private async Task UpdateAppImages(string outputDirectory, string projectDirectory, ImageGeneratorResult appImages, CancellationToken cancelToken)
         {
-            CopyAppImages(appImages, Path.Combine(projectDirectory, "Images"));
+            CopyAppImages(appImages, Path.Combine(projectDirectory, "Images"), cancelToken);
 
-            await makePri.Execute(projectDirectory, outputDirectory);
+            await makePri.Execute(projectDirectory, outputDirectory, cancelToken);
         }
 
-        private void CopyAppImages(ImageGeneratorResult appImages, string targetDir)
+        private void CopyAppImages(ImageGeneratorResult appImages, string targetDir, CancellationToken cancelToken)
         {
             // Delete the placeholder images.
             var placeholderImages = Directory.EnumerateFiles(targetDir);
             foreach (var placeholder in placeholderImages)
             {
+                cancelToken.ThrowIfCancellationRequested();
                 File.Delete(placeholder);
             }
 
             // Copy in the app images.
             foreach (var sourceFilePath in appImages.ImagePaths)
             {
+                cancelToken.ThrowIfCancellationRequested();
                 var destinationFilePath = Path.Combine(targetDir, Path.GetFileName(sourceFilePath));
                 File.Copy(sourceFilePath, destinationFilePath);
+                cancelToken.ThrowIfCancellationRequested();
             }
         }
     }

--- a/apps/pwabuilder-microsoft-store/Services/ClassicWindowsPackageCreator.cs
+++ b/apps/pwabuilder-microsoft-store/Services/ClassicWindowsPackageCreator.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Serialization;
@@ -37,23 +38,26 @@ namespace PWABuilder.MicrosoftStore
         /// <param name="appImages">The app images.</param>
         /// <param name="outputDirectory">The output directory.</param>
         /// <param name="webManifest">The web manifest for the PWA.</param>
+        /// <param name="cancelToken">Cancels packaging and native tools.</param>
         /// <returns></returns>
         public async Task<ClassicWindowsPackageResult> Create(
             WindowsAppPackageOptions options,
             WebAppManifestContext webManifest,
             ImageGeneratorResult appImages,
             string outputDirectory,
-            string? edgeAppId)
+            string? edgeAppId,
+            CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             this.edgeAppId = edgeAppId;
             var appxPath = settings.ClassicWindowsAppPackagePath;
             var version = GetClassicAppVersion(options);
 
             // Make a new appx file from the ClassicWindowsAppPackage.appx template.
-            var updatedAppxResult = await this.GenerateAppx(appxPath, version, options, webManifest, appImages, outputDirectory);
+            var updatedAppxResult = await this.GenerateAppx(appxPath, version, options, webManifest, appImages, outputDirectory, cancelToken);
 
             // Bundle it into a .appxbundle
-            var appxBundleFilePath = await makeAppx.Bundle(updatedAppxResult.AppxFilePath, version.WithZeroRevision());
+            var appxBundleFilePath = await makeAppx.Bundle(updatedAppxResult.AppxFilePath, version.WithZeroRevision(), cancelToken);
 
             return new ClassicWindowsPackageResult
             {
@@ -95,12 +99,13 @@ namespace PWABuilder.MicrosoftStore
             }
         }
 
-        protected override async Task UpdateProjectFiles(string outputDirectory, string projectDirectory, Version version, WindowsAppPackageOptions options, WebAppManifestContext webManifest, Publisher publisher, ImageGeneratorResult appImages)
+        /// <inheritdoc/>
+        protected override async Task UpdateProjectFiles(string outputDirectory, string projectDirectory, Version version, WindowsAppPackageOptions options, WebAppManifestContext webManifest, Publisher publisher, ImageGeneratorResult appImages, CancellationToken cancelToken = default)
         {
-            await base.UpdateProjectFiles(outputDirectory, projectDirectory, version, options, webManifest, publisher, appImages);
+            await base.UpdateProjectFiles(outputDirectory, projectDirectory, version, options, webManifest, publisher, appImages, cancelToken);
 
             // Create the pwa.json file used in our pwainstaller.exe, which instructs Edge to install the PWA.
-            await CreatePwaJson(options, webManifest, projectDirectory, edgeAppId);
+            await CreatePwaJson(options, webManifest, projectDirectory, edgeAppId, cancelToken);
         }
 
         private void AddPwaBuilderNode(XmlDocument xmlDoc)
@@ -125,7 +130,7 @@ namespace PWABuilder.MicrosoftStore
             buildItem.ParentNode?.AppendChild(pwaBuilderNode);
         }
 
-        private Task CreatePwaJson(WindowsAppPackageOptions options, WebAppManifestContext webManifest, string outputDirectory, string? edgeAppId)
+        private Task CreatePwaJson(WindowsAppPackageOptions options, WebAppManifestContext webManifest, string outputDirectory, string? edgeAppId, CancellationToken cancelToken)
         {
             var jsonData = new
             {
@@ -134,7 +139,7 @@ namespace PWABuilder.MicrosoftStore
             };
             var jsonString = JsonSerializer.Serialize(jsonData);
             var filePath = Path.Combine(outputDirectory, "pwa.json");
-            return File.WriteAllTextAsync(filePath, jsonString);
+            return File.WriteAllTextAsync(filePath, jsonString, cancelToken);
         }
 
         private Version GetClassicAppVersion(WindowsAppPackageOptions options)

--- a/apps/pwabuilder-microsoft-store/Services/ImageGenerator.cs
+++ b/apps/pwabuilder-microsoft-store/Services/ImageGenerator.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PWABuilder.MicrosoftStore
@@ -44,19 +45,21 @@ namespace PWABuilder.MicrosoftStore
         /// <param name="options">The package options.</param>
         /// <param name="manifest">The web app manifest containing one or more images.</param>
         /// <param name="outputDirectory">The directory to write the images to.</param>
+        /// <param name="cancelToken">Cancels image generation, downloads, and file writes.</param>
         /// <returns>An object containing the paths to the generated images.</returns>
-        public async Task<ImageGeneratorResult> Generate(WindowsAppPackageOptions options, WebAppManifestContext manifest, string outputDirectory)
+        public async Task<ImageGeneratorResult> Generate(WindowsAppPackageOptions options, WebAppManifestContext manifest, string outputDirectory, CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             // 1. Generate images using PWABuilder's image generation service. 
             // These will be used as a backup if the options and manifest are missing images.
             var imageOptions = options.Images ?? new WindowsImages();
-            using var generatedImagesZip = await InvokePwabuilderImageGeneratorService(imageOptions, manifest);
+            using var generatedImagesZip = await InvokePwabuilderImageGeneratorService(imageOptions, manifest, cancelToken);
 
             // 2. Assemble the image sources from the options, web manifest, and generated images zip.
             var imageSources = GetImageSources(imageOptions, manifest, generatedImagesZip);
 
             // 3. Write all the available images to the output directory.
-            var imagePaths = await TryWriteImageSourcesToDirectory(imageSources, outputDirectory);
+            var imagePaths = await TryWriteImageSourcesToDirectory(imageSources, outputDirectory, cancelToken);
             return new ImageGeneratorResult(imagePaths);
         }
 
@@ -67,13 +70,13 @@ namespace PWABuilder.MicrosoftStore
             return scaleSetImages.Concat(targetSizeImages);
         }
 
-        private async Task<ImageGeneratorServiceZipFile> InvokePwabuilderImageGeneratorService(WindowsImages imageOptions, WebAppManifestContext webManifest)
+        private async Task<ImageGeneratorServiceZipFile> InvokePwabuilderImageGeneratorService(WindowsImages imageOptions, WebAppManifestContext webManifest, CancellationToken cancelToken)
         {
-            var baseImageBytes = await GetBaseImage(imageOptions, webManifest);
-            return await CreateWindows11ImagesZip(baseImageBytes, imageOptions.Padding, imageOptions.BackgroundColor);
+            var baseImageBytes = await GetBaseImage(imageOptions, webManifest, cancelToken);
+            return await CreateWindows11ImagesZip(baseImageBytes, imageOptions.Padding, imageOptions.BackgroundColor, cancelToken);
         }
 
-        private async Task<byte[]> GetBaseImage(WindowsImages imageOptions, WebAppManifestContext webManifest)
+        private async Task<byte[]> GetBaseImage(WindowsImages imageOptions, WebAppManifestContext webManifest, CancellationToken cancelToken)
         {
             // Find a base image from which to generate all Windows package images.
             // Best: the user supplied an image.
@@ -103,10 +106,10 @@ namespace PWABuilder.MicrosoftStore
             {
                 if (source != null)
                 {
-                    using var stream = await TryDownloadImage(source);
+                    using var stream = await TryDownloadImage(source, cancelToken);
                     if (stream != null)
                     {
-                        var bytes = await TryReadStreamBytes(stream, $"{source}, {description}");
+                        var bytes = await TryReadStreamBytes(stream, $"{source}, {description}", cancelToken);
                         if (bytes != null)
                         {
                             return bytes;
@@ -121,7 +124,7 @@ namespace PWABuilder.MicrosoftStore
             throw new InvalidOperationException($"Couldn't find a suitable base image from which to generate all Windows package images. Please ensure your web app manifest has a square PNG image 512x512 or larger. Base image sources: {string.Join(", ", imageSourceDescriptions)}");
         }
 
-        private async Task<ImageGeneratorServiceZipFile> CreateWindows11ImagesZip(byte[] image, double padding, string? backgroundColor)
+        private async Task<ImageGeneratorServiceZipFile> CreateWindows11ImagesZip(byte[] image, double padding, string? backgroundColor, CancellationToken cancelToken)
         {
             // The image generation API documentation: https://github.com/pwa-builder/PWABuilder/blob/ac5aec8c3ad235cb7f2f54bfa64189ec73e947a6/apps/pwabuilder/Controllers/ImagesController.cs#L83
             // states the image generator takes the following parameters:
@@ -132,7 +135,7 @@ namespace PWABuilder.MicrosoftStore
             var memStream = new MemoryStream(image);
             using var fileContent = new StreamContent(memStream);
             fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png");
-            var imageGeneratorArgs = new MultipartFormDataContent
+            using var imageGeneratorArgs = new MultipartFormDataContent
             {
                 { fileContent, "BaseImage", "image.png" },
                 { new StringContent(padding.ToString(System.Globalization.CultureInfo.InvariantCulture)), "Padding" },
@@ -140,17 +143,25 @@ namespace PWABuilder.MicrosoftStore
                 { new StringContent(backgroundColor ?? "transparent"), "BackgroundColor" }
             };
 
-            using var imagesResponse = await this.http.PostAsync(imageGeneratorServiceUrl, imageGeneratorArgs);
+            using var imagesResponse = await this.http.PostAsync(imageGeneratorServiceUrl, imageGeneratorArgs, cancelToken);
             imagesResponse.EnsureSuccessStatusCode();
 
             // Copy the response into a self-contained MemoryStream so that
             // the ZipArchive remains usable after the HTTP response is disposed.
             var zipMemoryStream = new MemoryStream();
-            await imagesResponse.Content.CopyToAsync(zipMemoryStream);
-            zipMemoryStream.Position = 0;
-
-            var zipArchive = new ZipArchive(zipMemoryStream, ZipArchiveMode.Read);
-            return new ImageGeneratorServiceZipFile(zipArchive);
+            try
+            {
+                await imagesResponse.Content.CopyToAsync(zipMemoryStream, cancelToken);
+                zipMemoryStream.Position = 0;
+                cancelToken.ThrowIfCancellationRequested();
+                var zipArchive = new ZipArchive(zipMemoryStream, ZipArchiveMode.Read);
+                return new ImageGeneratorServiceZipFile(zipArchive);
+            }
+            catch
+            {
+                zipMemoryStream.Dispose();
+                throw;
+            }
         }
 
         private IEnumerable<ImageSource> GetImageSourcesForTargetSizes(WindowsImages imageOptions, WebAppManifestContext webManifest, ImageGeneratorServiceZipFile generatedImagesZip)
@@ -171,12 +182,13 @@ namespace PWABuilder.MicrosoftStore
                    select ImageSource.From(set, scale, imageOptions, webManifest, generatedImagesZip);
         }
 
-        private async Task<List<string>> TryWriteImageSourcesToDirectory(IEnumerable<ImageSource> sources, string outputDirectory)
+        private async Task<List<string>> TryWriteImageSourcesToDirectory(IEnumerable<ImageSource> sources, string outputDirectory, CancellationToken cancelToken)
         {
             var imageFilePaths = new List<string>(40);
             foreach (var source in sources)
             {
-                var filePath = await TryWriteImageSourceToDirectory(source, outputDirectory);
+                cancelToken.ThrowIfCancellationRequested();
+                var filePath = await TryWriteImageSourceToDirectory(source, outputDirectory, cancelToken);
                 if (filePath != null)
                 {
                     imageFilePaths.Add(filePath);
@@ -186,7 +198,7 @@ namespace PWABuilder.MicrosoftStore
             return imageFilePaths;
         }
 
-        private async Task<string?> TryWriteImageSourceToDirectory(ImageSource source, string outputDirectory)
+        private async Task<string?> TryWriteImageSourceToDirectory(ImageSource source, string outputDirectory, CancellationToken cancelToken)
         {
             // Go through each source in the specified ImageSource and try to write it to a file.
             //
@@ -197,17 +209,18 @@ namespace PWABuilder.MicrosoftStore
 
             var streamOpeners = new (Func<Task<Stream?>> action, string? description)[]
             {
-                (action: () => TryDownloadImage(source.AppPackageOptionsSource), description: source.AppPackageOptionsSource?.ToString()),
-                (action: () => TryDownloadImage(source.WebManifestSource), description: source.WebManifestSource?.ToString()),
+                (action: () => TryDownloadImage(source.AppPackageOptionsSource, cancelToken), description: source.AppPackageOptionsSource?.ToString()),
+                (action: () => TryDownloadImage(source.WebManifestSource, cancelToken), description: source.WebManifestSource?.ToString()),
                 (action: () => TryOpenZipEntry(source.GeneratedImageSource), description: source.GeneratedImageSource?.FullName)
             };
 
             foreach (var (action, description) in streamOpeners)
             {
+                cancelToken.ThrowIfCancellationRequested();
                 using var stream = await action();
                 if (stream != null)
                 {
-                    var filePath = await TryWriteStreamToOutputDirectory(stream, source.TargetFileName, outputDirectory, description ?? string.Empty);
+                    var filePath = await TryWriteStreamToOutputDirectory(stream, source.TargetFileName, outputDirectory, description ?? string.Empty, cancelToken);
                     if (filePath != null)
                     {
                         return filePath;
@@ -218,8 +231,9 @@ namespace PWABuilder.MicrosoftStore
             return null;
         }
 
-        private async Task<Stream?> TryDownloadImage(Uri? imageUri)
+        private async Task<Stream?> TryDownloadImage(Uri? imageUri, CancellationToken cancelToken)
         {
+            cancelToken.ThrowIfCancellationRequested();
             if (imageUri == null)
             {
                 return null;
@@ -229,14 +243,15 @@ namespace PWABuilder.MicrosoftStore
             try
             {
                 using var request = new HttpRequestMessage(HttpMethod.Get, imageUri);
-                imageFetch = await http.SendAsync(request);
+                imageFetch = await http.SendAsync(request, cancelToken);
                 if (!imageFetch.IsSuccessStatusCode)
                 {
                     logger.LogWarning("Attempted to fetch image at {url}, but download failed with status {code}, {reason}", imageUri, imageFetch.StatusCode, imageFetch.ReasonPhrase);
+                    imageFetch.Dispose();
                     return null;
                 }
             }
-            catch (Exception fetchError)
+            catch (Exception fetchError) when (fetchError is not OperationCanceledException)
             {
                 logger.LogWarning(fetchError, "Attempted to fetch image at {url}, but download failed with exception. Will try HTTP/2", imageUri);
             }
@@ -248,14 +263,15 @@ namespace PWABuilder.MicrosoftStore
                 {
                     using var request = new HttpRequestMessage(HttpMethod.Get, imageUri);
                     request.Version = HttpVersion.Version20;
-                    imageFetch = await http.SendAsync(request);
+                    imageFetch = await http.SendAsync(request, cancelToken);
                     if (!imageFetch.IsSuccessStatusCode)
                     {
                         logger.LogWarning("Attempted to fetch image at {url} with HTTP/2, but download failed with status {code}, {reason}", imageUri, imageFetch.StatusCode, imageFetch.ReasonPhrase);
+                        imageFetch.Dispose();
                         return null;
                     }
                 }
-                catch (Exception fetchError)
+                catch (Exception fetchError) when (fetchError is not OperationCanceledException)
                 {
                     logger.LogError(fetchError, "Attempted to fetch image at {url} with HTTP/2, but download failed with exception", imageUri);
                     return null;
@@ -264,26 +280,32 @@ namespace PWABuilder.MicrosoftStore
 
             try
             {
-                var imageStream = await imageFetch.Content.ReadAsStreamAsync();
+                var imageStream = await imageFetch.Content.ReadAsStreamAsync(cancelToken);
                 return new HttpMessageStream(imageStream, imageFetch);
+            }
+            catch (OperationCanceledException)
+            {
+                imageFetch.Dispose();
+                throw;
             }
             catch (Exception imageBytesError)
             {
+                imageFetch.Dispose();
                 logger.LogWarning(imageBytesError, "Unable to read image bytes from {url}", imageUri);
                 return null;
             }
         }
 
-        private async Task<byte[]?> TryReadStreamBytes(Stream stream, string streamDescription)
+        private async Task<byte[]?> TryReadStreamBytes(Stream stream, string streamDescription, CancellationToken cancelToken)
         {
             using var memoryStream = new MemoryStream();
             try
             {
-                await stream.CopyToAsync(memoryStream);
-                await memoryStream.FlushAsync();
+                await stream.CopyToAsync(memoryStream, cancelToken);
+                await memoryStream.FlushAsync(cancelToken);
                 return memoryStream.ToArray();
             }
-            catch (Exception streamError)
+            catch (Exception streamError) when (streamError is not OperationCanceledException)
             {
                 logger.LogWarning(streamError, "Unable to read bytes from stream {description}", streamDescription);
                 return null;
@@ -316,19 +338,21 @@ namespace PWABuilder.MicrosoftStore
         /// <param name="fileName">The desired file name to write the stream into.</param>
         /// <param name="outputDirectory">The output directory to write the file into.</param>
         /// <param name="sourceDescription">The description of the source stream. This can be a URL for an image from the web, or the zip entry name for an image from a zip file.</param>
+        /// <param name="cancelToken">Cancels copying the image stream.</param>
         /// <returns>The file path of the written file, if successful. Null if downloading the stream failed.</returns>
-        private async Task<string?> TryWriteStreamToOutputDirectory(Stream stream, string fileName, string outputDirectory, string sourceDescription)
+        private async Task<string?> TryWriteStreamToOutputDirectory(Stream stream, string fileName, string outputDirectory, string sourceDescription, CancellationToken cancelToken)
         {
             var filePath = "";
             try
             {
+                cancelToken.ThrowIfCancellationRequested();
                 filePath = Path.Combine(outputDirectory, fileName);
                 using var fileStream = File.Create(filePath);
-                await stream.CopyToAsync(fileStream);
-                await fileStream.FlushAsync();
+                await stream.CopyToAsync(fileStream, cancelToken);
+                await fileStream.FlushAsync(cancelToken);
                 return filePath;
             }
-            catch (Exception streamError)
+            catch (Exception streamError) when (streamError is not OperationCanceledException)
             {
                 logger.LogWarning(streamError, "Failed to download stream from {source} into {destination}", sourceDescription, filePath);
                 return null;

--- a/apps/pwabuilder-microsoft-store/Services/MakeAppxWrapper.cs
+++ b/apps/pwabuilder-microsoft-store/Services/MakeAppxWrapper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PWABuilder.MicrosoftStore
@@ -33,10 +34,11 @@ namespace PWABuilder.MicrosoftStore
         /// </summary>
         /// <param name="outputDirectory">The directory in which to create temporary files.</param>
         /// <param name="appxProjectDirectory">The unzipped appx or msix directory. It should contain AppxManifest.xml and an Images directory.</param>
+        /// <param name="cancelToken">Cancels packaging and the native tool.</param>
         /// <returns>The file path to the generated .appx file.</returns>
-        public Task<string> Execute(string appxProjectDirectory, string outputDirectory)
+        public Task<string> Execute(string appxProjectDirectory, string outputDirectory, CancellationToken cancelToken = default)
         {
-            return MakeAppx(appxProjectDirectory, outputDirectory);
+            return MakeAppx(appxProjectDirectory, outputDirectory, cancelToken);
         }
 
         /// <summary>
@@ -44,9 +46,11 @@ namespace PWABuilder.MicrosoftStore
         /// </summary>
         /// <param name="packageFilePath">The path to the .msix or .appx file.</param>
         /// <param name="version">The version of the app. This is needed to mark the bundle version.</param>
+        /// <param name="cancelToken">Cancels bundling and the native tool.</param>
         /// <returns></returns>
-        public async Task<string> Bundle(string packageFilePath, Version version)
+        public async Task<string> Bundle(string packageFilePath, Version version, CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             var appxDirectory = Path.GetDirectoryName(packageFilePath);
             if (appxDirectory == null)
             {
@@ -58,11 +62,12 @@ namespace PWABuilder.MicrosoftStore
             Directory.CreateDirectory(bundleDirectory);
             var inputPath = Path.Combine(bundleDirectory, Path.GetFileName(packageFilePath));
             File.Copy(packageFilePath, inputPath);
+            cancelToken.ThrowIfCancellationRequested();
 
             var appxFileNameWithoutExt = Path.GetFileNameWithoutExtension(packageFilePath);
             var outputBundlePath = Path.Combine(bundleDirectory, appxFileNameWithoutExt + ".appxbundle");            
             var bundleArgs = $"bundle /bv {version} /d \"{bundleDirectory}\" /p \"{outputBundlePath}\"";
-            var procResult = await this.procRunner.Run(MakeAppxPath, bundleArgs, TimeSpan.FromMinutes(5));
+            var procResult = await this.procRunner.Run(MakeAppxPath, bundleArgs, TimeSpan.FromMinutes(5), cancellationToken: cancelToken);
 
             if (!File.Exists(outputBundlePath))
             {
@@ -80,12 +85,14 @@ namespace PWABuilder.MicrosoftStore
         /// When Widgets are enabled, we need to bundle all the platform MSIXs together.
         /// </summary>
         /// <param name="packageFilePaths"></param>
-        /// <param name="outputDirectory"></param>
+        /// <param name="appxDirectory">The package output directory.</param>
         /// <param name="version"></param>
+        /// <param name="cancelToken">Cancels bundling and the native tool.</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
-        public async Task<string> BundlePlatforms(List<string> packageFilePaths, string appxDirectory, Version version)
+        public async Task<string> BundlePlatforms(List<string> packageFilePaths, string appxDirectory, Version version, CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             if (appxDirectory == null)
             {
                 throw new InvalidOperationException("Couldn't find the directory" + appxDirectory);
@@ -99,13 +106,13 @@ namespace PWABuilder.MicrosoftStore
             var outputBundlePath = Path.Combine(bundleDirectory, appxFileNameWithoutExt + ".appxbundle");
             foreach (string packageFilePath in packageFilePaths)
             {
-
+                cancelToken.ThrowIfCancellationRequested();
                 var inputPath = Path.Combine(bundleDirectory, Path.GetFileName(packageFilePath));
                 File.Copy(packageFilePath, inputPath);
-
+                cancelToken.ThrowIfCancellationRequested();
             }
             var bundleArgs = $"bundle /bv {version} /d \"{bundleDirectory}\" /p \"{outputBundlePath}\"";
-            var procResult = await this.procRunner.Run(MakeAppxPath, bundleArgs, TimeSpan.FromMinutes(5));
+            var procResult = await this.procRunner.Run(MakeAppxPath, bundleArgs, TimeSpan.FromMinutes(5), cancellationToken: cancelToken);
 
             if (!File.Exists(outputBundlePath))
             {
@@ -119,11 +126,11 @@ namespace PWABuilder.MicrosoftStore
             return outputBundlePath;
         }
 
-        private async Task<string> MakeAppx(string projectDirectory, string outputDirectory)
+        private async Task<string> MakeAppx(string projectDirectory, string outputDirectory, CancellationToken cancelToken)
         {
             var appxFilePath = Path.Combine(outputDirectory, $"{Guid.NewGuid()}.appx");
             var makeAppxArgs = $"pack /o /d \"{projectDirectory}\" /p \"{appxFilePath}\"";
-            var procResult = await procRunner.Run(MakeAppxPath, makeAppxArgs, TimeSpan.FromMinutes(5));
+            var procResult = await procRunner.Run(MakeAppxPath, makeAppxArgs, TimeSpan.FromMinutes(5), cancellationToken: cancelToken);
 
             if (!File.Exists(appxFilePath))
             {

--- a/apps/pwabuilder-microsoft-store/Services/MakePriWrapper.cs
+++ b/apps/pwabuilder-microsoft-store/Services/MakePriWrapper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PWABuilder.MicrosoftStore
@@ -33,39 +34,41 @@ namespace PWABuilder.MicrosoftStore
         /// </summary>
         /// <param name="appxProjectDirectory">The unzipped appx or msix directory. It should contain AppxManifest.xml and an Images directory.</param>
         /// <param name="outputDirectory">The directory in which to create temporary files.</param>
+        /// <param name="cancelToken">Cancels resource generation and native tools.</param>
         /// <returns>The file path to the generated resources.pri file.</returns>
-        public async Task<string> Execute(string appxProjectDirectory, string outputDirectory)
+        public async Task<string> Execute(string appxProjectDirectory, string outputDirectory, CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             // Delete any existing .pri file. Without this, we get duplicated resources in final resources.pri file.
             File.Delete(Path.Combine(appxProjectDirectory, "resources.pri"));
 
             // Create priconfig.xml resource config file.
             var priConfigPath = Path.Combine(outputDirectory, "priconfig.xml");
-            await RunMakePri($"createconfig /cf \"{priConfigPath}\" /dq en-US /o /v /pv 10.0.0", appxProjectDirectory);
+            await RunMakePri($"createconfig /cf \"{priConfigPath}\" /dq en-US /o /v /pv 10.0.0", appxProjectDirectory, cancelToken);
 
             // Remove the <autoResourcePackage qualifier="Scale"/> line from the pri config file.
             // Without this, multiple resources files (one for each Windows DPI scale) are generated, e.g. resources.scale-200.pri, resources.scale-400.pri, etc.
             // By removing this line, all the images will be packed into a single resources.pri.
-            await RemoveScaleQualifier(priConfigPath);
+            await RemoveScaleQualifier(priConfigPath, cancelToken);
 
             // Generate the actual resource file, resources.pri
-            await RunMakePri($"new /pr \"{appxProjectDirectory}\" /cf \"{priConfigPath}\" /v /o", appxProjectDirectory);
+            await RunMakePri($"new /pr \"{appxProjectDirectory}\" /cf \"{priConfigPath}\" /v /o", appxProjectDirectory, cancelToken);
 
             return Path.Combine(appxProjectDirectory, "resources.pri");
         }
 
-        private Task<ProcessResult> RunMakePri(string args, string workingDirectory)
+        private Task<ProcessResult> RunMakePri(string args, string workingDirectory, CancellationToken cancelToken)
         {
             var makePriPath = Path.Combine(this.settings.WindowsSdkDirectory, "makepri.exe");
-            return procRunner.Run(makePriPath, args, TimeSpan.FromMinutes(5), workingDirectory, System.Text.Encoding.Unicode);
+            return procRunner.Run(makePriPath, args, TimeSpan.FromMinutes(5), workingDirectory, System.Text.Encoding.Unicode, cancelToken);
         }
 
-        private async Task RemoveScaleQualifier(string priConfigPath)
+        private async Task RemoveScaleQualifier(string priConfigPath, CancellationToken cancelToken)
         {
             // We want to remove the line: <autoResourcePackage qualifier="Scale"/>
             // Removing this line enables the resources to be packed into a single .pri file, regardless of app icon scales.
             var scaleQualifierLine = "<autoResourcePackage qualifier=\"Scale\"/>";
-            var lines = await File.ReadAllLinesAsync(priConfigPath);
+            var lines = await File.ReadAllLinesAsync(priConfigPath, cancelToken);
             var linesWithoutScaleQualifier = lines
                 .Where(l => !l.Contains(scaleQualifierLine, StringComparison.InvariantCultureIgnoreCase))
                 .ToArray();
@@ -76,7 +79,7 @@ namespace PWABuilder.MicrosoftStore
                 logger.LogWarning("Unable to remove the scale qualifier line from the resources. Icons for different DPI scales will not be used in the app.");
             }
 
-            await File.WriteAllLinesAsync(priConfigPath, linesWithoutScaleQualifier);
+            await File.WriteAllLinesAsync(priConfigPath, linesWithoutScaleQualifier, cancelToken);
         }
     }
 }

--- a/apps/pwabuilder-microsoft-store/Services/ModernWindowsPackageCreator.cs
+++ b/apps/pwabuilder-microsoft-store/Services/ModernWindowsPackageCreator.cs
@@ -42,21 +42,26 @@ namespace PWABuilder.MicrosoftStore.Services
         /// Creates the modern Windows hosted app for the PWA.
         /// </summary>
         /// <param name="options"></param>
+        /// <param name="appImages">The generated app images.</param>
+        /// <param name="webManifest">The PWA manifest.</param>
         /// <param name="outputDirectory"></param>
+        /// <param name="cancelToken">Cancels the build and its native processes.</param>
         /// <returns></returns>
-        public async Task<ModernWindowsPackageResult> Create(WindowsAppPackageOptions options, ImageGeneratorResult appImages, WebAppManifestContext webManifest, string outputDirectory, CancellationToken cancelToken)
+        public async Task<ModernWindowsPackageResult> Create(WindowsAppPackageOptions options, ImageGeneratorResult appImages, WebAppManifestContext webManifest, string outputDirectory, CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             // 1. Build the Store package. If widgets are present, build multiple.
             var storeBuilderResult = await BuildStoreReadyPackage(options, appImages, webManifest, outputDirectory, cancelToken);
 
             // 2. Bundle the Store package.
-            var storeBundleFilePath = options.EnableWebAppWidgets != true ? await makeAppx.Bundle(storeBuilderResult.MsixFile, new Version(options.Version).WithZeroRevision()) : await makeAppx.BundlePlatforms(storeBuilderResult.MsixPlatformFiles, outputDirectory, new Version(options.Version).WithZeroRevision());
+            var storeBundleFilePath = options.EnableWebAppWidgets != true ? await makeAppx.Bundle(storeBuilderResult.MsixFile, new Version(options.Version).WithZeroRevision(), cancelToken) : await makeAppx.BundlePlatforms(storeBuilderResult.MsixPlatformFiles, outputDirectory, new Version(options.Version).WithZeroRevision(), cancelToken);
 
             // 3. Build the side load package.
             var sideLoadMsixFilePath = await BuildSideloadPackage(options, storeBuilderResult, appImages, webManifest, outputDirectory, cancelToken);
 
             // 4. Read the generated package info.
             var packageInfo = ReadPackageInfo(storeBuilderResult.AppxManifest);
+            cancelToken.ThrowIfCancellationRequested();
 
             return new ModernWindowsPackageResult(storeBundleFilePath, sideLoadMsixFilePath, packageInfo);
         }
@@ -112,7 +117,7 @@ namespace PWABuilder.MicrosoftStore.Services
             };
 
             // Generate a real resources.pri for the project.
-            appxResult.MsixFile = await UpdateMsixWithLegitResources(appxResult, outputDirectory);
+            appxResult.MsixFile = await UpdateMsixWithLegitResources(appxResult, outputDirectory, cancelToken);
 
             return appxResult;
         }
@@ -125,6 +130,7 @@ namespace PWABuilder.MicrosoftStore.Services
             string outputDirectory,
             CancellationToken cancelToken)
         {
+            cancelToken.ThrowIfCancellationRequested();
             // The sideload package must have AllowSigning = false.
             // This is required for sideloading the package via /Resources/cli/pwainstaller/pwainstaller.exe
 
@@ -140,7 +146,7 @@ namespace PWABuilder.MicrosoftStore.Services
             var sideLoadOptions = options.Clone();
             sideLoadOptions.AllowSigning = false;
             var sideLoadBuilderResult = await RunPwaBuilderWithOfflineManifestFallback(sideLoadOptions, appImages, webManifest, sideLoadDirectory, string.Empty, cancelToken);
-            return await UpdateMsixWithLegitResources(sideLoadBuilderResult, sideLoadDirectory);
+            return await UpdateMsixWithLegitResources(sideLoadBuilderResult, sideLoadDirectory, cancelToken);
         }
 
         /// <summary>
@@ -148,9 +154,11 @@ namespace PWABuilder.MicrosoftStore.Services
         /// </summary>
         /// <param name="msixResult">The path to the new .msix containing the correct resources.pri file.</param>
         /// <param name="outputDirectory">Temp directory where artifacts can be stored during the build process.</param>
+        /// <param name="cancelToken">Cancels extraction and resource rebuilding.</param>
         /// <returns></returns>
-        private async Task<string> UpdateMsixWithLegitResources(PwaBuilderCommandLineResult msixResult, string outputDirectory)
+        private async Task<string> UpdateMsixWithLegitResources(PwaBuilderCommandLineResult msixResult, string outputDirectory, CancellationToken cancelToken)
         {
+            cancelToken.ThrowIfCancellationRequested();
             // We need to crack open the msix and swap out its resources.pri with
             // a real one generated specifically for this app.
             // Otherwise, the resources.pri contains references to placeholder stuff.
@@ -158,15 +166,16 @@ namespace PWABuilder.MicrosoftStore.Services
             // Crack open the msix.
             var msixUnpackedDirectory = Directory.CreateDirectory(Path.Combine(outputDirectory, "unpacked")).FullName;
             ZipFile.ExtractToDirectory(msixResult.MsixFile, msixUnpackedDirectory);
+            cancelToken.ThrowIfCancellationRequested();
 
             // Delete the placeholder resources.pri file
             File.Delete(Path.Combine(msixUnpackedDirectory, "resources.pri"));
 
             // Generate a legit resources.pri file.
-            await makePri.Execute(msixUnpackedDirectory, Directory.CreateDirectory(Path.Combine(outputDirectory, "pri-config")).FullName);
+            await makePri.Execute(msixUnpackedDirectory, Directory.CreateDirectory(Path.Combine(outputDirectory, "pri-config")).FullName, cancelToken);
             // Repackage the msix.
             var repackagedMsixOutputDir = Directory.CreateDirectory(Path.Combine(outputDirectory, "repackaged")).FullName;
-            return await makeAppx.Execute(msixUnpackedDirectory, repackagedMsixOutputDir);
+            return await makeAppx.Execute(msixUnpackedDirectory, repackagedMsixOutputDir, cancelToken);
         }
 
         private HostedPackage ReadPackageInfo(string xmlSourceFile)

--- a/apps/pwabuilder-microsoft-store/Services/ProcessRunner.cs
+++ b/apps/pwabuilder-microsoft-store/Services/ProcessRunner.cs
@@ -15,21 +15,36 @@ namespace PWABuilder.MicrosoftStore
     public class ProcessRunner
     {
         private readonly ILogger<ProcessRunner> logger;
-        private readonly ZombieProcessKiller procKiller;
 
+        /// <summary>
+        /// Creates a runner for owned command-line processes.
+        /// </summary>
+        /// <param name="logger">The process logger.</param>
+        /// <param name="procKiller">Retained for constructor compatibility; each run now owns and disposes its timeout.</param>
         public ProcessRunner(ILogger<ProcessRunner> logger, ZombieProcessKiller procKiller)
         {
             this.logger = logger;
-            this.procKiller = procKiller;
         }
 
+        /// <summary>
+        /// Runs a tool, capturing both output streams and terminating its process tree on timeout or cancellation.
+        /// </summary>
+        /// <param name="processPath">The executable path.</param>
+        /// <param name="processArgs">The command-line arguments.</param>
+        /// <param name="killTime">The timeout, or thirty minutes when omitted.</param>
+        /// <param name="workingDirectory">The working directory for the process.</param>
+        /// <param name="outputEncoding">The optional encoding of the redirected output.</param>
+        /// <param name="cancellationToken">Cancels the process and its descendants.</param>
+        /// <returns>The captured standard output and error.</returns>
         public async Task<ProcessResult> Run(
             string processPath,
             string processArgs,
             TimeSpan? killTime = null,
             string workingDirectory = "",
-            Encoding? outputEncoding = null)
+            Encoding? outputEncoding = null,
+            CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!File.Exists(processPath))
             {
                 var pwaFileMissingError = new FileNotFoundException($"Unable to find {processPath}");
@@ -50,31 +65,45 @@ namespace PWABuilder.MicrosoftStore
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
+            var processTimeout = killTime ?? TimeSpan.FromMinutes(30);
+            using var timeoutCancellation = new CancellationTokenSource(processTimeout);
+            using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellation.Token);
+            using var outputCancellation = new CancellationTokenSource();
+            cancellationToken.ThrowIfCancellationRequested();
             using var cliProc = Process.Start(processStartInfo);
-            if (cliProc == null)
+            if (cliProc is null)
             {
                 throw new InvalidOperationException("Couldn't start Process");
             }
 
-            if (killTime.HasValue)
-            {
-                procKiller.KillProcessAfter(cliProc, killTime.Value);
-            }
-
-            var cliOutputTask = cliProc.StandardOutput.ReadToEndAsync();
-            var cliErrorOutputTask = cliProc.StandardError.ReadToEndAsync();
-            var processTimeout = killTime ?? TimeSpan.FromMinutes(30);
-            using var timeoutCancellation = new CancellationTokenSource(processTimeout);
+            var cliOutputTask = cliProc.StandardOutput.ReadToEndAsync(outputCancellation.Token);
+            var cliErrorOutputTask = cliProc.StandardError.ReadToEndAsync(outputCancellation.Token);
 
             try
             {
-                await cliProc.WaitForExitAsync(timeoutCancellation.Token);
+                await Task.WhenAll(cliProc.WaitForExitAsync(linkedCancellation.Token), cliOutputTask, cliErrorOutputTask)
+                    .WaitAsync(linkedCancellation.Token);
+                cancellationToken.ThrowIfCancellationRequested();
             }
             catch (OperationCanceledException)
             {
                 TryKillProcess(cliProc, processPath);
-                var timedOutOutput = await cliOutputTask;
-                var timedOutErrorOutput = await cliErrorOutputTask;
+                // A descendant may retain an inherited pipe even after the parent exits.
+                // Bound both exit waiting and pipe draining so cancellation cannot hang a worker.
+                outputCancellation.CancelAfter(TimeSpan.FromSeconds(5));
+                try
+                {
+                    await Task.WhenAll(cliProc.WaitForExitAsync(outputCancellation.Token), cliOutputTask, cliErrorOutputTask)
+                        .WaitAsync(outputCancellation.Token);
+                }
+                catch (Exception cleanupError)
+                {
+                    logger.LogWarning(cleanupError, "Unable to finish draining CLI process for {procPath}", processPath);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                var timedOutOutput = cliOutputTask.IsCompletedSuccessfully ? cliOutputTask.Result : string.Empty;
+                var timedOutErrorOutput = cliErrorOutputTask.IsCompletedSuccessfully ? cliErrorOutputTask.Result : string.Empty;
                 var noExitError = CreateCliError($"The {processFileName} process timed out.", timedOutOutput, timedOutErrorOutput, processPath, processArgs);
                 throw noExitError;
             }

--- a/apps/pwabuilder-microsoft-store/Services/PwaBuilderWrapper.cs
+++ b/apps/pwabuilder-microsoft-store/Services/PwaBuilderWrapper.cs
@@ -57,7 +57,7 @@ namespace PWABuilder.MicrosoftStore.Services
         /// <param name="webManifest">The web manifest of the PWA.</param>
         /// <param name="outputDirectory">The output directory to store the artifacts in.</param>
         /// <param name="processor"></param>
-        /// <param name="fallback"></param>
+        /// <param name="cancelToken">Cancels packaging and the native tool.</param>
         /// <returns></returns>
         public async Task<PwaBuilderCommandLineResult> Run(
             WindowsAppPackageOptions options,
@@ -65,24 +65,25 @@ namespace PWABuilder.MicrosoftStore.Services
             WebAppManifestContext webManifest,
             string outputDirectory,
             string processor,
-            CancellationToken cancelToken)
+            CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             var pwaBuilderFilePath = Path.Combine(host.ContentRootPath, PwaBuilderPath);
 
             var actionsFiles = await windowsActionService.GetWindowsActionsFilesAsync(options, outputDirectory, cancelToken);
             var pwaBuilderArgs = CreateCommandLineArgs(options, appImages, webManifest, actionsFiles, outputDirectory, processor);
-            return await RunPwabuilderExe(options, appImages, webManifest, actionsFiles, outputDirectory, pwaBuilderFilePath, pwaBuilderArgs);
+            return await RunPwabuilderExe(options, appImages, webManifest, actionsFiles, outputDirectory, pwaBuilderFilePath, pwaBuilderArgs, cancelToken);
         }
 
-        private async Task<PwaBuilderCommandLineResult> RunPwabuilderExe(WindowsAppPackageOptions options, ImageGeneratorResult appImages, WebAppManifestContext webManifest, WindowsActionsFiles? actionsFiles, string outputDirectory, string pwaBuilderFilePath, string pwaBuilderArgs)
+        private async Task<PwaBuilderCommandLineResult> RunPwabuilderExe(WindowsAppPackageOptions options, ImageGeneratorResult appImages, WebAppManifestContext webManifest, WindowsActionsFiles? actionsFiles, string outputDirectory, string pwaBuilderFilePath, string pwaBuilderArgs, CancellationToken cancelToken)
         {
             ProcessResult procResult;
             try
             {
-                procResult = await procRunner.Run(pwaBuilderFilePath, pwaBuilderArgs, TimeSpan.FromMinutes(10));
+                procResult = await procRunner.Run(pwaBuilderFilePath, pwaBuilderArgs, TimeSpan.FromMinutes(10), cancellationToken: cancelToken);
                 logger.LogWarning("Raw args passed to pwa_builder {args}", pwaBuilderArgs);
             }
-            catch (Exception error)
+            catch (Exception error) when (error is not OperationCanceledException)
             {
                 var stdOut = (error as ProcessException)?.StandardOutput;
                 var stdErr = (error as ProcessException)?.StandardError;

--- a/apps/pwabuilder-microsoft-store/Services/SpartanWindowsPackageCreator.cs
+++ b/apps/pwabuilder-microsoft-store/Services/SpartanWindowsPackageCreator.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 
@@ -33,17 +34,22 @@ namespace PWABuilder.MicrosoftStore
         /// Creates the classic Windows app package. Returns the file path to the generated app package.
         /// </summary>
         /// <param name="options">The package creation options.</param>
+        /// <param name="webManifest">The PWA manifest.</param>
+        /// <param name="appImages">The generated app images.</param>
+        /// <param name="outputDirectory">The package output directory.</param>
+        /// <param name="cancelToken">Cancels packaging and native tools.</param>
         /// <returns></returns>
-        public async Task<SpartanWindowsPackageResult> Create(WindowsAppPackageOptions options, WebAppManifestContext webManifest, ImageGeneratorResult appImages, string outputDirectory)
+        public async Task<SpartanWindowsPackageResult> Create(WindowsAppPackageOptions options, WebAppManifestContext webManifest, ImageGeneratorResult appImages, string outputDirectory, CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             var appxTemplatePath = settings.SpartanWindowsAppPackagePath;
             var version = GetSpartanVersion(options).WithZeroRevision();
 
             // Create a new appx from the SpartanWindowsAppPackage.appx template.
-            var updatedAppxResult = await this.GenerateAppx(appxTemplatePath, version, options, webManifest, appImages, outputDirectory);
+            var updatedAppxResult = await this.GenerateAppx(appxTemplatePath, version, options, webManifest, appImages, outputDirectory, cancelToken);
 
             // Bundle it.
-            var appxBundlePath = await this.makeAppx.Bundle(updatedAppxResult.AppxFilePath, version);
+            var appxBundlePath = await this.makeAppx.Bundle(updatedAppxResult.AppxFilePath, version, cancelToken);
 
             return new SpartanWindowsPackageResult
             {

--- a/apps/pwabuilder-microsoft-store/Services/WebManifestFinder.cs
+++ b/apps/pwabuilder-microsoft-store/Services/WebManifestFinder.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PWABuilder.MicrosoftStore
@@ -34,8 +35,9 @@ namespace PWABuilder.MicrosoftStore
             this.temp = temp;
         }
 
-        private async Task GenerateManifestFile(WindowsAppPackageOptions options)
+        private async Task GenerateManifestFile(WindowsAppPackageOptions options, CancellationToken cancelToken)
         {
+            cancelToken.ThrowIfCancellationRequested();
             var manifestFilePath = temp.CreateFile(".json");
 
             try
@@ -48,11 +50,11 @@ namespace PWABuilder.MicrosoftStore
                     : JsonSerializer.Serialize(options.Manifest);
                 using (StreamWriter writer = new StreamWriter(manifestFilePath))
                 {
-                    await writer.WriteAsync(jsonString);
+                    await writer.WriteAsync(jsonString.AsMemory(), cancelToken);
                 }
                 options.ManifestFilePath = manifestFilePath;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 Console.WriteLine($"An error occurred: {ex.Message}");
             }
@@ -64,16 +66,18 @@ namespace PWABuilder.MicrosoftStore
         /// Gets the web app manifest for the PWA.
         /// </summary>
         /// <param name="options"></param>
+        /// <param name="cancelToken">Cancels manifest discovery, downloading, and writing.</param>
         /// <returns></returns>
-        public async Task<WebAppManifestContext> Find(WindowsAppPackageOptions options)
+        public async Task<WebAppManifestContext> Find(WindowsAppPackageOptions options, CancellationToken cancelToken = default)
         {
+            cancelToken.ThrowIfCancellationRequested();
             // If we have a manifest and a manifest URL, use those.
             var manifestUri = options.ManifestUrl;
             if (options.Manifest == null && manifestUri != null)
             {
-                var rawManifest = await TryFetchManifestFrom(manifestUri, options);
+                var rawManifest = await TryFetchManifestFrom(manifestUri, options, cancelToken);
                 options.Manifest = rawManifest;
-                await GenerateManifestFile(options);
+                await GenerateManifestFile(options, cancelToken);
                 return WebAppManifestContext.From(options.Manifest!, manifestUri);
             }
 
@@ -81,7 +85,7 @@ namespace PWABuilder.MicrosoftStore
             if (options.Manifest != null && options.EnableWebAppWidgets != true)
             {
                 options.UsePWABuilderWithCustomManifest = true;
-                await GenerateManifestFile(options);
+                await GenerateManifestFile(options, cancelToken);
                 return WebAppManifestContext.From(options.Manifest, manifestUri != null ? manifestUri : options.Url);
             }
 
@@ -89,13 +93,13 @@ namespace PWABuilder.MicrosoftStore
             var pwaUri = options.Url;
 
             var apiUrl = webManifestFinderServiceUrl + $"?site={Uri.EscapeDataString(pwaUri.ToString())}";
-            var jsonResult = await InvokeManifestFinderService(apiUrl);
+            var jsonResult = await InvokeManifestFinderService(apiUrl, cancelToken);
             var manifestResult = DeserializeJson(jsonResult);
 
             if (manifestResult.content?.json != null && Uri.TryCreate(manifestResult.content.url, UriKind.Absolute, out var discoveredManifestUri))
             {
                 options.Manifest = manifestResult.content?.json;
-                await GenerateManifestFile(options);
+                await GenerateManifestFile(options, cancelToken);
                 return WebAppManifestContext.From(manifestResult.content!.json, discoveredManifestUri);
             }
 
@@ -123,35 +127,36 @@ namespace PWABuilder.MicrosoftStore
             }
         }
 
-        private async Task<string> InvokeManifestFinderService(string apiUrl)
+        private async Task<string> InvokeManifestFinderService(string apiUrl, CancellationToken cancelToken)
         {
             try
             {
                 using var httpGetMessage = new HttpRequestMessage(HttpMethod.Get, apiUrl);
                 httpGetMessage.Version = new Version(2, 0);
-                using var manifestResponse = await this.http.SendAsync(httpGetMessage);
+                using var manifestResponse = await this.http.SendAsync(httpGetMessage, cancelToken);
                 manifestResponse.EnsureSuccessStatusCode();
-                return await manifestResponse.Content.ReadAsStringAsync();
+                return await manifestResponse.Content.ReadAsStringAsync(cancelToken);
             }
-            catch (Exception httpError)
+            catch (Exception httpError) when (httpError is not OperationCanceledException)
             {
                 logger.LogError(httpError, "Unable to fetch manifest via manifest finder service. The call to {url} failed.", apiUrl);
                 throw new InvalidOperationException("Unable to fetch manifest via manifest finder service. The call to " + apiUrl + " failed");
             }
         }
 
-        private async Task<JsonDocument?> TryFetchManifestFrom(Uri manifestUrl, WindowsAppPackageOptions options)
+        private async Task<JsonDocument?> TryFetchManifestFrom(Uri manifestUrl, WindowsAppPackageOptions options, CancellationToken cancelToken)
         {
             try
             {
                 using var manifestFetchMessage = new HttpRequestMessage(HttpMethod.Get, manifestUrl);
                 manifestFetchMessage.Version = new Version(2, 0);
-                using var manifestResponse = await this.http.SendAsync(manifestFetchMessage);
+                using var manifestResponse = await this.http.SendAsync(manifestFetchMessage, cancelToken);
                 manifestResponse.EnsureSuccessStatusCode();
-                var manifestJson = await JsonDocument.ParseAsync(await manifestResponse.Content.ReadAsStreamAsync());
+                await using var stream = await manifestResponse.Content.ReadAsStreamAsync(cancelToken);
+                var manifestJson = await JsonDocument.ParseAsync(stream, cancellationToken: cancelToken);
                 return manifestJson;
             }
-            catch (Exception manifestFetchError)
+            catch (Exception manifestFetchError) when (manifestFetchError is not OperationCanceledException)
             {
                 logger.LogWarning(manifestFetchError, "Unable to fetch manifest using {url}", manifestUrl);
                 return null;

--- a/apps/pwabuilder-microsoft-store/Services/WindowsAppPackageCreator.cs
+++ b/apps/pwabuilder-microsoft-store/Services/WindowsAppPackageCreator.cs
@@ -65,6 +65,29 @@ namespace PWABuilder.MicrosoftStore.Services
         /// <returns></returns>
         public async Task<WindowsAppPackageResult> CreateAppPackageAsync(WindowsAppPackageOptions options, AnalyticsInfo analyticsInfo, CancellationToken cancelToken)
         {
+            try
+            {
+                var package = await CreateAppPackageFileAsync(options, analyticsInfo, cancelToken);
+                var zipBytes = await File.ReadAllBytesAsync(package.FilePath, cancelToken);
+                return new WindowsAppPackageResult(package.ModernAppPackage, package.ClassicAppPackage, package.EdgeHtmlAppPackage, zipBytes);
+            }
+            finally
+            {
+                temp.CleanUp();
+            }
+        }
+
+        /// <summary>
+        /// Builds a ZIP package on disk without loading it into memory. The owning dependency-injection scope
+        /// must remain alive until the caller finishes reading or uploading the file.
+        /// </summary>
+        /// <param name="options">The Windows package options.</param>
+        /// <param name="analyticsInfo">The analytics context for this build.</param>
+        /// <param name="cancelToken">Cancels downloads, file operations, and native packaging tools.</param>
+        /// <returns>The generated ZIP path and modern package metadata.</returns>
+        public async Task<WindowsAppPackageFileResult> CreateAppPackageFileAsync(WindowsAppPackageOptions options, AnalyticsInfo analyticsInfo, CancellationToken cancelToken)
+        {
+            cancelToken.ThrowIfCancellationRequested();
             ValidateOptions(options);
 
             // COMMENTED OUT 2/25/2026 - This code had unintended consequences. For example, this code would detect https://app.eyegifs.com redirects to https://app.eyegifs.com/account/login. But if the user is logged in, we want the PWA to keep the original url and not redirect to login.
@@ -84,15 +107,11 @@ namespace PWABuilder.MicrosoftStore.Services
                 await analytics.RecordStorePackageSuccess(options, packageType, analyticsInfo);
                 return zipResult;
             }
-            catch (Exception error)
+            catch (Exception error) when (error is not OperationCanceledException)
             {
                 logger.LogError(error, "Error generating app package for {url}", options.Url);
                 await analytics.RecordStorePackageFailure(error, options, packageType, analyticsInfo);
                 throw;
-            }
-            finally
-            {
-                temp.CleanUp();
             }
         }
 
@@ -102,12 +121,13 @@ namespace PWABuilder.MicrosoftStore.Services
         /// <returns></returns>
         public async Task<MsixResult> CreateMsixAsync(WindowsAppPackageOptions options, CancellationToken cancelToken)
         {
+            cancelToken.ThrowIfCancellationRequested();
             ValidateOptions(options);
             try
             {
                 return await GenerateMsix(options, cancelToken);
             }
-            catch (Exception error)
+            catch (Exception error) when (error is not OperationCanceledException)
             {
                 logger.LogError(error, "Error generating MSIX for {url}", options.Url);
                 throw;
@@ -159,33 +179,38 @@ namespace PWABuilder.MicrosoftStore.Services
 
         private async Task<MsixResult> GenerateMsix(WindowsAppPackageOptions options, CancellationToken cancelToken)
         {
-            var manifest = await manifestFinder.Find(options);
-            var appImages = await GenerateImages(options, manifest);
+            var manifest = await manifestFinder.Find(options, cancelToken);
+            var appImages = await GenerateImages(options, manifest, cancelToken);
             var package = await this.CreateModernWindowsPackage(options, appImages, manifest, cancelToken);
             if (package == null)
             {
                 throw new InvalidOperationException("Attempted to generate MSIX file, but passed in options to skip generating the modern package.");
             }
 
-            var msixBytes = await File.ReadAllBytesAsync(package.StoreMsixFilePath);
+            var msixBytes = await File.ReadAllBytesAsync(package.StoreMsixFilePath, cancelToken);
             return new MsixResult(package, msixBytes);
         }
 
-        private async Task<WindowsAppPackageResult> GenerateZipAsync(WindowsAppPackageOptions options, CancellationToken cancelToken)
+        private async Task<WindowsAppPackageFileResult> GenerateZipAsync(WindowsAppPackageOptions options, CancellationToken cancelToken)
         {
-            var manifest = await manifestFinder.Find(options);
-            var appImages = await GenerateImages(options, manifest);
+            var manifest = await manifestFinder.Find(options, cancelToken);
+            var appImages = await GenerateImages(options, manifest, cancelToken);
             //Todo: instead of adding filepath to the options, pass it to the filepath directly
             var modernPackage = await this.CreateModernWindowsPackage(options, appImages, manifest, cancelToken);
-            var classicPackage = await CreateClassicWindowsPackage(options, manifest, appImages, modernPackage?.PackageInfo.GetAppId());
-            var spartanPackage = await CreateSpartanWindowsPackage(options, manifest, appImages);
-            var zipFilePath = await CreateZipPackage(options, modernPackage, classicPackage, spartanPackage);
-            var zipBytes = await File.ReadAllBytesAsync(zipFilePath);
-            return new WindowsAppPackageResult(modernPackage, classicPackage, spartanPackage, zipBytes);
+            var classicPackage = await CreateClassicWindowsPackage(options, manifest, appImages, modernPackage?.PackageInfo.GetAppId(), cancelToken);
+            var spartanPackage = await CreateSpartanWindowsPackage(options, manifest, appImages, cancelToken);
+            var zipFilePath = await CreateZipPackage(options, modernPackage, classicPackage, spartanPackage, cancelToken);
+            cancelToken.ThrowIfCancellationRequested();
+            return new WindowsAppPackageFileResult(zipFilePath, modernPackage)
+            {
+                ClassicAppPackage = classicPackage,
+                EdgeHtmlAppPackage = spartanPackage
+            };
         }
 
         private async Task<ModernWindowsPackageResult?> CreateModernWindowsPackage(WindowsAppPackageOptions options, ImageGeneratorResult appImages, WebAppManifestContext webManifest, CancellationToken cancelToken)
         {
+            cancelToken.ThrowIfCancellationRequested();
             if (options.GenerateModernPackage)
             {
                 var outputDirectory = temp.CreateDirectory("modernpackage-" + Guid.NewGuid());
@@ -195,31 +220,34 @@ namespace PWABuilder.MicrosoftStore.Services
             return null;
         }
 
-        private async Task<ClassicWindowsPackageResult?> CreateClassicWindowsPackage(WindowsAppPackageOptions options, WebAppManifestContext manifest, ImageGeneratorResult appImages, string? edgeAppId)
+        private async Task<ClassicWindowsPackageResult?> CreateClassicWindowsPackage(WindowsAppPackageOptions options, WebAppManifestContext manifest, ImageGeneratorResult appImages, string? edgeAppId, CancellationToken cancelToken)
         {
+            cancelToken.ThrowIfCancellationRequested();
             if (options.ClassicPackage?.Generate == true)
             {
                 var outputDirectory = temp.CreateDirectory("classic-package-" + Guid.NewGuid().ToString());
-                return await this.classicPackageCreator.Create(options, manifest, appImages, outputDirectory, edgeAppId);
+                return await this.classicPackageCreator.Create(options, manifest, appImages, outputDirectory, edgeAppId, cancelToken);
             }
 
             return null;
         }
 
-        private async Task<SpartanWindowsPackageResult?> CreateSpartanWindowsPackage(WindowsAppPackageOptions options, WebAppManifestContext webManifest, ImageGeneratorResult appImages)
+        private async Task<SpartanWindowsPackageResult?> CreateSpartanWindowsPackage(WindowsAppPackageOptions options, WebAppManifestContext webManifest, ImageGeneratorResult appImages, CancellationToken cancelToken)
         {
+            cancelToken.ThrowIfCancellationRequested();
             if (options.EdgeHtmlPackage?.Generate == true)
             {
                 var outputDirectory = temp.CreateDirectory("spartan-package-" + Guid.NewGuid().ToString());
-                return await this.spartanPackageCreator.Create(options, webManifest, appImages, outputDirectory);
+                return await this.spartanPackageCreator.Create(options, webManifest, appImages, outputDirectory, cancelToken);
             }
 
             return null;
         }
 
 
-        private async Task<string> CreateZipPackage(WindowsAppPackageOptions options, ModernWindowsPackageResult? modernPackage, ClassicWindowsPackageResult? classicPackage, SpartanWindowsPackageResult? spartanPackage)
+        private async Task<string> CreateZipPackage(WindowsAppPackageOptions options, ModernWindowsPackageResult? modernPackage, ClassicWindowsPackageResult? classicPackage, SpartanWindowsPackageResult? spartanPackage, CancellationToken cancelToken)
         {
+            cancelToken.ThrowIfCancellationRequested();
             var zipFilePath = temp.CreateFile();
             using var zipFile = File.Create(zipFilePath);
             using var zipArchive = new ZipArchive(zipFile, ZipArchiveMode.Create);
@@ -234,56 +262,70 @@ namespace PWABuilder.MicrosoftStore.Services
             if (modernPackage != null)
             {
                 var msixFileName = $"{appFileName}.msixbundle";
-                zipArchive.CreateEntryFromFile(modernPackage.StoreMsixFilePath, msixFileName);
+                AddFileToZip(zipArchive, modernPackage.StoreMsixFilePath, msixFileName, cancelToken);
 
                 // Append the sideload msix for developer testing on a Windows box.
                 var sideLoadMsixFileName = $"{appFileName}.sideload.msix";
-                zipArchive.CreateEntryFromFile(modernPackage.SideLoadMsixFilePath, sideLoadMsixFileName);
+                AddFileToZip(zipArchive, modernPackage.SideLoadMsixFilePath, sideLoadMsixFileName, cancelToken);
 
                 // Append the install.ps1 script for installing the sideload modern app package.
-                var powerShellInstallScriptTemplate = await File.ReadAllTextAsync(settings.InstallScriptPath);
+                var powerShellInstallScriptTemplate = await File.ReadAllTextAsync(settings.InstallScriptPath, cancelToken);
                 var powerShellInstallScript = MaterializePowershellTemplate(powerShellInstallScriptTemplate, appName, sideLoadMsixFileName);
                 await zipArchive.CreateEntryFromString(powerShellInstallScript, "install.ps1");
+                cancelToken.ThrowIfCancellationRequested();
 
                 // Append the pwainstaller.exe tool which the install.ps1 script uses to install the app locally.
                 var installerPath = Path.Combine(host.ContentRootPath, settings.PwaInstallerPath);
-                zipArchive.CreateEntryFromFile(installerPath, "utils\\pwainstaller.exe");
+                AddFileToZip(zipArchive, installerPath, "utils\\pwainstaller.exe", cancelToken);
 
                 // Append next-steps readme
-                zipArchive.CreateEntryFromFile(settings.ReadmePath, "readme.html");
+                AddFileToZip(zipArchive, settings.ReadmePath, "readme.html", cancelToken);
             }
 
             // Append the classic package.
             if (classicPackage != null)
             {
-                zipArchive.CreateEntryFromFile(classicPackage.AppxFilePath, $"{appFileName}.classic.appxbundle");
+                AddFileToZip(zipArchive, classicPackage.AppxFilePath, $"{appFileName}.classic.appxbundle", cancelToken);
             }
 
             // Append the EdgeHTML (Spartan) package.
             if (spartanPackage != null)
             {
                 // The package itself.
-                zipArchive.CreateEntryFromFile(spartanPackage.AppxPath, $"{appFileName}.edgehtml.appxbundle");
+                AddFileToZip(zipArchive, spartanPackage.AppxPath, $"{appFileName}.edgehtml.appxbundle", cancelToken);
 
                 // The directory used for sideloading the app.
                 zipArchive.CreateEntryFromDirectory(spartanPackage.AppxLooseFilesDirectory, "EdgeHTML-sideload");
+                cancelToken.ThrowIfCancellationRequested();
 
                 // The sideload install script.
-                var powerShellInstallScriptTemplate = await File.ReadAllTextAsync(settings.SpartanInstallScriptPath);
+                var powerShellInstallScriptTemplate = await File.ReadAllTextAsync(settings.SpartanInstallScriptPath, cancelToken);
                 var powerShellInstallScript = MaterializePowershellTemplate(powerShellInstallScriptTemplate, appName, string.Empty);
                 await zipArchive.CreateEntryFromString(powerShellInstallScript, "install-edgehtml.ps1");
+                cancelToken.ThrowIfCancellationRequested();
 
                 // The Spartan next steps readme.
-                zipArchive.CreateEntryFromFile(settings.SpartanReadmePath, options.GenerateModernPackage ? "readme-edgehtml.html" : "readme.html");
+                AddFileToZip(zipArchive, settings.SpartanReadmePath, options.GenerateModernPackage ? "readme-edgehtml.html" : "readme.html", cancelToken);
             }
 
             return zipFilePath;
         }
 
-        private Task<ImageGeneratorResult> GenerateImages(WindowsAppPackageOptions options, WebAppManifestContext manifest)
+        /// <summary>
+        /// Checks cancellation around synchronous ZIP compression.
+        /// </summary>
+        private static void AddFileToZip(ZipArchive archive, string sourcePath, string entryName, CancellationToken cancelToken)
         {
+            cancelToken.ThrowIfCancellationRequested();
+            archive.CreateEntryFromFile(sourcePath, entryName);
+            cancelToken.ThrowIfCancellationRequested();
+        }
+
+        private Task<ImageGeneratorResult> GenerateImages(WindowsAppPackageOptions options, WebAppManifestContext manifest, CancellationToken cancelToken)
+        {
+            cancelToken.ThrowIfCancellationRequested();
             var imagesDir = temp.CreateDirectory("app-images-" + Guid.NewGuid());
-            return this.imageGenerator.Generate(options, manifest, imagesDir);
+            return this.imageGenerator.Generate(options, manifest, imagesDir, cancelToken);
         }
 
         private string MaterializePowershellTemplate(string powerShellTemplate, string appName, string msixFileName)

--- a/apps/pwabuilder-microsoft-store/Startup.cs
+++ b/apps/pwabuilder-microsoft-store/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using PWABuilder.MicrosoftStore.Common;
+using PWABuilder.MicrosoftStore.Jobs;
 using PWABuilder.MicrosoftStore.Models;
 using PWABuilder.MicrosoftStore.Services;
 
@@ -81,6 +82,7 @@ public class Startup
             );
 
         services.AddControllers();
+        services.AddWindowsPackageJobs(Configuration);
     }
 
     static ApplicationInsightsServiceOptions setUpAppInsights(IConfigurationSection appSettings)

--- a/apps/pwabuilder-microsoft-store/readme.md
+++ b/apps/pwabuilder-microsoft-store/readme.md
@@ -31,7 +31,7 @@ PWABuilder.com today calls the `/msix/generateZip` endpoint, which creates a mod
 
 ## The API
 
-The web API exposes 6 endpoints:
+The web API exposes these synchronous endpoints:
 
 - `/msix/generateZip` - generates a zip file containing the .msixbundle file that runs on newer versions of Windows, a classic .appx package that runs on older versions of Windows, and a .sideload.msix package that can run locally on a developer's machine. This is the API called by pwabuilder.com's frontend.
 - `/msix/generate` - generates a single .msix package
@@ -39,6 +39,8 @@ The web API exposes 6 endpoints:
 - `/msix/updatePackage` - updates the Package ID, Publisher ID, and Publisher Display Name of an existing PWA app package.
 - `/msix/bundle` - accepts a .appx or .msix and creates a bundle file from it.
 - `/msix/createPackageFromLoose` - accepts a .zip file containing loose layout app files (e.g. AppxManifest.xml, resources.pri, Images, etc.) and generates a .msix package from it.
+
+An opt-in asynchronous packaging API is described in [Queued Windows packaging](#queued-windows-packaging-opt-in).
 
 ## Usage
 
@@ -195,6 +197,72 @@ To call `create` or `createZip`, issue a HTTP POST to `/msix/generate` or `/msix
 The following fields are required: `version`, `url`, `packageId`. All other fields are optional.
 
 Note the `usePwaBuilderWithCustomManifest` flag can be used to use a different manifest than the one used by the PWA. This can be used for testing manifests for non-public websites or non-public manifests, or to force a different manifest for an existing site. If the flag is set to true, the package will be created using the manifest specified by `manifestUrl`, disregarding the manifest actually used by the site. This is discouraged as it can cause problems related to app identity - speak to Mustapaha Jaber for more details - but it can be useful in creating prototypes or test packages. It does this using the old v91 of pwa_builder.exe tool.
+
+### Queued Windows packaging (opt-in)
+
+The asynchronous API runs alongside `/msix/generateZip`; existing callers and response formats are unchanged. It is disabled by default. Enabling it requires provisioning Azure resources and configuring the service; deploying code alone does not enable it.
+
+#### Resources and configuration
+
+Use separate resources for production and staging even when both deployments set `ASPNETCORE_ENVIRONMENT=Production`. For example, provision the queues and Blob container in `pwabuildercommon`, and the job container in the existing Cosmos database:
+
+- Queues `windows-package-jobs-prod` and `windows-package-jobs-prod-poison`; use `-nonprod` and `-nonprod-poison` for staging.
+- A **private** Blob container `windows-package-jobs-prod` for `inputs/` and `artifacts/`.
+- A **dedicated** Cosmos container `windows-package-jobs-prod`, partition key `/id`, default TTL `-1` (TTL enabled with per-document expiration), in the database configured by `AppSettings.CosmosDbDatabaseName`. Keep the default indexing policy for outbox queries. Do not reuse the package analytics container.
+
+Grant the service's managed identity access to these specific resources: Storage Queue Data Contributor (including the poison queue), Storage Blob Data Contributor, and Cosmos DB Built-in Data Contributor for the job container. The existing `AppSettings.AzureManagedIdentityApplicationId` selects a user-assigned identity; omit it to use the system-assigned identity. Provision resources separately; workers do not create queues, Blob containers, or Cosmos containers.
+
+Configure this top-level section through deployment settings (double underscores for environment variables):
+
+```json
+{
+  "WindowsPackageJobs": {
+    "Enabled": true,
+    "QueueServiceUri": "https://pwabuildercommon.queue.core.windows.net",
+    "QueueName": "windows-package-jobs-prod",
+    "BlobServiceUri": "https://pwabuildercommon.blob.core.windows.net",
+    "BlobContainerName": "windows-package-jobs-prod",
+    "CosmosContainerName": "windows-package-jobs-prod",
+    "RunWorkers": true,
+    "WorkerCount": 1,
+    "MaxAttempts": 3,
+    "JobLifetimeHours": 168,
+    "AttemptTimeoutMinutes": 30,
+    "VisibilitySeconds": 120,
+    "RenewalSeconds": 30,
+    "PollSeconds": 2,
+    "RetryDelaySeconds": 30
+  }
+}
+```
+
+`AppSettings.CosmosDbEndpoint` and `AppSettings.CosmosDbDatabaseName` must also be configured. `RenewalSeconds` must be at most one third of `VisibilitySeconds`. Retention and attempt deadlines are configurable; jobs are not discarded merely because a browser stopped polling.
+
+Enable Blob lifecycle deletion for both `inputs/` and `artifacts/` after **at least `JobLifetimeHours / 24 + 1` days**, rounded up. This removes abandoned inputs, stale attempt artifacts, and completed downloads. Cosmos job TTL includes an additional day; the API enforces `ExpiresAt` independently of storage cleanup.
+
+#### Calling the API
+
+1. `POST /msix/enqueuePackageJob` with the same JSON options as `/msix/generateZip`. Optional `platform-identifier`, `platform-identifier-version`, `correlation-id`, and `?ref=` attribution are persisted with the job. A valid request returns **202 Accepted**, a job status body, a polling `Location`, and `Retry-After`.
+2. `GET /msix/getPackageJob?id=<id>` returns `Queued`, `InProgress`, `Completed`, `Failed`, or `Expired`, plus timestamps, attempt count, and a safe error description. It does not expose the input manifest, options, logs, or storage paths.
+3. `GET /msix/downloadPackageZip?id=<id>` streams the completed ZIP from private Blob Storage. It returns 409 if not completed, 410 if expired, or 404 for an unknown job.
+
+Requests to the asynchronous API return 503 while the feature is disabled. Invalid packaging options return 400 before any job is accepted. Enqueue requests have a 2 MiB body limit.
+
+Job IDs are random bearer capabilities: anyone with an ID can poll and download that job. Treat IDs and polling URLs as sensitive, use HTTPS, and do not publish them. The platform header is self-reported attribution, **not authentication**. Put partner authentication and rate limits at the gateway before enabling this for partner traffic. The API returns only safe error summaries; detailed failures remain in server logs.
+
+#### Delivery, recovery, and scaling
+
+Inputs are saved to Blob Storage, then a Cosmos job with a pending-dispatch flag is persisted before returning 202. A dispatcher retries pending records until their job-ID-only queue messages have been sent. A crash between sending and clearing the flag can duplicate delivery, but does not lose an accepted job.
+
+Workers receive messages **without deleting them**, claim jobs through Cosmos ETag conditional writes, and renew both queue visibility and job ownership while building. Ownership loss, shutdown, expiration, and attempt deadlines cancel builds and their native child processes. A fresh DI scope owns each build's temporary files.
+
+Artifacts are uploaded to attempt-specific Blob paths. The worker conditionally persists completion before acknowledging the latest queue receipt. Terminal redeliveries do not rebuild packages. This is **at-least-once**, not exactly-once execution: a crash can cause an unfinished attempt to run again. Failed attempts retry with bounded exponential delay; exhausted jobs are persisted as failed and copied to the poison queue before acknowledgement. Poison entries can duplicate and must not be automatically replayed without investigating the failure.
+
+Keep the returned job ID and poll it rather than resubmitting the POST. Each new POST currently creates a new job; the correlation ID is tracing metadata, not a deduplication key.
+
+Start with one queued build per Windows instance and tune against representative package sizes, widget builds, child-process memory/CPU, and temporary-disk usage. Scale on queue age/depth and resource usage. Legacy synchronous endpoints do not share this worker limit. For strict partner isolation, use a separate Windows deployment/compute plan. `RunWorkers=false` supports API-only instances; these still dispatch accepted jobs, while another enabled deployment with the same resource configuration must run workers.
+
+Monitor pending-dispatch records, queue age/depth, failed renewal logs, poison deliveries, and terminal jobs by `PlatformId`. Do not configure a busy-but-healthy worker to restart solely because its queue has a backlog. Keep Windows instances warm and allow graceful shutdown; interrupted jobs recover through visibility/ownership expiration.
 
 ### `/msix/isPwaPackage`
 


### PR DESCRIPTION
Related issue: N/A.
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
- Documentation content changes
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->

Windows packaging holds HTTP requests open while native tools build packages. Increased partner traffic needs durable acceptance, crash recovery, and bounded background processing without breaking existing PWABuilder clients.

## Describe the new behavior?

Adds an opt-in asynchronous API alongside the unchanged `/msix/generateZip` endpoint:

- `POST /msix/enqueuePackageJob` durably accepts packaging options and returns a job ID and polling location.
- `GET /msix/getPackageJob` exposes safe job status; `GET /msix/downloadPackageZip` streams the completed ZIP.
- Private Blob Storage holds inputs/artifacts, Cosmos stores job state and pending dispatch, and Azure Queue Storage carries job IDs. The outbox recovers dispatch failures; completion is persisted before queue acknowledgement.
- Bounded workers renew ownership and queue visibility, retry interrupted work, and poison exhausted jobs. Attempt-specific artifacts and conditional writes fence stale workers. Cancellation propagates to owned native process trees.

Existing platform/correlation headers remain supported and are persisted with queued jobs. The README documents resource isolation, managed-identity permissions, retention, configuration, and scaling; CI now runs the Windows test project.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass. N/A for this C# service; the Release .NET suite passed all 87 tests.
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes. N/A: no UI changes.

## Additional Information

**Disabled by default.** Provision separate production/nonproduction queues, private Blob storage, a dedicated Cosmos job container, and managed-identity permissions before setting `WindowsPackageJobs.Enabled=true`. No live Azure resources were changed.

Delivery is at-least-once: duplicate delivery is handled per job, but each POST creates a new job. Job IDs are bearer capabilities; caller headers are attribution, not authentication. Partner authentication and quotas belong at the gateway. Legacy synchronous calls do not share the worker concurrency limit.

Coverage includes crash/retry recovery, renewal/completion races, SDK storage contracts, HTTP routes, cancellation, and legacy compatibility. Live Azure and actual Windows SDK end-to-end packaging have not been exercised.