### PR TITLE
fix(cloudapk): patch tar container dependency

### DIFF
--- a/apps/pwabuilder-google-play/package-lock.json
+++ b/apps/pwabuilder-google-play/package-lock.json
@@ -8193,9 +8193,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.20",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-7.5.20.tgz",
-            "integrity": "sha1-N6ZaqRHL1phkAC4Uv4qSalVR4kA=",
+            "version": "7.5.22",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",

--- a/apps/pwabuilder-google-play/package.json
+++ b/apps/pwabuilder-google-play/package.json
@@ -73,7 +73,7 @@
         "async": ">=3.2.2",
         "file-type": "21.3.4",
         "minimatch": ">=3.0.2",
-        "tar": ">=7.5.20",
+        "tar": ">=7.5.21",
         "@opentelemetry/propagator-jaeger": ">=2.9.0"
     }
 }


### PR DESCRIPTION
## PR Type

- Bugfix
- Build or CI related changes

## Describe the current behavior?

The Google Play packager container installs `tar@7.5.20` through `@bubblewrap/core`. This version is affected by [GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m), which requires `tar@7.5.21` or later.

## Describe the new behavior?

- Raise the `tar` override minimum from `>=7.5.20` to `>=7.5.21`.
- Update the lockfile to `tar@7.5.22`, retaining the existing Microsoft npm feed and verified artifact integrity.
- Leave all other dependencies unchanged. `brace-expansion` is already locked to the patched version 5.0.9.

## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass (targeted validation performed instead; see below)
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [ ] Ensure that your contribution follows standard accessibility guidelines (not applicable: dependency-only change)

## Additional Information

Validation in `apps/pwabuilder-google-play`:
- Dependency restore with the container's configured npm feed succeeded.
- `npm run build` succeeded.
- `node --test ./tests/bubblewrap-gradle-patch.test.mjs ./tests/android-package-routes.test.mjs` passed all 3 tests.
- `npm ls tar --omit=dev` resolves `@bubblewrap/core` to `tar@7.5.22`.
- Confirmed the mirrored tarball matches the lockfile SHA-512 integrity.

This PR does not deploy changes. After merge, rebuild/deploy the container, promote the patched image to production, and rescan to clear the affected-image findings.