### PR TITLE
Fix CloudAPK Gradle code injection

### DIFF
--- a/apps/pwabuilder-google-play/README.md
+++ b/apps/pwabuilder-google-play/README.md
@@ -40,3 +40,34 @@ Once a Google Play app package has been generated, follow the steps on [Next Ste
 ## Deploy
 
 Deploys are automatically pushed to cloudapk/staging slot. To deploy to production, swap staging and production.
+
+### Android build input security
+
+Packaging options are untrusted, including options loaded from queued jobs. The
+HTTP validator checks DNS hosts (also accepting HTTPS prefixes, ports, IDNs, and
+legacy path prefixes) and the runtime types of Gradle scalar inputs. The worker
+revalidates before project generation and only forwards supported manifest fields
+and features to Bubblewrap.
+
+`scripts/patch-bubblewrap-gradle.mjs` patches Bubblewrap 1.25.0's Gradle template
+and shortcut URL serializer. Strings are encoded as single-quoted Groovy literals,
+not interpolated GStrings; numbers and booleans are type-checked at the template
+boundary. The patch checks the dependency version and complete source hashes and
+fails closed on unreviewed changes. Remove it only after an upstream release
+secures the same sinks and the regression tests pass.
+
+The patch runs during installation, build, and npm start/dev. Docker deliberately
+installs with `--ignore-scripts`, then applies it through `npm run build`. Do not
+deploy an install made with `--ignore-scripts` without running the build. Run
+`npm test` for validation, real-template rendering, patch lifecycle, and isolated
+HTTP-route regressions; these do not execute Gradle or contact production.
+
+This code fix does not isolate the build process from the service's identity,
+other jobs, or signing material. Following a reported production code execution,
+pause packaging and involve incident response: replace affected workers, review
+queued jobs and build artifacts, investigate identity/storage access, and rotate
+potentially exposed credentials and signing material as appropriate. Deploy the
+patched image to every slot/worker before resuming. Separately move builds into
+per-job, non-root sandboxes without backend credentials or managed-identity access;
+keep signing and artifact publication outside those sandboxes. Running as non-root
+alone does not remove managed-identity access.

--- a/apps/pwabuilder-google-play/package.json
+++ b/apps/pwabuilder-google-play/package.json
@@ -6,10 +6,12 @@
     "type": "module",
     "scripts": {
         "start": "node ./server.js",
-        "postinstall": "tsc",
+        "postinstall": "npm run build",
+        "prestart": "node ./scripts/patch-bubblewrap-gradle.mjs",
+        "predev": "node ./scripts/patch-bubblewrap-gradle.mjs",
         "dev": "cross-env NODE_ENV=development node --inspect=5858 --loader ts-node/esm ./server.ts",
-        "test": "npm run build && node --test ./tests/signing-options-validation.test.js ./tests/safe-key-tool.test.js ./tests/redact-secrets.test.js ./tests/key-tool-integration.test.js ./tests/signing-command-credentials.test.js ./tests/public-url-fetch.test.js ./tests/cloudflare-detection.test.js ./tests/package-job-id.test.js",
-        "prebuild": "node ./scripts/patch-jimp-file-type.mjs",
+        "test": "npm run build && node --test ./tests/signing-options-validation.test.js ./tests/gradle-injection.test.js ./tests/bubblewrap-gradle-patch.test.mjs ./tests/android-package-routes.test.mjs ./tests/safe-key-tool.test.js ./tests/redact-secrets.test.js ./tests/key-tool-integration.test.js ./tests/signing-command-credentials.test.js ./tests/public-url-fetch.test.js ./tests/cloudflare-detection.test.js ./tests/package-job-id.test.js",
+        "prebuild": "node ./scripts/patch-jimp-file-type.mjs && node ./scripts/patch-bubblewrap-gradle.mjs",
         "build": "tsc --noEmitOnError",
         "docker:build": "npm run build && docker build -t cloud-apk .",
         "docker:run": "docker run -p 5779:5858 -e NODE_ENV=development cloud-apk"

--- a/apps/pwabuilder-google-play/scripts/patch-bubblewrap-gradle.mjs
+++ b/apps/pwabuilder-google-play/scripts/patch-bubblewrap-gradle.mjs
@@ -1,0 +1,128 @@
+import { createHash } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// Bubblewrap 1.25.0 interpolates request data into executable Groovy. Keep this
+// local patch until upstream encodes these sinks; dependency changes must be reviewed.
+// Single-quoted Groovy literals deliberately avoid GString (${...}) interpolation.
+const stringLiteralFunction = String.raw`function gradleString(value) {
+    if (typeof value !== 'string') {
+        throw new Error('Expected a string in the Gradle template');
+    }
+    const escapes = { '\\': '\\\\', "'": "\\'", '\r': '\\r', '\n': '\\n',
+        '\u2028': '\\u2028', '\u2029': '\\u2029' };
+    return "'" + value.replace(/[\\'\r\n\u2028\u2029]/g, character => escapes[character]) + "'";
+}`;
+
+const templatePreamble = `<%\n${stringLiteralFunction}\n` + String.raw`
+function gradleInteger(value) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+        throw new Error('Expected a non-negative safe integer in the Gradle template');
+    }
+    return value;
+}
+function gradleBoolean(value) {
+    if (typeof value !== 'boolean') {
+        throw new Error('Expected a boolean in the Gradle template');
+    }
+    return value;
+}
+function gradleResourceString(value) {
+    // Preserve Bubblewrap's additional Android resource escaping for app names.
+    return gradleString(value.replace(/[\\']/g, '\\$&'));
+}
+%>
+`;
+
+const stringFields = [
+    'packageId', 'host', 'startUrl', 'generatorApp', 'fallbackType', 'orientation',
+    'launchHandlerClientMode', 'webManifestUrl.toString()', 'fullScopeUrl.toString()',
+    'themeColor.hex()', 'themeColorDark.hex()', 'navigationColor.hex()',
+    'navigationColorDark.hex()', 'navigationDividerColor.hex()',
+    'navigationDividerColorDark.hex()', 'backgroundColor.hex()', 'dep',
+];
+const patches = [
+    {
+        path: 'template_project/app/build.gradle',
+        sha256: '8d8c2e53522217487d55a0c21d8e400c458d885086547392a1b813de716e94d9',
+        replacements: [
+            ["import groovy.xml.MarkupBuilder", `${templatePreamble}import groovy.xml.MarkupBuilder`],
+            ...stringFields.map(field => [
+                `'<%= ${field.replace('.toString()', '')} %>'`,
+                `<%= gradleString(${field}) %>`,
+            ]),
+            ...['namespace', 'applicationId'].map(method => [
+                `${method} "<%= packageId %>"`, `${method} <%= gradleString(packageId) %>`,
+            ]),
+            ['versionName "<%= appVersionName %>"', 'versionName <%= gradleString(appVersionName) %>'],
+            ...['name', 'launcherName'].map(field => [
+                `'<%= escapeGradleString(${field}) %>'`,
+                `<%= gradleResourceString(${field}) %>`,
+            ]),
+            ...['splashScreenFadeOutDuration', 'minSdkVersion', 'appVersionCode'].map(field => [
+                `<%= ${field} %>`, `<%= gradleInteger(${field}) %>`,
+            ]),
+            ...['enableNotifications', 'enableSiteSettingsShortcut'].map(field => [
+                `<%= ${field} %>`, `<%= gradleBoolean(${field}) %>`,
+            ]),
+        ],
+    },
+    {
+        path: 'dist/lib/ShortcutInfo.js',
+        sha256: '1eed841c96aff06887910aed04e3c2b59c970555f6a5a7bf1c6d81002855ca9a',
+        replacements: [
+            ['const util_1 = require("./util");', `const util_1 = require("./util");\n${stringLiteralFunction}`],
+            ["url:'${this.url}'", 'url:${gradleString(this.url)}'],
+        ],
+    },
+];
+
+function hash(source) {
+    return createHash('sha256').update(source).digest('hex');
+}
+
+function patchSource(source, patch) {
+    const original = hash(source) === patch.sha256 ? source :
+        [...patch.replacements].reverse().reduce(
+            (text, [before, after]) => text.replaceAll(after, () => before), source);
+    if (hash(original) !== patch.sha256) {
+        throw new Error(`Unexpected Bubblewrap source in ${patch.path}; review the Gradle security patch before upgrading`);
+    }
+    const patched = patch.replacements.reduce((text, [before, after]) => {
+        if (!text.includes(before)) {
+            throw new Error(`Missing Bubblewrap patch context in ${patch.path}`);
+        }
+        return text.replaceAll(before, () => after);
+    }, original);
+    if (source !== original && source !== patched) {
+        throw new Error(`Incomplete Bubblewrap security patch in ${patch.path}`);
+    }
+    return patched;
+}
+
+export async function patchBubblewrapGradle(
+    coreDirectory = new URL('../node_modules/@bubblewrap/core/', import.meta.url)
+) {
+    const packageJson = JSON.parse(await readFile(new URL('package.json', coreDirectory), 'utf8'));
+    if (packageJson.version !== '1.25.0') {
+        throw new Error('Review the Gradle security patch for this Bubblewrap version');
+    }
+
+    // Validate every file before writing anything, and accept only pristine or fully patched files.
+    const files = [];
+    for (const patch of patches) {
+        const path = new URL(patch.path, coreDirectory);
+        const source = await readFile(path, 'utf8');
+        files.push({ path, source, patched: patchSource(source, patch) });
+    }
+    for (const { path, source, patched } of files) {
+        if (source !== patched) {
+            await writeFile(path, patched);
+        }
+    }
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+    await patchBubblewrapGradle();
+}

--- a/apps/pwabuilder-google-play/services/bubbleWrapper.ts
+++ b/apps/pwabuilder-google-play/services/bubbleWrapper.ts
@@ -25,6 +25,7 @@ import { FetchEngine } from '@bubblewrap/core/dist/lib/FetchUtils.js';
 import generatePassword from 'password-generator';
 import { PackageCreationProgress } from "../models/packageCreationProgress.js";
 import EventEmitter from "events";
+import { validateAndroidOptionsRequest } from '../utils/android-options-validation.js';
 
 /*
  * Wraps Google's bubblewrap to build a signed APK from a PWA.
@@ -323,25 +324,12 @@ export class BubbleWrapper {
     }
 
     private createTwaManifest(pwaSettings: AndroidPackageOptions): TwaManifest {
-        // Bubblewrap expects a TwaManifest object.
-        // We create one using our ApkSettings and signing key info.
-
-        // Host without HTTPS: this is needed because the current version of Bubblewrap doesn't handle
-        // a host with protocol specified. Remove the protocol here. See https://github.com/GoogleChromeLabs/bubblewrap/issues/227
-        // NOTE: we cannot use new URL(pwaSettings.host).host, because this breaks PWAs located at subpaths, e.g. https://ics.hutton.ac.uk/gridscore
-        let hostWithoutHttps = pwaSettings.host;
-        const httpsProtocol = 'https://';
-        if (hostWithoutHttps.startsWith(httpsProtocol)) {
-            hostWithoutHttps = hostWithoutHttps.substring(httpsProtocol.length);
+        // Persisted jobs may predate HTTP validation. Revalidate before generating executable code.
+        const request = validateAndroidOptionsRequest(pwaSettings);
+        if (!request.options || request.validationErrors.length > 0) {
+            throw new Error('Invalid PWA settings: ' + request.validationErrors.join(', '));
         }
-
-        // Trim any trailing slash from the host. See https://github.com/pwa-builder/PWABuilder/issues/1221
-        if (hostWithoutHttps.endsWith('/')) {
-            hostWithoutHttps = hostWithoutHttps.substring(
-                0,
-                hostWithoutHttps.length - 1
-            );
-        }
+        pwaSettings = request.options;
 
         const signingKey = {
             path: this.signingKeyInfo?.keyFilePath || '',
@@ -354,8 +342,44 @@ export class BubbleWrapper {
             ? { enabled: true }
             : undefined;
         const manifestJson: TwaManifestJson = {
-            ...pwaSettings,
-            host: hostWithoutHttps,
+            // Do not spread untrusted JSON: undeclared Bubblewrap features can also emit build code.
+            packageId: pwaSettings.packageId,
+            host: pwaSettings.host,
+            name: pwaSettings.name,
+            launcherName: pwaSettings.launcherName,
+            appVersion: pwaSettings.appVersion,
+            appVersionCode: pwaSettings.appVersionCode,
+            startUrl: pwaSettings.startUrl,
+            display: pwaSettings.display,
+            orientation: pwaSettings.orientation,
+            themeColor: pwaSettings.themeColor,
+            themeColorDark: pwaSettings.themeColorDark,
+            backgroundColor: pwaSettings.backgroundColor,
+            navigationColor: pwaSettings.navigationColor,
+            navigationColorDark: pwaSettings.navigationColorDark,
+            navigationDividerColor: pwaSettings.navigationDividerColor,
+            navigationDividerColorDark: pwaSettings.navigationDividerColorDark,
+            iconUrl: pwaSettings.iconUrl,
+            maskableIconUrl: pwaSettings.maskableIconUrl,
+            monochromeIconUrl: pwaSettings.monochromeIconUrl,
+            splashScreenFadeOutDuration: pwaSettings.splashScreenFadeOutDuration,
+            enableNotifications: pwaSettings.enableNotifications,
+            enableSiteSettingsShortcut: pwaSettings.enableSiteSettingsShortcut,
+            isChromeOSOnly: pwaSettings.isChromeOSOnly,
+            isMetaQuest: pwaSettings.isMetaQuest,
+            minSdkVersion: pwaSettings.minSdkVersion,
+            webManifestUrl: pwaSettings.webManifestUrl,
+            fullScopeUrl: pwaSettings.fullScopeUrl,
+            fallbackType: pwaSettings.fallbackType,
+            shareTarget: pwaSettings.shareTarget,
+            additionalTrustedOrigins: pwaSettings.additionalTrustedOrigins,
+            serviceAccountJsonFile: pwaSettings.serviceAccountJsonFile,
+            features: {
+                appsFlyer: pwaSettings.features?.appsFlyer,
+                firstRunFlag: pwaSettings.features?.firstRunFlag,
+                locationDelegation: pwaSettings.features?.locationDelegation,
+                playBilling: pwaSettings.features?.playBilling,
+            },
             shortcuts: this.createShortcuts(
                 pwaSettings.shortcuts,
                 pwaSettings.webManifestUrl

--- a/apps/pwabuilder-google-play/tests/android-package-routes.test.mjs
+++ b/apps/pwabuilder-google-play/tests/android-package-routes.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { test } from 'node:test';
+import { app, effects } from './fixtures/isolated-app.mjs';
+import { validOptions } from './fixtures/android-package-options.js';
+
+test('all public packaging endpoints reject injection before queueing or building', async () => {
+    const server = createServer(app);
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const origin = `http://127.0.0.1:${server.address().port}`;
+    try {
+        for (const route of ['/generateAppPackage', '/generateApkZip', '/enqueuePackageJob']) {
+            for (const override of [
+                { host: "example.com', injected: (1 + 1), ignored: '" },
+                { splashScreenFadeOutDuration: '(1 + 1)' },
+                { minSdkVersion: '(1 + 1)' },
+            ]) {
+                const response = await fetch(origin + route, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ...validOptions(), ...override }),
+                });
+                assert.equal(response.status, 500); // Existing API validation response contract.
+                assert.match(await response.text(), /^Invalid PWA settings:/u);
+                assert.equal(effects.builds, 0);
+                assert.equal(effects.enqueued.length, 0);
+            }
+        }
+
+        const response = await fetch(origin + '/enqueuePackageJob', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ...validOptions(), host: 'https://example.com/subpath/' }),
+        });
+        assert.equal(response.status, 200);
+        assert.equal(await response.text(), 'test-job');
+        assert.equal(effects.enqueued.length, 1);
+        assert.equal(effects.enqueued[0].host, 'example.com/subpath');
+        assert.equal(effects.builds, 0);
+    } finally {
+        await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    }
+});

--- a/apps/pwabuilder-google-play/tests/bubblewrap-gradle-patch.test.mjs
+++ b/apps/pwabuilder-google-play/tests/bubblewrap-gradle-patch.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { test } from 'node:test';
+import { patchBubblewrapGradle } from '../scripts/patch-bubblewrap-gradle.mjs';
+
+test('the installed security patch is idempotent', async () => {
+    const template = new URL('../node_modules/@bubblewrap/core/template_project/app/build.gradle', import.meta.url);
+    const shortcut = new URL('../node_modules/@bubblewrap/core/dist/lib/ShortcutInfo.js', import.meta.url);
+    const before = [await readFile(template, 'utf8'), await readFile(shortcut, 'utf8')];
+    await patchBubblewrapGradle();
+    assert.deepEqual([await readFile(template, 'utf8'), await readFile(shortcut, 'utf8')], before);
+});
+
+test('unexpected upstream source or version fails closed without changing other files', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'cloudapk-patch-test-'));
+    const core = pathToFileURL(directory + sep);
+    try {
+        await mkdir(new URL('template_project/app/', core), { recursive: true });
+        await mkdir(new URL('dist/lib/', core), { recursive: true });
+        for (const path of ['package.json', 'template_project/app/build.gradle', 'dist/lib/ShortcutInfo.js']) {
+            await copyFile(new URL(`../node_modules/@bubblewrap/core/${path}`, import.meta.url), new URL(path, core));
+        }
+        const template = new URL('template_project/app/build.gradle', core);
+        const shortcut = new URL('dist/lib/ShortcutInfo.js', core);
+        const before = await readFile(shortcut, 'utf8');
+        await writeFile(template, await readFile(template, 'utf8') + '\n// Unreviewed upstream change\n');
+        await assert.rejects(patchBubblewrapGradle(core), /Unexpected Bubblewrap source/u);
+        assert.equal(await readFile(shortcut, 'utf8'), before);
+
+        await writeFile(new URL('package.json', core), JSON.stringify({ version: '1.26.0' }));
+        await assert.rejects(patchBubblewrapGradle(core), /Review the Gradle security patch/u);
+    } finally {
+        await rm(directory, { recursive: true, force: true });
+    }
+});

--- a/apps/pwabuilder-google-play/tests/fixtures/android-package-options.ts
+++ b/apps/pwabuilder-google-play/tests/fixtures/android-package-options.ts
@@ -1,0 +1,27 @@
+import type { AndroidPackageOptions } from '../../models/androidPackageOptions.js';
+
+export function validOptions(): AndroidPackageOptions {
+    return {
+        analysisId: null,
+        appVersion: '1.0.0',
+        appVersionCode: 1,
+        backgroundColor: '#ffffff',
+        display: 'standalone',
+        enableNotifications: false,
+        fallbackType: 'customtabs',
+        host: 'example.com',
+        iconUrl: 'https://example.com/icon.png',
+        includeSourceCode: false,
+        launcherName: 'Example',
+        name: 'Example',
+        navigationColor: '#000000',
+        packageId: 'com.example.app',
+        pwaUrl: 'https://example.com/',
+        signingMode: 'none',
+        signing: null,
+        splashScreenFadeOutDuration: 0,
+        startUrl: '/',
+        themeColor: '#ffffff',
+        webManifestUrl: 'https://example.com/manifest.json',
+    };
+}

--- a/apps/pwabuilder-google-play/tests/fixtures/isolated-app.mjs
+++ b/apps/pwabuilder-google-play/tests/fixtures/isolated-app.mjs
@@ -1,0 +1,47 @@
+import { registerHooks } from 'node:module';
+
+export const effects = { builds: 0, enqueued: [] };
+const effectKey = Symbol.for('cloudapk-route-test-effects');
+globalThis[effectKey] = effects;
+
+// Load the real Express app/router, but prohibit builds and any production service access.
+const sources = new Map(Object.entries({
+    'analytics.js': 'export function trackEvent() {}',
+    'packageCreator.js': `
+        const effects = globalThis[Symbol.for('cloudapk-route-test-effects')];
+        export class PackageCreator {
+            addEventListener() {}
+            async createZip() {
+                effects.builds++;
+                throw new Error('Builds are disabled in route tests');
+            }
+        }`,
+    'packageJobQueue.js': `
+        const effects = globalThis[Symbol.for('cloudapk-route-test-effects')];
+        export const packageJobQueue = {
+            async enqueue(options) {
+                effects.enqueued.push(options);
+                return 'test-job';
+            }
+        };`,
+    'redisService.js': 'export const redisService = {};',
+    'azureStorageBlobService.js': 'export const blobStorage = {};',
+}).map(([file, source]) => [new URL(`../../services/${file}`, import.meta.url).href, source]));
+
+const hooks = registerHooks({
+    load(url, context, nextLoad) {
+        const source = sources.get(url);
+        return source === undefined ? nextLoad(url, context) :
+            { format: 'module', source, shortCircuit: true };
+    },
+});
+
+let app;
+try {
+    ({ default: app } = await import('../../app.js'));
+} finally {
+    hooks.deregister();
+    delete globalThis[effectKey];
+}
+
+export { app };

--- a/apps/pwabuilder-google-play/tests/gradle-injection.test.ts
+++ b/apps/pwabuilder-google-play/tests/gradle-injection.test.ts
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import { TwaGenerator, TwaManifest } from '@bubblewrap/core';
+import { ShortcutInfo } from '@bubblewrap/core/dist/lib/ShortcutInfo.js';
+import { escapeGradleString, escapeJsonString } from '@bubblewrap/core/dist/lib/util.js';
+import { FeatureManager } from '@bubblewrap/core/dist/lib/features/FeatureManager.js';
+import { validOptions } from './fixtures/android-package-options.js';
+import { BubbleWrapper } from '../services/bubbleWrapper.js';
+import { normalizeAndroidHost } from '../utils/android-host.js';
+import { validateAndroidOptionsRequest } from '../utils/android-options-validation.js';
+
+function manifest(): TwaManifest {
+    return new TwaManifest({
+        ...validOptions(),
+        shortcuts: [],
+        signingKey: { path: '', alias: '' },
+    });
+}
+
+async function renderGradle(twaManifest: TwaManifest): Promise<string> {
+    const directory = await mkdtemp(join(tmpdir(), 'cloudapk-gradle-test-'));
+    try {
+        const generator = new TwaGenerator();
+        const source = fileURLToPath(new URL(
+            '../node_modules/@bubblewrap/core/template_project/app/build.gradle', import.meta.url));
+        const target = join(directory, 'build.gradle');
+        // Exercise Bubblewrap's installed renderer without downloading resources or executing Gradle.
+        await generator['applyTemplate'](source, target, {
+            ...twaManifest,
+            ...new FeatureManager(twaManifest),
+            generateShortcuts: twaManifest.generateShortcuts.bind(twaManifest),
+            escapeGradleString,
+            escapeJsonString,
+        });
+        return await readFile(target, 'utf8');
+    } finally {
+        await rm(directory, { recursive: true, force: true });
+    }
+}
+
+function assertStringLiteral(source: string, prefix: string, expected: string): void {
+    const line = source.split('\n').map(value => value.trim()).find(value => value.startsWith(prefix));
+    assert.ok(line, `Missing ${prefix}`);
+    // Match exactly one single-quoted Groovy literal, followed only by a comma/comment.
+    const literal = /^'((?:\\(?:[\\'rn]|u[0-9a-f]{4})|[^'\\\r\n])*)',?(?:\s*\/\/.*)?$/u.exec(line.slice(prefix.length));
+    assert.ok(literal, `Expected literal-only value for ${prefix}: ${line}`);
+    const decoded = literal[1].replace(/\\(u([0-9a-f]{4})|[\\'rn])/gu, (_, escape: string, unicode: string | undefined) => {
+        if (unicode) {
+            return String.fromCharCode(parseInt(unicode, 16));
+        }
+        return escape === 'r' ? '\r' : escape === 'n' ? '\n' : escape;
+    });
+    assert.equal(decoded, expected);
+}
+
+test('normalizes DNS, IDNs, ports and legacy subpaths without discarding paths', () => {
+    for (const [input, expected] of [
+        ['example.com', 'example.com'],
+        ['https://EXAMPLE.com/', 'example.com'],
+        ['example.com:8443', 'example.com:8443'],
+        ['https://ics.hutton.ac.uk/gridscore/', 'ics.hutton.ac.uk/gridscore'],
+        ['example.com/path//', 'example.com/path'],
+        ['https://b\u00fccher.example/path', 'xn--bcher-kva.example/path'],
+        ['example.com./path%27name', 'example.com./path%27name'],
+        [`${'a'.repeat(63)}.example`, `${'a'.repeat(63)}.example`],
+    ]) {
+        assert.equal(normalizeAndroidHost(input), expected);
+        assert.equal(normalizeAndroidHost(expected), expected);
+        assert.deepEqual(validateAndroidOptionsRequest({ ...validOptions(), host: input }).validationErrors, []);
+    }
+});
+
+test('rejects malformed or executable hosts before URL parser normalization', () => {
+    for (const host of [
+        "example.com', injected: (1 + 1), ignored: '", 'example.com\\path',
+        'example.com\n', '\texample.com', 'example.com\r/path', 'example.com\u0000',
+        'example.com\u2028', '"example.com"', 'user@example.com', 'https://user:pass@example.com',
+        'http://example.com', 'file:///tmp/file', '//example.com', 'https:///example.com',
+        '-example.com', 'example-.com', 'example..com', '_example.com', 'example.com:abc',
+        'example.com?query', 'example.com#fragment', 'example.com/path?query',
+        `${'a'.repeat(64)}.example`, `${'a'.repeat(63)}.${'b'.repeat(63)}.${'c'.repeat(63)}.${'d'.repeat(63)}`,
+    ]) {
+        assert.equal(normalizeAndroidHost(host), null, JSON.stringify(host));
+        assert.ok(validateAndroidOptionsRequest({ ...validOptions(), host }).validationErrors.length > 0);
+    }
+});
+
+test('rejects wrong types and expressions in numeric and boolean Gradle inputs', () => {
+    for (const field of ['splashScreenFadeOutDuration', 'minSdkVersion', 'appVersionCode']) {
+        for (const value of ['(1 + 1)', '1', {}, [], true, null, -1, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1]) {
+            assert.ok(validateAndroidOptionsRequest({
+                ...validOptions(), [field]: value,
+            }).validationErrors.length > 0, `${field}: ${String(value)}`);
+        }
+    }
+    for (const field of ['enableSiteSettingsShortcut', 'isChromeOSOnly']) {
+        for (const value of ["true', injected: (1 + 1), ignored: '", {}, 1, null]) {
+            assert.ok(validateAndroidOptionsRequest({ ...validOptions(), [field]: value }).validationErrors.length > 0);
+        }
+    }
+    assert.ok(validateAndroidOptionsRequest({
+        ...validOptions(), orientation: "default', injected: (1 + 1), ignored: '",
+    }).validationErrors.length > 0);
+    for (const packageId of ['../outside', 'com.example.app\n', 'com.example.app\r', 'com.example.app\u2028']) {
+        assert.ok(validateAndroidOptionsRequest({ ...validOptions(), packageId }).validationErrors.length > 0);
+    }
+});
+
+test('the worker rejects previously queued hostile options before creating a TWA project', () => {
+    const options = validOptions();
+    const wrapper = new BubbleWrapper(options, 'unused', null, 'node-fetch');
+    for (const [field, value] of [
+        ['host', "example.com', injected: (1 + 1), ignored: '"],
+        ['splashScreenFadeOutDuration', '(1 + 1)'],
+        ['minSdkVersion', '(1 + 1)'],
+    ]) {
+        assert.throws(() => wrapper['createTwaManifest']({
+            ...options, [field]: value,
+        }), /Invalid PWA settings/u);
+    }
+});
+
+test('only supported options and features reach Bubblewrap from persisted JSON', () => {
+    const options = validOptions();
+    const wrapper = new BubbleWrapper(options, 'unused', null, 'node-fetch');
+    const persisted = {
+        ...options,
+        ...{
+            launchHandlerClientMode: "' + (1 + 1) + '",
+            fileHandlers: [{ actionUrl: '${1 + 1}', accept: [] }],
+            protocolHandlers: [{ protocol: 'web+test', url: 'https://example.com' }],
+            generatorApp: '${1 + 1}',
+            alphaDependencies: { enabled: true },
+            features: { arCore: { enabled: true }, playBilling: { enabled: true } },
+        },
+    };
+    const twa = wrapper['createTwaManifest'](persisted);
+    assert.equal(twa.fileHandlers, undefined);
+    assert.equal(twa.protocolHandlers, undefined);
+    assert.equal(twa.launchHandlerClientMode, undefined);
+    assert.equal(twa.generatorApp, 'PWABuilder');
+    assert.equal(twa.features.arCore, undefined);
+    assert.equal(twa.features.playBilling?.enabled, true);
+    assert.equal(twa.alphaDependencies.enabled, true);
+});
+
+test('installed Gradle template emits literal strings for every string injection sink', async () => {
+    const payload = "before\\', injected: (1 + 1), ignored: ' \"${1 + 1}\"\r\n\u2028after";
+    const twa = manifest();
+    for (const field of ['host', 'startUrl', 'packageId', 'appVersionName', 'generatorApp', 'fallbackType', 'orientation', 'launchHandlerClientMode']) {
+        Reflect.set(twa, field, payload);
+    }
+    const url = new URL("https://example.com/path'quoted");
+    twa.webManifestUrl = url;
+    twa.fullScopeUrl = url;
+    const source = await renderGradle(twa);
+    for (const prefix of [
+        'applicationId: ', 'hostName: ', 'launchUrl: ', 'generatorApp: ', 'fallbackType: ', 'orientation: ',
+        'namespace ', 'applicationId ', 'versionName ', 'resValue "string", "launchHandlerClientMode", ',
+    ]) {
+        assertStringLiteral(source, prefix, payload);
+    }
+    assertStringLiteral(source, 'resValue "string", "webManifestUrl", ', url.toString());
+    assertStringLiteral(source, 'resValue "string", "fullScopeUrl", ', url.toString());
+});
+
+test('app and shortcut names retain Android resource escaping and international text', async () => {
+    const twa = manifest();
+    twa.name = "Ben & Jerry's \u6771\u4eac\\app\n${1 + 1}";
+    twa.launcherName = twa.name;
+    const source = await renderGradle(twa);
+    const androidResource = "Ben & Jerry\\'s \u6771\u4eac\\\\app\n${1 + 1}";
+    assertStringLiteral(source, 'name: ', androidResource);
+    assertStringLiteral(source, 'launcherName: ', androidResource);
+});
+
+test('shortcut URLs cannot break out of their generated Groovy literal', () => {
+    const url = "https://example.com/path', injected: (1 + 1), ignored: '\\${1 + 1}\n";
+    const shortcut = new ShortcutInfo('Example', 'Example', url, 'https://example.com/icon.png');
+    const value = shortcut.toString(0);
+    const urlLiteral = value.slice(value.indexOf('url:') + 4, value.lastIndexOf(", icon:"));
+    assertStringLiteral(`url: ${urlLiteral}`, 'url: ', url);
+});
+
+test('the template rejects nonprimitive numeric and boolean values even if ingress is bypassed', async () => {
+    for (const field of ['splashScreenFadeOutDuration', 'minSdkVersion', 'appVersionCode', 'enableNotifications', 'enableSiteSettingsShortcut']) {
+        const twa = manifest();
+        Reflect.set(twa, field, '(1 + 1)');
+        await assert.rejects(renderGradle(twa), /Expected (?:a boolean|a non-negative safe integer) in the Gradle template/u);
+    }
+});
+
+test('normal unsigned, signed, and Meta Quest manifests keep valid Gradle settings', async () => {
+    for (const { isMetaQuest, signingKey } of [
+        { isMetaQuest: false, signingKey: { path: '', alias: '' } },
+        { isMetaQuest: false, signingKey: { path: 'signingKey.keystore', alias: 'release-key' } },
+        { isMetaQuest: true, signingKey: { path: 'signingKey.keystore', alias: 'release-key' } },
+    ]) {
+        const twa = manifest();
+        twa.isMetaQuest = isMetaQuest;
+        twa.fullScopeUrl = isMetaQuest ? new URL('https://example.com/') : undefined;
+        twa.minSdkVersion = 23;
+        twa.splashScreenFadeOutDuration = 300;
+        twa.enableNotifications = true;
+        twa.enableSiteSettingsShortcut = false;
+        twa.signingKey = signingKey;
+        const source = await renderGradle(twa);
+        assertStringLiteral(source, 'hostName: ', 'example.com');
+        assertStringLiteral(source, 'versionName ', '1.0.0');
+        assert.match(source, /minSdkVersion 23/u);
+        assert.match(source, /versionCode 1/u);
+        assert.match(source, /splashScreenFadeOutDuration: 300/u);
+        assert.match(source, /enableNotifications: true/u);
+        assert.match(source, /enableSiteSettingsShortcut: 'false'/u);
+    }
+});

--- a/apps/pwabuilder-google-play/tests/signing-options-validation.test.ts
+++ b/apps/pwabuilder-google-play/tests/signing-options-validation.test.ts
@@ -266,6 +266,7 @@ test('request validation has no service or server dependencies', async () => {
         new Set([
             'password-generator',
             './signing-options-validation.js',
+            './android-host.js',
         ])
     );
 });
@@ -413,6 +414,32 @@ test('request validation rejects an object body without packageId', () => {
         malformedBody
     );
 });
+
+test('request validation rejects a host that breaks out of a Gradle string', () => {
+    const body = createValidRequestBody();
+    body.signingMode = 'none';
+    body.host = "example.com', injected: (1 + 1), ignored: '";
+
+    assertRequestValidationError(
+        body,
+        ['host must contain a valid DNS hostname, optionally with an HTTPS prefix, port, and path'],
+        body.host
+    );
+});
+
+for (const field of ['splashScreenFadeOutDuration', 'minSdkVersion'] as const) {
+    test(`request validation rejects a Gradle expression in ${field}`, () => {
+        const body = createValidRequestBody();
+        body.signingMode = 'none';
+        Reflect.set(body, field, '(1 + 1)');
+
+        assertRequestValidationError(
+            body,
+            [`${field} must be a non-negative safe integer`],
+            '(1 + 1)'
+        );
+    });
+}
 
 for (const field of requiredStringFields) {
     for (const malformedValue of malformedRequiredStringValues) {

--- a/apps/pwabuilder-google-play/utils/android-host.ts
+++ b/apps/pwabuilder-google-play/utils/android-host.ts
@@ -1,0 +1,32 @@
+/**
+ * Validates the DNS authority before normalizing the legacy HTTPS/path host format.
+ * URL parsing alone is insufficient: it accepts quotes and strips some controls.
+ */
+export function normalizeAndroidHost(value: string): string | null {
+    if (/['"\\?#\p{C}\p{Z}]/u.test(value)) {
+        return null;
+    }
+
+    const hostAndPath = value.replace(/^https:\/\//iu, '');
+    if (!hostAndPath || hostAndPath.startsWith('/') || hostAndPath.includes('://')) {
+        return null;
+    }
+
+    let url: URL;
+    try {
+        url = new URL(`https://${hostAndPath}`);
+    } catch {
+        return null;
+    }
+
+    const hostname = url.hostname.replace(/\.$/u, '');
+    if (url.username || url.password || hostAndPath.includes('@') ||
+        hostname.length > 253 ||
+        !hostname.split('.').every(label =>
+            /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/iu.test(label))) {
+        return null;
+    }
+
+    // Keep subpath-based PWAs working rather than silently replacing host with .hostname.
+    return `${url.host}${url.pathname}`.replace(/\/+$/u, '');
+}

--- a/apps/pwabuilder-google-play/utils/android-options-validation.ts
+++ b/apps/pwabuilder-google-play/utils/android-options-validation.ts
@@ -3,6 +3,7 @@ import type { AndroidPackageOptions } from '../models/androidPackageOptions.js';
 import type { AppPackageRequest } from '../models/appPackageRequest.js';
 import type { SigningOptions } from '../models/signingOptions.js';
 import { validateNewKeySigningOptions } from './signing-options-validation.js';
+import { normalizeAndroidHost } from './android-host.js';
 
 const malformedOptionsError =
     "Malformed argument. Coudn't find AndroidPackageOptions in body";
@@ -25,6 +26,10 @@ const displayValues = [
 ] as const;
 const fallbackTypeValues = ['customtabs', 'webview'] as const;
 const signingModeValues = ['new', 'none', 'mine'] as const;
+const orientationValues = [
+    'default', 'any', 'natural', 'landscape', 'portrait',
+    'portrait-primary', 'portrait-secondary', 'landscape-primary', 'landscape-secondary',
+] as const;
 
 type SigningMode = (typeof signingModeValues)[number];
 
@@ -58,11 +63,34 @@ export function validateAndroidOptionsRequest(body: unknown): AppPackageRequest 
         validateRequiredStringField(body, field, validationErrors);
     }
 
-    validateRequiredFiniteNumberField(
+    if (packageId.trim() !== packageId || !/^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$/iu.test(packageId)) {
+        validationErrors.push('packageId must be a valid Android application ID');
+    }
+
+    if (typeof body.host === 'string' && body.host !== '') {
+        const host = normalizeAndroidHost(body.host);
+        if (host === null) {
+            validationErrors.push('host must contain a valid DNS hostname, optionally with an HTTPS prefix, port, and path');
+        } else {
+            options.host = host;
+        }
+    }
+
+    const appVersionCode = validateRequiredFiniteNumberField(
         body,
         'appVersionCode',
         validationErrors
     );
+    if (appVersionCode !== null && (!Number.isSafeInteger(appVersionCode) || appVersionCode < 1)) {
+        validationErrors.push('appVersionCode must be a positive safe integer');
+    }
+    validateNonNegativeIntegerField(body, 'splashScreenFadeOutDuration', false, validationErrors);
+    validateNonNegativeIntegerField(body, 'minSdkVersion', true, validationErrors);
+    validateOptionalBooleanField(body, 'enableSiteSettingsShortcut', validationErrors);
+    validateOptionalBooleanField(body, 'isChromeOSOnly', validationErrors);
+    if (body.orientation !== undefined) {
+        validateEnumeratedField(body, 'orientation', orientationValues, validationErrors);
+    }
     validateEnumeratedField(
         body,
         'display',
@@ -326,6 +354,21 @@ function validateRequiredFiniteNumberField(
     }
 
     return value;
+}
+
+function validateNonNegativeIntegerField(
+    options: Record<string, unknown>,
+    field: string,
+    optional: boolean,
+    validationErrors: string[]
+): void {
+    const value = options[field];
+    if (optional && value === undefined) {
+        return;
+    }
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+        validationErrors.push(`${field} must be a non-negative safe integer`);
+    }
 }
 
 function validateRequiredSigningStringField(


### PR DESCRIPTION
N/A - security report; no linked GitHub issue.
<!-- Link to relevant issue (for ex: "fixes #1234") which will automatically close the issue once the PR is merged -->

## PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
- Documentation content changes
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## Describe the current behavior?
<!-- Please describe the current behavior that is being modified or link to a relevant issue. -->

CloudAPK forwards anonymous packaging input into executable Gradle source generated by Bubblewrap. Unescaped strings and expression-valued numeric fields permit Groovy code injection. Fixing only `host` would leave adjacent template sinks and previously queued requests exposed.

## Describe the new behavior?

- Validate DNS hosts, package identifiers, numeric inputs, booleans, and orientation at the shared request boundary, preserving HTTPS prefixes, IDNs, ports, and legacy host paths.
- Revalidate persisted jobs before project generation and explicitly project supported manifest fields/features instead of spreading arbitrary request JSON into Bubblewrap.
- Apply a repository-managed Bubblewrap 1.25.0 patch that encodes Gradle strings as single-quoted literals, guards numeric/boolean expressions, and escapes shortcut URLs. Version and complete-source hash checks fail closed on unreviewed dependency changes.
- Apply the patch during install, build, and npm start/dev, including the Docker build's `--ignore-scripts` installation flow. Document deployment and incident-response boundaries.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

Accessibility: N/A - backend and build-tooling changes only; no UI changes.

## Additional Information

All 262 packaging-service tests pass. Regression coverage includes all three public packaging endpoints, worker revalidation, installed-template rendering with inert payloads, literal encoding, and patch idempotence/failure behavior. Clean installation, postinstall patching, and preservation after production dependency pruning were exercised.

No Gradle/Android SDK build, production exploit probe, or deployment was performed. The local dependency patch is temporary until upstream secures the same sinks; dependency upgrades require reviewing the patch.

This closes the scoped code-injection paths, not the worker isolation gap. Production rollout, exposure investigation, appropriate credential/signing-material remediation, and per-job build isolation from backend identities remain operational work.